### PR TITLE
making CLS compliant

### DIFF
--- a/src/Confluent.Kafka/CommittedOffsets.cs
+++ b/src/Confluent.Kafka/CommittedOffsets.cs
@@ -32,7 +32,7 @@ namespace Confluent.Kafka
         public CommittedOffsets(IList<TopicPartitionOffsetError> offsets)
         {
             Offsets = offsets;
-            Error = new Error(ErrorCode.NO_ERROR);
+            Error = new Error(ErrorCode.NoError);
         }
 
         public CommittedOffsets(Error error)

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -657,7 +657,7 @@ namespace Confluent.Kafka
                 {
                     case ErrorCode.NoError:
                         return true;
-                    case ErrorCode.Local_PartitionEof:
+                    case ErrorCode.Local_PartitionEOF:
                         OnPartitionEOF?.Invoke(this, message.TopicPartitionOffset);
                         return false;
                     default:
@@ -761,8 +761,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public async Task<CommittedOffsets> CommitAsync(Message message)
         {
-            if (message.Error.Code != ErrorCode.NO_ERROR)
+            if (message.Error.Code != ErrorCode.NoError)
+            {
                 throw new InvalidOperationException("Must not commit offset for errored message");
+            }
             return await CommitAsync(new List<TopicPartitionOffset> { new TopicPartitionOffset(message.TopicPartition, message.Offset + 1) });
         }
 

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -657,7 +657,7 @@ namespace Confluent.Kafka
                 {
                     case ErrorCode.NoError:
                         return true;
-                    case ErrorCode.Local_PartitionEOF:
+                    case ErrorCode.Local_PartitionEof:
                         OnPartitionEOF?.Invoke(this, message.TopicPartitionOffset);
                         return false;
                     default:

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -399,7 +399,7 @@ namespace Confluent.Kafka
             IntPtr opaque)
         {
             var partitionList = SafeKafkaHandle.GetTopicPartitionOffsetErrorList(partitions).Select(p => p.TopicPartition).ToList();
-            if (err == ErrorCode._ASSIGN_PARTITIONS)
+            if (err == ErrorCode.Local_AssignPartitions)
             {
                 var handler = OnPartitionsAssigned;
                 if (handler != null && handler.GetInvocationList().Length > 0)
@@ -411,7 +411,7 @@ namespace Confluent.Kafka
                     Assign(partitionList.Select(p => new TopicPartitionOffset(p, Offset.Invalid)));
                 }
             }
-            if (err == ErrorCode._REVOKE_PARTITIONS)
+            if (err == ErrorCode.Local_RevokePartitions)
             {
                 var handler = OnPartitionsRevoked;
                 if (handler != null && handler.GetInvocationList().Length > 0)
@@ -488,7 +488,7 @@ namespace Confluent.Kafka
             configHandle.SetHandleAsInvalid(); // config object is no longer useable.
 
             var pollSetConsumerError = kafkaHandle.PollSetConsumer();
-            if (pollSetConsumerError != ErrorCode.NO_ERROR)
+            if (pollSetConsumerError != ErrorCode.NoError)
             {
                 throw new KafkaException(new Error(pollSetConsumerError,
                     $"Failed to redirect the poll queue to consumer_poll queue: {ErrorCodeExtensions.GetReason(pollSetConsumerError)}"));
@@ -655,9 +655,9 @@ namespace Confluent.Kafka
             {
                 switch (message.Error.Code)
                 {
-                    case ErrorCode.NO_ERROR:
+                    case ErrorCode.NoError:
                         return true;
-                    case ErrorCode._PARTITION_EOF:
+                    case ErrorCode.Local_PartitionEOF:
                         OnPartitionEOF?.Invoke(this, message.TopicPartitionOffset);
                         return false;
                     default:

--- a/src/Confluent.Kafka/Error.cs
+++ b/src/Confluent.Kafka/Error.cs
@@ -46,7 +46,12 @@ namespace Confluent.Kafka
         public bool HasError
             => Code != ErrorCode.NO_ERROR;
 
-        // TODO: questionably too tricky?
+        public bool IsLocalError
+            => (int)Code < -1;
+
+        public bool IsBrokerError
+            => (int)Code > 0;
+
         public static implicit operator bool(Error e)
             => e.HasError;
 

--- a/src/Confluent.Kafka/Error.cs
+++ b/src/Confluent.Kafka/Error.cs
@@ -44,7 +44,7 @@ namespace Confluent.Kafka
         }
 
         public bool HasError
-            => Code != ErrorCode.NO_ERROR;
+            => Code != ErrorCode.NoError;
 
         public bool IsLocalError
             => (int)Code < -1;

--- a/src/Confluent.Kafka/ErrorCode.cs
+++ b/src/Confluent.Kafka/ErrorCode.cs
@@ -24,78 +24,77 @@ namespace Confluent.Kafka
     public enum ErrorCode
     {
         /// <summary>Begin internal error codes</summary>
-        _BEGIN = -200,
+        RD_BEGIN = -200,
         /// <summary>Received message is incorrect</summary>
-        _BAD_MSG = -199,
+        RD_BAD_MSG = -199,
         /// <summary>Bad/unknown compression</summary>
-        _BAD_COMPRESSION = -198,
+        RD_BAD_COMPRESSION = -198,
         /// <summary>Broker is going away</summary>
-        _DESTROY = -197,
+        RD_DESTROY = -197,
         /// <summary>Generic failure</summary>
-        _FAIL = -196,
+        RD_FAIL = -196,
         /// <summary>Broker transport failure</summary>
-        _TRANSPORT = -195,
+        RD_TRANSPORT = -195,
         /// <summary>Critical system resource</summary>
-        _CRIT_SYS_RESOURCE = -194,
+        RD_CRIT_SYS_RESOURCE = -194,
         /// <summary>Failed to resolve broker</summary>
-        _RESOLVE = -193,
+        RD_RESOLVE = -193,
         /// <summary>Produced message timed out</summary>
-        _MSG_TIMED_OUT = -192,
+        RD_MSG_TIMED_OUT = -192,
         /// <summary>Reached the end of the topic+partition queue on the broker. Not really an error.</summary>
-        _PARTITION_EOF = -191,
+        RD_PARTITION_EOF = -191,
         /// <summary>Permanent: Partition does not exist in cluster.</summary>
-        _UNKNOWN_PARTITION = -190,
+        RD_UNKNOWN_PARTITION = -190,
         /// <summary>File or filesystem error</summary>
-        _FS = -189,
+        RD_FS = -189,
          /// <summary>Permanent: Topic does not exist in cluster.</summary>
-        _UNKNOWN_TOPIC = -188,
+        RD_UNKNOWN_TOPIC = -188,
         /// <summary>All broker connections are down.</summary>
-        _ALL_BROKERS_DOWN = -187,
+        RD_ALL_BROKERS_DOWN = -187,
         /// <summary>Invalid argument, or invalid configuration</summary>
-        _INVALID_ARG = -186,
+        RD_INVALID_ARG = -186,
         /// <summary>Operation timed out</summary>
-        _TIMED_OUT = -185,
+        RD_TIMED_OUT = -185,
         /// <summary>Queue is full</summary>
-        _QUEUE_FULL = -184,
+        RD_QUEUE_FULL = -184,
         /// <summary>ISR count &lt; required.acks</summary>
-        _ISR_INSUFF = -183,
+        RD_ISR_INSUFF = -183,
         /// <summary>Broker node update</summary>
-        _NODE_UPDATE = -182,
+        RD_NODE_UPDATE = -182,
         /// <summary>SSL error</summary>
-        _SSL = -181,
+        RD_SSL = -181,
         /// <summary>Waiting for coordinator to become available.</summary>
-        _WAIT_COORD = -180,
+        RD_WAIT_COORD = -180,
         /// <summary>Unknown client group</summary>
-        _UNKNOWN_GROUP = -179,
+        RD_UNKNOWN_GROUP = -179,
         /// <summary>Operation in progress</summary>
-        _IN_PROGRESS = -178,
-         /// <summary>Previous operation in progress, wait for it to finish.</summary>
-        _PREV_IN_PROGRESS = -177,
-         /// <summary>This operation would interfere with an existing subscription</summary>
-        _EXISTING_SUBSCRIPTION = -176,
+        RD_IN_PROGRESS = -178,
+        /// <summary>Previous operation in progress, wait for it to finish.</summary>
+        RD_PREV_IN_PROGRESS = -177,
+        /// <summary>This operation would interfere with an existing subscription</summary>
+        RD_EXISTING_SUBSCRIPTION = -176,
         /// <summary>Assigned partitions (rebalance_cb)</summary>
-        _ASSIGN_PARTITIONS = -175,
+        RD_ASSIGN_PARTITIONS = -175,
         /// <summary>Revoked partitions (rebalance_cb)</summary>
-        _REVOKE_PARTITIONS = -174,
+        RD_REVOKE_PARTITIONS = -174,
         /// <summary>Conflicting use</summary>
-        _CONFLICT = -173,
+        RD_CONFLICT = -173,
         /// <summary>Wrong state</summary>
-        _STATE = -172,
+        RD_STATE = -172,
         /// <summary>Unknown protocol</summary>
-        _UNKNOWN_PROTOCOL = -171,
+        RD_UNKNOWN_PROTOCOL = -171,
         /// <summary>Not implemented</summary>
-        _NOT_IMPLEMENTED = -170,
+        RD_NOT_IMPLEMENTED = -170,
         /// <summary>Authentication failure</summary>
-        _AUTHENTICATION = -169,
+        RD_AUTHENTICATION = -169,
         /// <summary>No stored offset</summary>
-        _NO_OFFSET = -168,
+        RD_NO_OFFSET = -168,
         ///<summary>Outdated</summary>
-        _OUTDATED = -167,
+        RD_OUTDATED = -167,
         /// <summary>Timed out in queue</summary>
-        _TIMED_OUT_QUEUE = -166,
+        RD_TIMED_OUT_QUEUE = -166,
         /// <summary>End internal error codes</summary>
-
-        _END = -100,
+        RD_END = -100,
 
         // Kafka broker errors:
         /// <summary>Unknown broker error</summary>

--- a/src/Confluent.Kafka/ErrorCode.cs
+++ b/src/Confluent.Kafka/ErrorCode.cs
@@ -67,7 +67,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Reached the end of the topic+partition queue on the broker. Not really an error.
         /// </summary>
-        Local_PartitionEof = -191,
+        Local_PartitionEOF = -191,
 
         /// <summary>
         ///     Permanent: Partition does not exist in cluster.
@@ -208,177 +208,177 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Offset out of range
         /// </summary>
-        Broker_OffsetOutOfRange = 1,
+        OffsetOutOfRange = 1,
 
         /// <summary>
         ///     Invalid message
         /// </summary>
-        Broker_InvalidMsg = 2,
+        InvalidMsg = 2,
 
         /// <summary>
         ///     Unknown topic or partition
         /// </summary>
-        Broker_UnknownTopicOrPart = 3,
+        UnknownTopicOrPart = 3,
 
         /// <summary>
         ///     Invalid message size
         /// </summary>
-        Broker_InvalidMsgSize = 4,
+        InvalidMsgSize = 4,
 
         /// <summary>
         ///     Leader not available
         /// </summary>
-        Broker_LeaderNotAvailable = 5,
+        LeaderNotAvailable = 5,
 
         /// <summary>
         ///     Not leader for partition
         /// </summary>
-        Broker_NotLeaderForPartition = 6,
+        NotLeaderForPartition = 6,
 
         /// <summary>
         ///     Request timed out
         /// </summary>
-        Broker_RequestTimedOut = 7,
+        RequestTimedOut = 7,
 
         /// <summary>
         ///     Broker not available
         /// </summary>
-        Broker_BrokerNotAvailable = 8,
+        BrokerNotAvailable = 8,
 
         /// <summary>
         ///     Replica not available
         /// </summary>
-        Broker_ReplicaNotAvailable = 9,
+        ReplicaNotAvailable = 9,
 
         /// <summary>
         ///     Message size too large
         /// </summary>
-        Broker_MsgSizeTooLarge = 10,
+        MsgSizeTooLarge = 10,
 
         /// <summary>
         ///     StaleControllerEpochCode
         /// </summary>
-        Broker_StaleCtrlEpoch = 11,
+        StaleCtrlEpoch = 11,
 
         /// <summary>
         ///     Offset metadata string too large
         /// </summary>
-        Broker_OffsetMetadataTooLarge = 12,
+        OffsetMetadataTooLarge = 12,
 
         /// <summary>
         ///     Broker disconnected before response received
         /// </summary>
-        Broker_NetworkException = 13,
+        NetworkException = 13,
 
         /// <summary>
         ///     Group coordinator load in progress
         /// </summary>
-        Broker_GroupLoadInProress = 14,
+        GroupLoadInProress = 14,
 
         /// <summary>
         /// Group coordinator not available
         /// </summary>
-        Broker_GroupCoordinatorNotAvailable = 15,
+        GroupCoordinatorNotAvailable = 15,
 
         /// <summary>
         ///     Not coordinator for group
         /// </summary>
-        Broker_NotCoordinatorForGroup = 16,
+        NotCoordinatorForGroup = 16,
 
         /// <summary>
         ///     Invalid topic
         /// </summary>
-        Broker_TopicException = 17,
+        TopicException = 17,
 
         /// <summary>
         ///     Message batch larger than configured server segment size
         /// </summary>
-        Broker_RecordListTooLarge = 18,
+        RecordListTooLarge = 18,
 
         /// <summary>
         ///     Not enough in-sync replicas
         /// </summary>
-        Broker_NotEnoughReplicas = 19,
+        NotEnoughReplicas = 19,
 
         /// <summary>
         ///     Message(s) written to insufficient number of in-sync replicas
         /// </summary>
-        Broker_NotEnoughReplicasAfterAppend = 20,
+        NotEnoughReplicasAfterAppend = 20,
 
         /// <summary>
         ///     Invalid required acks value
         /// </summary>
-        Broker_InvalidRequiredAcks = 21,
+        InvalidRequiredAcks = 21,
 
         /// <summary>
         ///     Specified group generation id is not valid
         /// </summary>
-        Broker_IllegalGeneration = 22,
+        IllegalGeneration = 22,
 
         /// <summary>
         ///     Inconsistent group protocol
         /// </summary>
-        Broker_InconsistentGroupProtocol = 23,
+        InconsistentGroupProtocol = 23,
 
         /// <summary>
         ///     Invalid group.id
         /// </summary>
-        Broker_InvalidGroupId = 24,
+        InvalidGroupId = 24,
 
         /// <summary>
         ///     Unknown member
         /// </summary>
-        Broker_UnknownMemberId = 25,
+        UnknownMemberId = 25,
 
         /// <summary>
         ///     Invalid session timeout
         /// </summary>
-        Broker_InvalidSessionTimeout = 26,
+        InvalidSessionTimeout = 26,
 
         /// <summary>
         ///     Group rebalance in progress
         /// </summary>
-        Broker_RebalanceInProgress = 27,
+        RebalanceInProgress = 27,
 
         /// <summary>
         ///     Commit offset data size is not valid
         /// </summary>
-        Broker_InvalidCommitOffsetSize = 28,
+        InvalidCommitOffsetSize = 28,
 
         /// <summary>
         ///     Topic authorization failed
         /// </summary>
-        Broker_TopicAuthorizationFailed = 29,
+        TopicAuthorizationFailed = 29,
 
         /// <summary>
         ///     Group authorization failed
         /// </summary>
-        Broker_GroupAuthorizationFailed = 30,
+        GroupAuthorizationFailed = 30,
 
         /// <summary>
         ///     Cluster authorization failed
         /// </summary>
-        Broker_ClusterAuthorizationFailed = 31,
+        ClusterAuthorizationFailed = 31,
 
         /// <summary>
         ///     Invalid timestamp
         /// </summary>
-        Broker_InvalidTimestamp = 32,
+        InvalidTimestamp = 32,
 
         /// <summary>
         ///     Unsupported SASL mechanism
         /// </summary>
-        Broker_UnsupportedSaslMechanism = 33,
+        UnsupportedSaslMechanism = 33,
 
         /// <summary>
         ///     Illegal SASL state
         /// </summary>
-        Broker_IllegalSaslState = 34,
+        IllegalSaslState = 34,
 
         /// <summary>
         ///     Unuspported version
         /// </summary>
-        Broker_UnsupportedVersion = 35
+        UnsupportedVersion = 35
     };
 
     public static class ErrorCodeExtensions

--- a/src/Confluent.Kafka/ErrorCode.cs
+++ b/src/Confluent.Kafka/ErrorCode.cs
@@ -67,7 +67,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Reached the end of the topic+partition queue on the broker. Not really an error.
         /// </summary>
-        Local_PartitionEOF = -191,
+        Local_PartitionEof = -191,
 
         /// <summary>
         ///     Permanent: Partition does not exist in cluster.
@@ -82,7 +82,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Permanent: Topic does not exist in cluster.
         /// </summary>
-        Local_UnknownTOpic = -188,
+        Local_UnknownTopic = -188,
 
         /// <summary>
         ///     All broker connections are down.
@@ -107,7 +107,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     ISR count &lt; required.acks
         /// </summary>
-        Local_ISRInsuff = -183,
+        Local_IsrInsuff = -183,
 
         /// <summary>
         ///     Broker node update
@@ -117,7 +117,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     SSL error
         /// </summary>
-        Local_SSL = -181,
+        Local_Ssl = -181,
 
         /// <summary>
         ///     Waiting for coordinator to become available.
@@ -368,12 +368,12 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Unsupported SASL mechanism
         /// </summary>
-        Broker_UnsupportedSASLMechanism = 33,
+        Broker_UnsupportedSaslMechanism = 33,
 
         /// <summary>
         ///     Illegal SASL state
         /// </summary>
-        Broker_IllegalSASLState = 34,
+        Broker_IllegalSaslState = 34,
 
         /// <summary>
         ///     Unuspported version

--- a/src/Confluent.Kafka/ErrorCode.cs
+++ b/src/Confluent.Kafka/ErrorCode.cs
@@ -16,161 +16,369 @@
 //
 // Refer to LICENSE for more information.
 
+
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     Internal errors to rdkafka are prefixed with _
+    ///     Enumeration of client and server generated error codes.
     /// </summary>
     public enum ErrorCode
     {
-        /// <summary>Begin internal error codes</summary>
-        RD_BEGIN = -200,
-        /// <summary>Received message is incorrect</summary>
-        RD_BAD_MSG = -199,
-        /// <summary>Bad/unknown compression</summary>
-        RD_BAD_COMPRESSION = -198,
-        /// <summary>Broker is going away</summary>
-        RD_DESTROY = -197,
-        /// <summary>Generic failure</summary>
-        RD_FAIL = -196,
-        /// <summary>Broker transport failure</summary>
-        RD_TRANSPORT = -195,
-        /// <summary>Critical system resource</summary>
-        RD_CRIT_SYS_RESOURCE = -194,
-        /// <summary>Failed to resolve broker</summary>
-        RD_RESOLVE = -193,
-        /// <summary>Produced message timed out</summary>
-        RD_MSG_TIMED_OUT = -192,
-        /// <summary>Reached the end of the topic+partition queue on the broker. Not really an error.</summary>
-        RD_PARTITION_EOF = -191,
-        /// <summary>Permanent: Partition does not exist in cluster.</summary>
-        RD_UNKNOWN_PARTITION = -190,
-        /// <summary>File or filesystem error</summary>
-        RD_FS = -189,
-         /// <summary>Permanent: Topic does not exist in cluster.</summary>
-        RD_UNKNOWN_TOPIC = -188,
-        /// <summary>All broker connections are down.</summary>
-        RD_ALL_BROKERS_DOWN = -187,
-        /// <summary>Invalid argument, or invalid configuration</summary>
-        RD_INVALID_ARG = -186,
-        /// <summary>Operation timed out</summary>
-        RD_TIMED_OUT = -185,
-        /// <summary>Queue is full</summary>
-        RD_QUEUE_FULL = -184,
-        /// <summary>ISR count &lt; required.acks</summary>
-        RD_ISR_INSUFF = -183,
-        /// <summary>Broker node update</summary>
-        RD_NODE_UPDATE = -182,
-        /// <summary>SSL error</summary>
-        RD_SSL = -181,
-        /// <summary>Waiting for coordinator to become available.</summary>
-        RD_WAIT_COORD = -180,
-        /// <summary>Unknown client group</summary>
-        RD_UNKNOWN_GROUP = -179,
-        /// <summary>Operation in progress</summary>
-        RD_IN_PROGRESS = -178,
-        /// <summary>Previous operation in progress, wait for it to finish.</summary>
-        RD_PREV_IN_PROGRESS = -177,
-        /// <summary>This operation would interfere with an existing subscription</summary>
-        RD_EXISTING_SUBSCRIPTION = -176,
-        /// <summary>Assigned partitions (rebalance_cb)</summary>
-        RD_ASSIGN_PARTITIONS = -175,
-        /// <summary>Revoked partitions (rebalance_cb)</summary>
-        RD_REVOKE_PARTITIONS = -174,
-        /// <summary>Conflicting use</summary>
-        RD_CONFLICT = -173,
-        /// <summary>Wrong state</summary>
-        RD_STATE = -172,
-        /// <summary>Unknown protocol</summary>
-        RD_UNKNOWN_PROTOCOL = -171,
-        /// <summary>Not implemented</summary>
-        RD_NOT_IMPLEMENTED = -170,
-        /// <summary>Authentication failure</summary>
-        RD_AUTHENTICATION = -169,
-        /// <summary>No stored offset</summary>
-        RD_NO_OFFSET = -168,
-        ///<summary>Outdated</summary>
-        RD_OUTDATED = -167,
-        /// <summary>Timed out in queue</summary>
-        RD_TIMED_OUT_QUEUE = -166,
-        /// <summary>End internal error codes</summary>
-        RD_END = -100,
+        /// <summary>
+        ///     Received message is incorrect
+        /// </summary>
+        Local_BadMsg = -199,
 
-        // Kafka broker errors:
-        /// <summary>Unknown broker error</summary>
-        UNKNOWN = -1,
-        /// <summary>Success</summary>
-        NO_ERROR = 0,
-        /// <summary>Offset out of range</summary>
-        OFFSET_OUT_OF_RANGE = 1,
-        /// <summary>Invalid message</summary>
-        INVALID_MSG = 2,
-        /// <summary>Unknown topic or partition</summary>
-        UNKNOWN_TOPIC_OR_PART = 3,
-        /// <summary>Invalid message size</summary>
-        INVALID_MSG_SIZE = 4,
-        /// <summary>Leader not available</summary>
-        LEADER_NOT_AVAILABLE = 5,
-        /// <summary>Not leader for partition</summary>
-        NOT_LEADER_FOR_PARTITION = 6,
-        /// <summary>Request timed out</summary>
-        REQUEST_TIMED_OUT = 7,
-        /// <summary>Broker not available</summary>
-        BROKER_NOT_AVAILABLE = 8,
-        /// <summary>Replica not available</summary>
-        REPLICA_NOT_AVAILABLE = 9,
-        /// <summary>Message size too large</summary>
-        MSG_SIZE_TOO_LARGE = 10,
-        /// <summary>StaleControllerEpochCode</summary>
-        STALE_CTRL_EPOCH = 11,
-        /// <summary>Offset metadata string too large</summary>
-        OFFSET_METADATA_TOO_LARGE = 12,
-        /// <summary>Broker disconnected before response received</summary>
-        NETWORK_EXCEPTION = 13,
-        /// <summary>Group coordinator load in progress</summary>
-        GROUP_LOAD_IN_PROGRESS = 14,
-         /// <summary>Group coordinator not available</summary>
-        GROUP_COORDINATOR_NOT_AVAILABLE = 15,
-        /// <summary>Not coordinator for group</summary>
-        NOT_COORDINATOR_FOR_GROUP = 16,
-        /// <summary>Invalid topic</summary>
-        TOPIC_EXCEPTION = 17,
-        /// <summary>Message batch larger than configured server segment size</summary>
-        RECORD_LIST_TOO_LARGE = 18,
-        /// <summary>Not enough in-sync replicas</summary>
-        NOT_ENOUGH_REPLICAS = 19,
-        /// <summary>Message(s) written to insufficient number of in-sync replicas</summary>
-        NOT_ENOUGH_REPLICAS_AFTER_APPEND = 20,
-        /// <summary>Invalid required acks value</summary>
-        INVALID_REQUIRED_ACKS = 21,
-        /// <summary>Specified group generation id is not valid</summary>
-        ILLEGAL_GENERATION = 22,
-        /// <summary>Inconsistent group protocol</summary>
-        INCONSISTENT_GROUP_PROTOCOL = 23,
-        /// <summary>Invalid group.id</summary>
-        INVALID_GROUP_ID = 24,
-        /// <summary>Unknown member</summary>
-        UNKNOWN_MEMBER_ID = 25,
-        /// <summary>Invalid session timeout</summary>
-        INVALID_SESSION_TIMEOUT = 26,
-        /// <summary>Group rebalance in progress</summary>
-        REBALANCE_IN_PROGRESS = 27,
-        /// <summary>Commit offset data size is not valid</summary>
-        INVALID_COMMIT_OFFSET_SIZE = 28,
-        /// <summary>Topic authorization failed</summary>
-        TOPIC_AUTHORIZATION_FAILED = 29,
-        /// <summary>Group authorization failed</summary>
-        GROUP_AUTHORIZATION_FAILED = 30,
-        /// <summary>Cluster authorization failed</summary>
-        CLUSTER_AUTHORIZATION_FAILED = 31,
-        /// <summary>Invalid timestamp</summary>
-        INVALID_TIMESTAMP = 32,
-        /// <summary> Unsupported SASL mechanism</summary>
-        UNSUPPORTED_SASL_MECHANISM = 33,
-        /// <summary>Illegal SASL state</summary>
-        ILLEGAL_SASL_STATE = 34,
-        /// <summary>Unuspported version</summary>
-        UNSUPPORTED_VERSION = 35,
+        /// <summary>
+        ///     Bad/unknown compression
+        /// </summary>
+        Local_BadCompression = -198,
+
+        /// <summary>
+        ///     Broker is going away
+        /// </summary>
+        Local_Destroy = -197,
+
+        /// <summary>
+        ///     Generic failure
+        /// </summary>
+        Local_Fail = -196,
+
+        /// <summary>
+        ///     Broker transport failure
+        /// </summary>
+        Local_Transport = -195,
+
+        /// <summary>
+        ///     Critical system resource
+        /// </summary>
+        Local_CritSysResource = -194,
+
+        /// <summary>
+        ///     Failed to resolve broker
+        /// </summary>
+        Local_Resolve = -193,
+
+        /// <summary>
+        ///     Produced message timed out
+        /// </summary>
+        Local_MsgTimedOut = -192,
+
+        /// <summary>
+        ///     Reached the end of the topic+partition queue on the broker. Not really an error.
+        /// </summary>
+        Local_PartitionEOF = -191,
+
+        /// <summary>
+        ///     Permanent: Partition does not exist in cluster.
+        /// </summary>
+        Local_UnknownPartition = -190,
+
+        /// <summary>
+        ///     File or filesystem error
+        /// </summary>
+        Local_FS = -189,
+
+        /// <summary>
+        ///     Permanent: Topic does not exist in cluster.
+        /// </summary>
+        Local_UnknownTOpic = -188,
+
+        /// <summary>
+        ///     All broker connections are down.
+        /// </summary>
+        Local_AllBrokersDown = -187,
+
+        /// <summary>
+        ///     Invalid argument, or invalid configuration
+        /// </summary>
+        Local_InvalidArg = -186,
+
+        /// <summary>
+        ///     Operation timed out
+        /// </summary>
+        Local_TimedOut = -185,
+
+        /// <summary>
+        ///     Queue is full
+        /// </summary>
+        Local_QueueFull = -184,
+
+        /// <summary>
+        ///     ISR count &lt; required.acks
+        /// </summary>
+        Local_ISRInsuff = -183,
+
+        /// <summary>
+        ///     Broker node update
+        /// </summary>
+        Local_NodeUpdate = -182,
+
+        /// <summary>
+        ///     SSL error
+        /// </summary>
+        Local_SSL = -181,
+
+        /// <summary>
+        ///     Waiting for coordinator to become available.
+        /// </summary>
+        Local_WaitCoord = -180,
+
+        /// <summary>
+        ///     Unknown client group
+        /// </summary>
+        Local_UnknownGroup = -179,
+
+        /// <summary>
+        ///     Operation in progress
+        /// </summary>
+        Local_InProgress = -178,
+
+        /// <summary>
+        ///     Previous operation in progress, wait for it to finish.
+        /// </summary>
+        Local_PrevInProgress = -177,
+
+        /// <summary>
+        ///     This operation would interfere with an existing subscription
+        /// </summary>
+        Local_ExistingSubscription = -176,
+
+        /// <summary>
+        ///     Assigned partitions (rebalance_cb)
+        /// </summary>
+        Local_AssignPartitions=  -175,
+
+        /// <summary>
+        ///     Revoked partitions (rebalance_cb)
+        /// </summary>
+        Local_RevokePartitions = -174,
+
+        /// <summary>
+        ///     Conflicting use
+        /// </summary>
+        Local_Conflict = -173,
+
+        /// <summary>
+        ///     Wrong state
+        /// </summary>
+        Local_State = -172,
+
+        /// <summary>
+        ///     Unknown protocol
+        /// </summary>
+        Local_UnknownProtocol = -171,
+
+        /// <summary>
+        ///     Not implemented
+        /// </summary>
+        Local_NotImplemented = -170,
+
+        /// <summary>
+        ///     Authentication failure
+        /// </summary>
+        Local_Authentication = -169,
+
+        /// <summary>
+        ///     No stored offset
+        /// </summary>
+        Local_NoOffset = -168,
+
+        /// <summary>
+        ///     Outdated
+        /// </summary>
+        Local_Outdated = -167,
+
+        /// <summary>
+        ///     Timed out in queue
+        /// </summary>
+        Local_TimedOutQueue = -166,
+
+
+        /// <summary>
+        ///     Unknown broker error
+        /// </summary>
+        Unknown = -1,
+
+        /// <summary>
+        ///     Success
+        /// </summary>
+        NoError = 0,
+
+        /// <summary>
+        ///     Offset out of range
+        /// </summary>
+        Broker_OffsetOutOfRange = 1,
+
+        /// <summary>
+        ///     Invalid message
+        /// </summary>
+        Broker_InvalidMsg = 2,
+
+        /// <summary>
+        ///     Unknown topic or partition
+        /// </summary>
+        Broker_UnknownTopicOrPart = 3,
+
+        /// <summary>
+        ///     Invalid message size
+        /// </summary>
+        Broker_InvalidMsgSize = 4,
+
+        /// <summary>
+        ///     Leader not available
+        /// </summary>
+        Broker_LeaderNotAvailable = 5,
+
+        /// <summary>
+        ///     Not leader for partition
+        /// </summary>
+        Broker_NotLeaderForPartition = 6,
+
+        /// <summary>
+        ///     Request timed out
+        /// </summary>
+        Broker_RequestTimedOut = 7,
+
+        /// <summary>
+        ///     Broker not available
+        /// </summary>
+        Broker_BrokerNotAvailable = 8,
+
+        /// <summary>
+        ///     Replica not available
+        /// </summary>
+        Broker_ReplicaNotAvailable = 9,
+
+        /// <summary>
+        ///     Message size too large
+        /// </summary>
+        Broker_MsgSizeTooLarge = 10,
+
+        /// <summary>
+        ///     StaleControllerEpochCode
+        /// </summary>
+        Broker_StaleCtrlEpoch = 11,
+
+        /// <summary>
+        ///     Offset metadata string too large
+        /// </summary>
+        Broker_OffsetMetadataTooLarge = 12,
+
+        /// <summary>
+        ///     Broker disconnected before response received
+        /// </summary>
+        Broker_NetworkException = 13,
+
+        /// <summary>
+        ///     Group coordinator load in progress
+        /// </summary>
+        Broker_GroupLoadInProress = 14,
+
+        /// <summary>
+        /// Group coordinator not available
+        /// </summary>
+        Broker_GroupCoordinatorNotAvailable = 15,
+
+        /// <summary>
+        ///     Not coordinator for group
+        /// </summary>
+        Broker_NotCoordinatorForGroup = 16,
+
+        /// <summary>
+        ///     Invalid topic
+        /// </summary>
+        Broker_TopicException = 17,
+
+        /// <summary>
+        ///     Message batch larger than configured server segment size
+        /// </summary>
+        Broker_RecordListTooLarge = 18,
+
+        /// <summary>
+        ///     Not enough in-sync replicas
+        /// </summary>
+        Broker_NotEnoughReplicas = 19,
+
+        /// <summary>
+        ///     Message(s) written to insufficient number of in-sync replicas
+        /// </summary>
+        Broker_NotEnoughReplicasAfterAppend = 20,
+
+        /// <summary>
+        ///     Invalid required acks value
+        /// </summary>
+        Broker_InvalidRequiredAcks = 21,
+
+        /// <summary>
+        ///     Specified group generation id is not valid
+        /// </summary>
+        Broker_IllegalGeneration = 22,
+
+        /// <summary>
+        ///     Inconsistent group protocol
+        /// </summary>
+        Broker_InconsistentGroupProtocol = 23,
+
+        /// <summary>
+        ///     Invalid group.id
+        /// </summary>
+        Broker_InvalidGroupId = 24,
+
+        /// <summary>
+        ///     Unknown member
+        /// </summary>
+        Broker_UnknownMemberId = 25,
+
+        /// <summary>
+        ///     Invalid session timeout
+        /// </summary>
+        Broker_InvalidSessionTimeout = 26,
+
+        /// <summary>
+        ///     Group rebalance in progress
+        /// </summary>
+        Broker_RebalanceInProgress = 27,
+
+        /// <summary>
+        ///     Commit offset data size is not valid
+        /// </summary>
+        Broker_InvalidCommitOffsetSize = 28,
+
+        /// <summary>
+        ///     Topic authorization failed
+        /// </summary>
+        Broker_TopicAuthorizationFailed = 29,
+
+        /// <summary>
+        ///     Group authorization failed
+        /// </summary>
+        Broker_GroupAuthorizationFailed = 30,
+
+        /// <summary>
+        ///     Cluster authorization failed
+        /// </summary>
+        Broker_ClusterAuthorizationFailed = 31,
+
+        /// <summary>
+        ///     Invalid timestamp
+        /// </summary>
+        Broker_InvalidTimestamp = 32,
+
+        /// <summary>
+        ///     Unsupported SASL mechanism
+        /// </summary>
+        Broker_UnsupportedSASLMechanism = 33,
+
+        /// <summary>
+        ///     Illegal SASL state
+        /// </summary>
+        Broker_IllegalSASLState = 34,
+
+        /// <summary>
+        ///     Unuspported version
+        /// </summary>
+        Broker_UnsupportedVersion = 35
     };
 
     public static class ErrorCodeExtensions

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -434,7 +434,7 @@ namespace Confluent.Kafka.Impl
             ErrorCode err = LibRdKafka.commit_queue(handle, cOffsets, cQueue, dummyOffsetCommitCb, IntPtr.Zero);
             if (cOffsets != IntPtr.Zero)
                 LibRdKafka.topic_partition_list_destroy(cOffsets);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 LibRdKafka.queue_destroy(cQueue);
                 return new CommittedOffsets(new Error(err));
@@ -446,7 +446,7 @@ namespace Confluent.Kafka.Impl
             if (rkev == IntPtr.Zero)
             {
                 // This shouldn't happen since timoeut is infinite
-                return new CommittedOffsets(new Error(ErrorCode._TIMED_OUT));
+                return new CommittedOffsets(new Error(ErrorCode.Local_TimedOut));
             }
 
             CommittedOffsets committedOffsets =

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -178,7 +178,7 @@ namespace Confluent.Kafka.Impl
                 /* const struct rd_kafka_metadata ** */ out metaPtr,
                 (IntPtr) millisecondsTimeout);
 
-            if (err == ErrorCode.NO_ERROR)
+            if (err == ErrorCode.NoError)
             {
                 try {
                     var meta = (rd_kafka_metadata) Marshal.PtrToStructure<rd_kafka_metadata>(metaPtr);
@@ -236,7 +236,7 @@ namespace Confluent.Kafka.Impl
             long high;
 
             ErrorCode err = LibRdKafka.query_watermark_offsets(handle, topic, partition, out low, out high, (IntPtr) millisecondsTimeout);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -250,7 +250,7 @@ namespace Confluent.Kafka.Impl
             long high;
 
             ErrorCode err = LibRdKafka.get_watermark_offsets(handle, topic, partition, out low, out high);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -272,7 +272,7 @@ namespace Confluent.Kafka.Impl
 
             ErrorCode err = LibRdKafka.subscribe(handle, list);
             LibRdKafka.topic_partition_list_destroy(list);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -281,7 +281,7 @@ namespace Confluent.Kafka.Impl
         internal void Unsubscribe()
         {
             ErrorCode err = LibRdKafka.unsubscribe(handle);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -344,7 +344,7 @@ namespace Confluent.Kafka.Impl
         internal void ConsumerClose()
         {
             ErrorCode err = LibRdKafka.consumer_close(handle);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -354,7 +354,7 @@ namespace Confluent.Kafka.Impl
         {
             IntPtr listPtr = IntPtr.Zero;
             ErrorCode err = LibRdKafka.assignment(handle, out listPtr);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -368,7 +368,7 @@ namespace Confluent.Kafka.Impl
         {
             IntPtr listPtr = IntPtr.Zero;
             ErrorCode err = LibRdKafka.subscription(handle, out listPtr);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -402,7 +402,7 @@ namespace Confluent.Kafka.Impl
             {
                 LibRdKafka.topic_partition_list_destroy(list);
             }
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -483,7 +483,7 @@ namespace Confluent.Kafka.Impl
             ErrorCode err = LibRdKafka.committed(handle, list, timeout_ms);
             var result = GetTopicPartitionOffsetErrorList(list);
             LibRdKafka.topic_partition_list_destroy(list);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -510,7 +510,7 @@ namespace Confluent.Kafka.Impl
             ErrorCode err = LibRdKafka.position(handle, list);
             var result = GetTopicPartitionOffsetErrorList(list);
             LibRdKafka.topic_partition_list_destroy(list);
-            if (err != ErrorCode.NO_ERROR)
+            if (err != ErrorCode.NoError)
             {
                 throw new KafkaException(err);
             }
@@ -599,7 +599,7 @@ namespace Confluent.Kafka.Impl
         {
             IntPtr grplistPtr;
             ErrorCode err = LibRdKafka.list_groups(handle, group, out grplistPtr, (IntPtr)millisecondsTimeout);
-            if (err == ErrorCode.NO_ERROR)
+            if (err == ErrorCode.NoError)
             {
                 var list = Marshal.PtrToStructure<rd_kafka_group_list>(grplistPtr);
                 var groups = Enumerable.Range(0, list.group_cnt)

--- a/src/Confluent.Kafka/Library.cs
+++ b/src/Confluent.Kafka/Library.cs
@@ -16,8 +16,11 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using Confluent.Kafka.Internal;
 using Confluent.Kafka.Impl;
+
+[assembly:CLSCompliant(true)]
 
 
 namespace Confluent.Kafka

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -562,7 +562,7 @@ namespace Confluent.Kafka
             var handler = new TypedTaskDeliveryHandlerShim(key, val);
             var keyBytes = KeySerializer?.Serialize(key);
             var valBytes = ValueSerializer?.Serialize(val);
-            producer.Produce(topic, valBytes, 0, valBytes.Length, keyBytes, 0, keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
+            producer.Produce(topic, valBytes, 0, valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
             return handler.Task;
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "test-consumer-group" },
+                { "group.id", "assign-overloads-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 }
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "test-consumer-group" },
+                { "group.id", "assign-past-end-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 }
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Background.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Background.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 consumer.OnMessage += (_, msg) =>
                 {
-                    Assert.Equal(msg.Error.Code, ErrorCode.NO_ERROR);
+                    Assert.Equal(msg.Error.Code, ErrorCode.NoError);
                     msgCnt += 1;
                 };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 consumer.OnMessage += (_, msg) =>
                 {
-                    Assert.Equal(msg.Error.Code, ErrorCode.NO_ERROR);
+                    Assert.Equal(msg.Error.Code, ErrorCode.NoError);
                     msgCnt += 1;
                 };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "simple-produce-consume" },
+                { "group.id", "deserializing-consumer-poll-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 }
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "test-consumer-group" },
+                { "group.id", "duplicate-consumer-assign-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 }
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -41,7 +41,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "simple-produce-consume" },
+                { "group.id", "garbage-collect-cg" },
                 { "bootstrap.servers", bootstrapServers }
             };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
@@ -66,7 +66,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 var g = consumer.ListGroup("list-group-cg");
                 Assert.NotNull(g);
-                Assert.Equal(ErrorCode.NO_ERROR, g.Error.Code);
+                Assert.Equal(ErrorCode.NoError, g.Error.Code);
                 Assert.Equal("list-group-cg", g.Group);
                 Assert.Equal("consumer", g.ProtocolType);
                 Assert.Equal(1, g.Members.Count);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -32,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "test-consumer-group" },
+                { "group.id", "null-vs-empty-cg" },
                 { "bootstrap.servers", bootstrapServers }
             };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "test-consumer-group" },
+                { "group.id", "on-log-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "log_level", 7 },
                 { "debug", "all" }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "test-consumer-group" },
+                { "group.id", "on-partitions-assigned-not-set-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 }
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ProduceTimestamp.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ProduceTimestamp.cs
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "simple-produce-consume" },
+                { "group.id", "produce-timestamp-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 },
                 { "api.version.request", true }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -42,7 +42,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "simple-produce-consume" },
+                { "group.id", "simple-produce-consume-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 },
                 { "api.version.request", true }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -67,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var consumerConfig = new Dictionary<string, object>
             {
-                { "group.id", "simple-produce-consume" },
+                { "group.id", "watermark-offset-cg" },
                 { "bootstrap.servers", bootstrapServers },
                 { "session.timeout.ms", 6000 }
             };

--- a/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
+++ b/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
@@ -26,7 +26,7 @@ namespace Confluent.Kafka.Tests
         public void Constuctor()
         {
             var tpos = new List<TopicPartitionOffsetError>();
-            var err = new Error(ErrorCode.UNKNOWN_TOPIC_OR_PART);
+            var err = new Error(ErrorCode.Broker_UnknownTopicOrPart);
             var co = new CommittedOffsets(tpos, err);
             Assert.Same(co.Offsets, tpos);
             Assert.Equal(co.Error, err);

--- a/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
+++ b/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
@@ -26,7 +26,7 @@ namespace Confluent.Kafka.Tests
         public void Constuctor()
         {
             var tpos = new List<TopicPartitionOffsetError>();
-            var err = new Error(ErrorCode.Broker_UnknownTopicOrPart);
+            var err = new Error(ErrorCode.UnknownTopicOrPart);
             var co = new CommittedOffsets(tpos, err);
             Assert.Same(co.Offsets, tpos);
             Assert.Equal(co.Error, err);

--- a/test/Confluent.Kafka.UnitTests/Error.cs
+++ b/test/Confluent.Kafka.UnitTests/Error.cs
@@ -24,8 +24,8 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void Constuctor()
         {
-            var e = new Error(ErrorCode._BAD_COMPRESSION);
-            Assert.Equal(e.Code, ErrorCode._BAD_COMPRESSION);
+            var e = new Error(ErrorCode.Local_BadCompression);
+            Assert.Equal(e.Code, ErrorCode.Local_BadCompression);
             Assert.NotNull(e.Reason);
             Assert.Equal(e.Reason, "Local: Invalid compressed data");
 
@@ -37,10 +37,10 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void Equality()
         {
-            var e1 = new Error(ErrorCode._ALL_BROKERS_DOWN);
-            var e2 = new Error(ErrorCode._ALL_BROKERS_DOWN);
-            var e3 = new Error(ErrorCode._IN_PROGRESS);
-            var e4 = new Error(ErrorCode._IN_PROGRESS, "Dummy message");
+            var e1 = new Error(ErrorCode.Local_AllBrokersDown);
+            var e2 = new Error(ErrorCode.Local_AllBrokersDown);
+            var e3 = new Error(ErrorCode.Local_InProgress);
+            var e4 = new Error(ErrorCode.Local_InProgress, "Dummy message");
 
             Assert.Equal(e1, e2);
             Assert.True(e1.Equals(e2));
@@ -61,8 +61,8 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void HasError()
         {
-            var e1 = new Error(ErrorCode.NO_ERROR);
-            var e2 = new Error(ErrorCode.NOT_COORDINATOR_FOR_GROUP);
+            var e1 = new Error(ErrorCode.NoError);
+            var e2 = new Error(ErrorCode.Broker_NotCoordinatorForGroup);
 
             Assert.False(e1.HasError);
             Assert.True(e2.HasError);
@@ -73,8 +73,8 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void BoolCast()
         {
-            var e1 = new Error(ErrorCode.NO_ERROR);
-            var e2 = new Error(ErrorCode.NOT_COORDINATOR_FOR_GROUP);
+            var e1 = new Error(ErrorCode.NoError);
+            var e2 = new Error(ErrorCode.Broker_NotCoordinatorForGroup);
 
             Assert.False(e1);
             Assert.True(e2);
@@ -83,8 +83,8 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void ErrorCodeCast()
         {
-            var e1 = new Error(ErrorCode.NOT_COORDINATOR_FOR_GROUP);
-            var ec1 = ErrorCode.NOT_COORDINATOR_FOR_GROUP;
+            var e1 = new Error(ErrorCode.Broker_NotCoordinatorForGroup);
+            var ec1 = ErrorCode.Broker_NotCoordinatorForGroup;
 
             Assert.Equal((ErrorCode)e1, ec1);
             Assert.Equal(ec1, (ErrorCode)e1);

--- a/test/Confluent.Kafka.UnitTests/Error.cs
+++ b/test/Confluent.Kafka.UnitTests/Error.cs
@@ -29,8 +29,8 @@ namespace Confluent.Kafka.Tests
             Assert.NotNull(e.Reason);
             Assert.Equal(e.Reason, "Local: Invalid compressed data");
 
-            var e2 = new Error(ErrorCode._BAD_MSG, "Dummy message");
-            Assert.Equal(e2.Code, ErrorCode._BAD_MSG);
+            var e2 = new Error(ErrorCode.Local_BadMsg, "Dummy message");
+            Assert.Equal(e2.Code, ErrorCode.Local_BadMsg);
             Assert.Equal(e2.Reason, "Dummy message");
         }
 
@@ -62,7 +62,7 @@ namespace Confluent.Kafka.Tests
         public void HasError()
         {
             var e1 = new Error(ErrorCode.NoError);
-            var e2 = new Error(ErrorCode.Broker_NotCoordinatorForGroup);
+            var e2 = new Error(ErrorCode.NotCoordinatorForGroup);
 
             Assert.False(e1.HasError);
             Assert.True(e2.HasError);
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.Tests
         public void BoolCast()
         {
             var e1 = new Error(ErrorCode.NoError);
-            var e2 = new Error(ErrorCode.Broker_NotCoordinatorForGroup);
+            var e2 = new Error(ErrorCode.NotCoordinatorForGroup);
 
             Assert.False(e1);
             Assert.True(e2);
@@ -83,8 +83,8 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void ErrorCodeCast()
         {
-            var e1 = new Error(ErrorCode.Broker_NotCoordinatorForGroup);
-            var ec1 = ErrorCode.Broker_NotCoordinatorForGroup;
+            var e1 = new Error(ErrorCode.NotCoordinatorForGroup);
+            var ec1 = ErrorCode.NotCoordinatorForGroup;
 
             Assert.Equal((ErrorCode)e1, ec1);
             Assert.Equal(ec1, (ErrorCode)e1);

--- a/test/Confluent.Kafka.UnitTests/GroupInfo.cs
+++ b/test/Confluent.Kafka.UnitTests/GroupInfo.cs
@@ -27,10 +27,10 @@ namespace Confluent.Kafka.Tests
         {
             var bmd = new BrokerMetadata(1, "host", 42);
             var members = new List<GroupMemberInfo>();
-            var gi = new GroupInfo(bmd, "mygroup", new Error(ErrorCode.NO_ERROR), "mystate", "myprotocoltype", "myprotocol", members);
+            var gi = new GroupInfo(bmd, "mygroup", new Error(ErrorCode.NoError), "mystate", "myprotocoltype", "myprotocol", members);
             Assert.Equal(gi.Broker, bmd);
             Assert.Equal(gi.Group, "mygroup");
-            Assert.Equal(gi.Error, new Error(ErrorCode.NO_ERROR));
+            Assert.Equal(gi.Error, new Error(ErrorCode.NoError));
             Assert.Equal(gi.State, "mystate");
             Assert.Equal(gi.ProtocolType, "myprotocoltype");
             Assert.Equal(gi.Protocol, "myprotocol");

--- a/test/Confluent.Kafka.UnitTests/Message.cs
+++ b/test/Confluent.Kafka.UnitTests/Message.cs
@@ -27,7 +27,7 @@ namespace Confluent.Kafka.Tests
         {
             byte[] key = new byte[0];
             byte[] val = new byte[0];
-            var mi = new Message("tp1", 24, 33, key, val, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime), new Error(ErrorCode.NO_ERROR));
+            var mi = new Message("tp1", 24, 33, key, val, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime), new Error(ErrorCode.NoError));
 
             Assert.Equal(mi.Topic, "tp1");
             Assert.Equal(mi.Partition, 24);
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.Tests
             Assert.Same(mi.Key, key);
             Assert.Same(mi.Value, val);
             Assert.Equal(mi.Timestamp, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime));
-            Assert.Equal(mi.Error, new Error(ErrorCode.NO_ERROR));
+            Assert.Equal(mi.Error, new Error(ErrorCode.NoError));
             Assert.Equal(mi.TopicPartition, new TopicPartition("tp1", 24));
             Assert.Equal(mi.TopicPartitionOffset, new TopicPartitionOffset("tp1", 24, 33));
         }
@@ -43,7 +43,7 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void ConstuctorAndProps_Generic()
         {
-            var mi = new Message<string, string>("tp1", 24, 33, "mykey", "myval", new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime), new Error(ErrorCode.NO_ERROR));
+            var mi = new Message<string, string>("tp1", 24, 33, "mykey", "myval", new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime), new Error(ErrorCode.NoError));
 
             Assert.Equal(mi.Topic, "tp1");
             Assert.Equal(mi.Partition, 24);
@@ -51,7 +51,7 @@ namespace Confluent.Kafka.Tests
             Assert.Equal(mi.Key, "mykey");
             Assert.Equal(mi.Value, "myval");
             Assert.Equal(mi.Timestamp, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime));
-            Assert.Equal(mi.Error, new Error(ErrorCode.NO_ERROR));
+            Assert.Equal(mi.Error, new Error(ErrorCode.NoError));
             Assert.Equal(mi.TopicPartition, new TopicPartition("tp1", 24));
             Assert.Equal(mi.TopicPartitionOffset, new TopicPartitionOffset("tp1", 24, 33));
         }

--- a/test/Confluent.Kafka.UnitTests/PartitionMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/PartitionMetadata.cs
@@ -26,12 +26,12 @@ namespace Confluent.Kafka.Tests
         {
             int[] replicas = new int[0];
             int[] inSyncReplicas = new int[0];
-            var pm = new PartitionMetadata(33, 1, replicas, inSyncReplicas, ErrorCode._ALL_BROKERS_DOWN);
+            var pm = new PartitionMetadata(33, 1, replicas, inSyncReplicas, ErrorCode.Local_AllBrokersDown);
             Assert.Equal(pm.PartitionId, 33);
             Assert.Equal(pm.Leader, 1);
             Assert.Same(pm.Replicas, replicas);
             Assert.Same(pm.InSyncReplicas, inSyncReplicas);
-            Assert.Equal(pm.Error, new Error(ErrorCode._ALL_BROKERS_DOWN));
+            Assert.Equal(pm.Error, new Error(ErrorCode.Local_AllBrokersDown));
         }
 
         // TODO: ToString() tests. Note: there is coverage of this already in the Metdata integration test.

--- a/test/Confluent.Kafka.UnitTests/TopicMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicMetadata.cs
@@ -26,11 +26,11 @@ namespace Confluent.Kafka.Tests
         public void Constuctor()
         {
             var partitions = new List<PartitionMetadata>();
-            var tm = new TopicMetadata("mytopic", partitions, ErrorCode._ALL_BROKERS_DOWN);
+            var tm = new TopicMetadata("mytopic", partitions, ErrorCode.Local_AllBrokersDown);
 
             Assert.Equal(tm.Topic, "mytopic");
             Assert.Same(partitions, tm.Partitions);
-            Assert.Equal(tm.Error, new Error(ErrorCode._ALL_BROKERS_DOWN));
+            Assert.Equal(tm.Error, new Error(ErrorCode.Local_AllBrokersDown));
         }
 
         // TODO: ToString() tests. Note: there is coverage of this already in the Metdata integration test.

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
@@ -25,24 +25,24 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void Constuctor()
         {
-            var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode._BAD_MSG);
+            var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.Local_BadMsg);
 
             Assert.Equal(tpoe.Topic, "mytopic");
             Assert.Equal(tpoe.Partition, 42);
             Assert.Equal(tpoe.Offset, 107);
-            Assert.Equal(tpoe.Error, new Error(ErrorCode._BAD_MSG));
+            Assert.Equal(tpoe.Error, new Error(ErrorCode.Local_BadMsg));
         }
 
         [Fact]
         public void Equality()
         {
-            var a = new TopicPartitionOffsetError("a", 31, 55, ErrorCode.NO_ERROR);
-            var a2 = new TopicPartitionOffsetError("a", 31, 55, ErrorCode.NO_ERROR);
+            var a = new TopicPartitionOffsetError("a", 31, 55, ErrorCode.NoError);
+            var a2 = new TopicPartitionOffsetError("a", 31, 55, ErrorCode.NoError);
             var nes = new List<TopicPartitionOffsetError> {
-                new TopicPartitionOffsetError("b", 31, 55, ErrorCode.NO_ERROR),
-                new TopicPartitionOffsetError("a", 32, 55, ErrorCode.NO_ERROR),
-                new TopicPartitionOffsetError("a", 31, 56, ErrorCode.NO_ERROR),
-                new TopicPartitionOffsetError("a", 31, 55, ErrorCode._CONFLICT),
+                new TopicPartitionOffsetError("b", 31, 55, ErrorCode.NoError),
+                new TopicPartitionOffsetError("a", 32, 55, ErrorCode.NoError),
+                new TopicPartitionOffsetError("a", 31, 56, ErrorCode.NoError),
+                new TopicPartitionOffsetError("a", 31, 55, ErrorCode.Local_Conflict),
             };
 
             Assert.Equal(a, a2);
@@ -62,7 +62,7 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void ToStringTest()
         {
-            var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode._BAD_MSG);
+            var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.Local_BadMsg);
 
             Assert.True(tpoe.ToString().Contains(tpoe.Topic));
             Assert.True(tpoe.ToString().Contains(tpoe.Partition.ToString()));
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void Properties()
         {
-            var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.NO_ERROR);
+            var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.NoError);
 
             Assert.Equal(tpoe.TopicPartition, new TopicPartition("mytopic", 42));
             Assert.Equal(tpoe.TopicPartitionOffset, new TopicPartitionOffset("mytopic", 42, 107));


### PR DESCRIPTION
Leading underscores on enum values are not CLS compliant so I've prefixed local ErrorCode values with RD_ instead. Alternatives are prefixing with L_ or LOCAL_ (and broker error codes with B_ or BROKER_), or just removing the underscore altogether.

prefixing with RD_ is my preferred option, but I don't like any of them to be honest. Seeking the opinion of others.

(and yes, whoops, accidentally pushed this branch to the confluentinc repo, not my own).