### PR TITLE
Config as IEnumerable<KeyValuePair<string,string>>

### DIFF
--- a/examples/AdvancedConsumer/Program.cs
+++ b/examples/AdvancedConsumer/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Confluent.Kafka;
+
 
 namespace Confluent.Kafka.AdvancedConsumer
 {
@@ -12,14 +12,15 @@ namespace Confluent.Kafka.AdvancedConsumer
         {
             bool enableAutoCommit = false;
 
-            var config = new Config()
+            var config = new Dictionary<string, string>
             {
-                GroupId = "advanced-csharp-consumer",
-                EnableAutoCommit = enableAutoCommit,
-                StatisticsInterval = TimeSpan.FromSeconds(60)
+                { "group.id", "advanced-csharp-consumer" },
+                { "enable.auto.commit", enableAutoCommit.ToString() },
+                { "statistics.interval.ms", "60000" },
+                { "bootstrap.servers", brokerList }
             };
 
-            using (var consumer = new EventConsumer(config, brokerList))
+            using (var consumer = new EventConsumer(config))
             {
                 consumer.OnMessage += (obj, msg) => {
                     string text = Encoding.UTF8.GetString(msg.Payload, 0, msg.Payload.Length);

--- a/examples/AdvancedProducer/Program.cs
+++ b/examples/AdvancedProducer/Program.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Text;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Confluent.Kafka;
+
 
 namespace Confluent.Kafka.AdvancedProducer
 {
@@ -12,6 +13,8 @@ namespace Confluent.Kafka.AdvancedProducer
             string brokerList = args[0];
             string topicName = args[1];
 
+            /*
+            // TODO(mhowlett): allow partitioner to be set.
             var topicConfig = new TopicConfig
             {
                 CustomPartitioner = (top, key, cnt) =>
@@ -23,9 +26,10 @@ namespace Confluent.Kafka.AdvancedProducer
                     return partition;
                 }
             };
+            */
 
-            using (Producer producer = new Producer(brokerList))
-            using (Topic topic = producer.Topic(topicName, topicConfig))
+            using (Producer producer = new Producer(new Dictionary<string, string> { { "bootstrap.servers", brokerList } }))
+            using (Topic topic = producer.Topic(topicName))
             {
                 Console.WriteLine($"{producer.Name} producing on {topic.Name}. q to exit.");
 

--- a/examples/Misc/Program.cs
+++ b/examples/Misc/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Confluent.Kafka;
 
 namespace Confluent.Kafka.Misc
 {
@@ -11,7 +11,7 @@ namespace Confluent.Kafka.Misc
 
         static async Task ListGroups(string brokerList)
         {
-            using (var producer = new Producer(brokerList))
+            using (var producer = new Producer(new Dictionary<string, string> { { "bootstrap.servers", brokerList } }))
             {
                 var groups = await producer.ListGroups(TimeSpan.FromSeconds(10));
                 Console.WriteLine($"Consumer Groups:");
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.Misc
 
         static async Task PrintMetadata(string brokerList)
         {
-            using (var producer = new Producer(brokerList))
+            using (var producer = new Producer(new Dictionary<string, string> { { "bootstrap.servers", brokerList } }))
             {
                 var meta = await producer.Metadata();
                 Console.WriteLine($"{meta.OriginatingBrokerId} {meta.OriginatingBrokerName}");
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.Misc
 
             if (args.Contains("--dump-config"))
             {
-                foreach (var kv in new Config().Dump())
+                foreach (var kv in new Config(new Dictionary<string, string>()).Dump())
                 {
                     Console.WriteLine($"\"{kv.Key}\": \"{kv.Value}\"");
                 }

--- a/examples/SimpleConsumer/Program.cs
+++ b/examples/SimpleConsumer/Program.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Confluent.Kafka;
 
 namespace Confluent.Kafka.SimpleProducer
 {
@@ -13,8 +12,13 @@ namespace Confluent.Kafka.SimpleProducer
             string brokerList = args[0];
             var topics = args.Skip(1).ToList();
 
-            var config = new Config() { GroupId = "simple-csharp-consumer" };
-            using (var consumer = new EventConsumer(config, brokerList))
+            var config = new Dictionary<string, string>
+            {
+                { "group.id", "simple-csharp-consumer" },
+                { "bootstrap.servers", brokerList }
+            };
+
+            using (var consumer = new EventConsumer(config))
             {
                 consumer.OnMessage += (obj, msg) =>
                 {

--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Confluent.Kafka;
 
 namespace Confluent.Kafka.SimpleProducer
 {
@@ -12,7 +12,7 @@ namespace Confluent.Kafka.SimpleProducer
             string brokerList = args[0];
             string topicName = args[1];
 
-            using (Producer producer = new Producer(brokerList))
+            using (var producer = new Producer(new Dictionary<string, string> { { "bootstrap.servers", brokerList } }))
             using (Topic topic = producer.Topic(topicName))
             {
                 Console.WriteLine($"{producer.Name} producing on {topic.Name}. q to exit.");

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Confluent.Kafka.Internal;
 
@@ -11,9 +12,13 @@ namespace Confluent.Kafka
     {
         internal readonly SafeConfigHandle handle;
 
-        public Config()
+        public Config(IEnumerable<KeyValuePair<string, string>> config)
         {
             handle = SafeConfigHandle.Create();
+            if (config != null)
+            {
+                config.ToList().ForEach((kvp) => { this[kvp.Key] = kvp.Value; });
+            }
         }
 
         /// <summary>
@@ -47,20 +52,6 @@ namespace Confluent.Kafka
         ///
         ///     All clients sharing the same group.id belong to the same group.
         /// </summary>>
-        public string GroupId
-        {
-            set { this["group.id"] = value; }
-            get { return this["group.id"]; }
-        }
-
-        /// <summary>
-        ///     Automatically and periodically commit offsets in the background.
-        /// </summary>>
-        public bool EnableAutoCommit
-        {
-            set { this["enable.auto.commit"] = value ? "true" : "false"; }
-            get { return this["enable.auto.commit"] == "true"; }
-        }
 
         public delegate void LogCallback(string handle, int level, string fac, string buf);
         /// <summary>
@@ -69,20 +60,5 @@ namespace Confluent.Kafka
         ///     By default Confluent.Kafka logs using Console.WriteLine.
         /// </summary>
         public LogCallback Logger { get; set; }
-
-        /// <summary>
-        ///     Statistics emit interval for <see cref="Handle.OnStatistics">OnStatistics</see>.
-        /// </summary>
-        public TimeSpan StatisticsInterval
-        {
-            set { this["statistics.interval.ms"] = ((int) value.TotalMilliseconds).ToString(); }
-            get { return TimeSpan.FromMilliseconds(int.Parse(this["statistics.interval.ms"])); }
-        }
-
-        /// <summary>
-        ///     Sets the default topic configuration to use for automatically subscribed topics
-        ///     (e.g., through pattern-matched topics).
-        /// </summary>
-        public TopicConfig DefaultTopicConfig { get; set; }
     }
 }

--- a/src/Confluent.Kafka/EventConsumer.cs
+++ b/src/Confluent.Kafka/EventConsumer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Confluent.Kafka
 {
@@ -18,8 +19,8 @@ namespace Confluent.Kafka
         public event EventHandler<ErrorCode> OnConsumerError;
         public event EventHandler<TopicPartitionOffset> OnEndReached;
 
-        public EventConsumer(Config config, string brokerList = null)
-            : base(config, brokerList)
+        public EventConsumer(IEnumerable<KeyValuePair<string,string>> config, IEnumerable<KeyValuePair<string, string>> defaultTopicConfig = null)
+            : base(config, defaultTopicConfig)
         {}
 
         /// <summary>
@@ -80,7 +81,6 @@ namespace Confluent.Kafka
                 consumerCts = null;
             }
         }
-
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Confluent.Kafka/TopicConfig.cs
+++ b/src/Confluent.Kafka/TopicConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Confluent.Kafka.Internal;
 
 namespace Confluent.Kafka
@@ -10,25 +11,37 @@ namespace Confluent.Kafka
     {
         internal readonly SafeTopicConfigHandle handle;
 
-        public TopicConfig()
+        public TopicConfig(IEnumerable<KeyValuePair<string, string>> config)
         {
             handle = SafeTopicConfigHandle.Create();
+            if (config != null)
+            {
+                config.ToList().ForEach((kvp) => { this[kvp.Key] = kvp.Value; });
+            }
         }
 
         /// <summary>
-        /// Dump all configuration names and values into a dictionary.
+        ///     Dump all configuration names and values into a dictionary.
         /// </summary>
         public Dictionary<string, string> Dump() => handle.Dump();
 
         /// <summary>
-        /// Get or set a configuration value directly.
+        ///     Get or set a configuration value directly.
         ///
-        /// See <see href="https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md">CONFIGURATION.md</see> for the full list of supported properties.
+        ///     See <see href="https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md">CONFIGURATION.md</see> for the full list of supported properties.
         /// </summary>
-        /// <param name="name">The configuration property name.</param>
-        /// <returns>The configuration property value.</returns>
-        /// <exception cref="System.ArgumentException"><paramref name="value" /> is invalid.</exception>
-        /// <exception cref="System.InvalidOperationException">Configuration property <paramref name="name" /> does not exist.</exception>
+        /// <param name="name">
+        ///     The configuration property name.
+        /// </param>
+        /// <returns>
+        ///     The configuration property value.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">
+        ///     <paramref name="value" /> is invalid.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        ///     Configuration property <paramref name="name" /> does not exist.
+        /// </exception>
         public string this[string name]
         {
             set
@@ -42,24 +55,24 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        /// The partitioner may be called in any thread at any time,
-        /// it may be called multiple times for the same message/key.
+        ///     The partitioner may be called in any thread at any time,
+        ///     it may be called multiple times for the same message/key.
         ///
-        /// Partitioner function constraints:
-        ///   - MUST NOT call any Confluent.Kafka methods except for
-        ///     <see cref="Topic.PartitionAvailable">Topic.PartitionAvailable</see>
-        ///   - MUST NOT block or execute for prolonged periods of time.
-        ///   - MUST return a value between 0 and partition_cnt-1, or the
-        ///     special <see cref="Topic.RD_KAFKA_PARTITION_UA">RD_KAFKA_PARTITION_UA</see>
-        ///     value if partitioning could not be performed.
+        ///     Partitioner function constraints:
+        ///         - MUST NOT call any Confluent.Kafka methods except for
+        ///             <see cref="Topic.PartitionAvailable">Topic.PartitionAvailable</see>
+        ///         - MUST NOT block or execute for prolonged periods of time.
+        ///         - MUST return a value between 0 and partition_cnt-1, or the
+        ///             special <see cref="Topic.RD_KAFKA_PARTITION_UA">RD_KAFKA_PARTITION_UA</see>
+        ///             value if partitioning could not be performed.
         /// </summary>
         public delegate int Partitioner(Topic topic, byte[] key, int partitionCount);
 
         /// <summary>
-        /// Sets a custom <see cref="TopicConfig.Partitioner">Partitioner</see>
-        /// delegate to control assignment of messages to partitions.
+        ///     Sets a custom <see cref="TopicConfig.Partitioner">Partitioner</see>
+        ///     delegate to control assignment of messages to partitions.
         ///
-        /// See <see cref="Topic.Produce">Topic.Produce</see> for details.
+        ///     See <see cref="Topic.Produce">Topic.Produce</see> for details.
         /// </summary>
         public Partitioner CustomPartitioner { get; set; }
     }

--- a/src/Confluent.Kafka/project.json
+++ b/src/Confluent.Kafka/project.json
@@ -12,7 +12,7 @@
     },
 
     "frameworks": {
-        "net451": { },
+        /* "net451": { }, */
         "netstandard1.3": {
             "dependencies": {
                 "System.Console": "4.0.0",

--- a/test/Confluent.Kafka.Tests/ConfigTests.cs
+++ b/test/Confluent.Kafka.Tests/ConfigTests.cs
@@ -10,37 +10,35 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void SetAndGetParameterWorks()
         {
-            var config = new Config();
-            config["client.id"] = "test";
+            var config = new Config(new Dictionary<string, string> { { "client.id", "test" }});
             Assert.Equal(config["client.id"], "test");
         }
 
         [Fact]
         public void SettingUnknownParameterThrows()
         {
-            var config = new Config();
+            var config = new Config(new Dictionary<string, string>());
             Assert.Throws<InvalidOperationException>(() => config["unknown"] = "something");
         }
 
         [Fact]
         public void SettingParameterToInvalidValueThrows()
         {
-            var config = new Config();
+            var config = new Config(new Dictionary<string, string>());
             Assert.Throws<ArgumentException>(() => config["session.timeout.ms"] = "string");
         }
 
         [Fact]
         public void GettingUnknownParameterThrows()
         {
-            var config = new Config();
+            var config = new Config(new Dictionary<string, string>());
             Assert.Throws<InvalidOperationException>(() => config["unknown"]);
         }
 
         [Fact]
         public void DumpedConfigLooksReasonable()
         {
-            var config = new Config();
-            config["client.id"] = "test";
+            var config = new Config(new Dictionary<string, string> { { "client.id", "test" }});
             Dictionary<string,string> dump = config.Dump();
             Assert.Equal(dump["client.id"], "test");
         }


### PR DESCRIPTION

All config now set via IEnumerable<KeyValuePair<string,string>> which is compatible with Dictionary<string,string> and ASP.NET Configuration classes.

Everything builds, and simple examples work.

This breaks some stuff and lots of things are not ideal. e.g.
  - Config and TopicConfig still public.
  - Partitioner can't be defined.
  - defaultTopicProperties not merged with other config.
  - etc. etc. 

As a general comment, I'm going to try and move the current API towards where we want it bit by bit, and I want to try to keep the commits pretty small and coherent. But where we want to go is a significant refactor. This means there is going to be a period where stuff gets broken + we have stuff we know is not a good factoring. 

For example, I expect the Config and TopicConfig classes will go away. Hence I don't want to do anything more to them now (like merge them, rename them or make them internal), which should be done if we thought having them was the end state.
