### PR TITLE
no longer release config handles

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -430,6 +430,7 @@ namespace Confluent.Kafka
                     defaultTopicConfig.ToList().ForEach((kvp) => { topicConfigHandle.Set(kvp.Key, kvp.Value.ToString()); });
                 }
                 LibRdKafka.conf_set_default_topic_conf(configPtr, topicConfigHandle.DangerousGetHandle());
+                topicConfigHandle.SetHandleAsInvalid(); // topic config object is no longer useable.
             }
 
             LibRdKafka.conf_set_error_cb(configPtr, ErrorCallback);
@@ -437,6 +438,7 @@ namespace Confluent.Kafka
             LibRdKafka.conf_set_stats_cb(configPtr, StatsCallback);
 
             this.kafkaHandle = SafeKafkaHandle.Create(RdKafkaType.Consumer, configPtr);
+            configHandle.SetHandleAsInvalid(); // config object is no longer useable.
 
             var pollSetConsumerError = kafkaHandle.PollSetConsumer();
             if (pollSetConsumerError != ErrorCode.NO_ERROR)

--- a/src/Confluent.Kafka/Impl/SafeConfigHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeConfigHandle.cs
@@ -26,15 +26,34 @@ using Confluent.Kafka.Internal;
 
 namespace Confluent.Kafka.Impl
 {
-    enum ConfRes {
-        Unknown = -2, /* Unknown configuration name. */
-        Invalid = -1, /* Invalid configuration value. */
-        Ok = 0        /* Configuration okay */
+    enum ConfRes
+    {
+        /// <summary>
+        ///     Unknown configuration name.
+        /// </summary>
+        Unknown = -2,
+
+        /// <summary>
+        ///     Invalid configuration value.
+        /// </summary>
+        Invalid = -1,
+
+        /// <summary>
+        ///     Configuration okay
+        /// </summary>
+        Ok = 0
     }
 
-    class SafeConfigHandle : SafeHandleZeroIsInvalid
+    class SafeConfigHandle : SafeHandle
     {
-        private SafeConfigHandle() {}
+        public SafeConfigHandle()
+            : base(IntPtr.Zero, false) { }
+
+        public override bool IsInvalid
+            => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+            => true;
 
         internal static SafeConfigHandle Create()
         {
@@ -44,12 +63,6 @@ namespace Confluent.Kafka.Impl
                 throw new Exception("Failed to create config");
             }
             return ch;
-        }
-
-        protected override bool ReleaseHandle()
-        {
-            LibRdKafka.conf_destroy(handle);
-            return true;
         }
 
         internal IntPtr Dup()

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -95,6 +95,7 @@ namespace Confluent.Kafka.Impl
                     (UIntPtr) errorStringBuilder.Capacity);
             if (skh.IsInvalid)
             {
+                LibRdKafka.conf_destroy(skh.DangerousGetHandle());
                 throw new InvalidOperationException(errorStringBuilder.ToString());
             }
             return skh;

--- a/src/Confluent.Kafka/Impl/SafeTopicConfigHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeTopicConfigHandle.cs
@@ -26,9 +26,16 @@ using Confluent.Kafka.Internal;
 
 namespace Confluent.Kafka.Impl
 {
-    internal sealed class SafeTopicConfigHandle : SafeHandleZeroIsInvalid
+    internal sealed class SafeTopicConfigHandle : SafeHandle
     {
-        private SafeTopicConfigHandle() {}
+        public SafeTopicConfigHandle()
+            : base(IntPtr.Zero, false) { }
+
+        public override bool IsInvalid
+            => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+            => true;
 
         internal static SafeTopicConfigHandle Create()
         {
@@ -38,12 +45,6 @@ namespace Confluent.Kafka.Impl
                 throw new Exception("Failed to create TopicConfig");
             }
             return ch;
-        }
-
-        protected override bool ReleaseHandle()
-        {
-            LibRdKafka.topic_conf_destroy(handle);
-            return true;
         }
 
         internal IntPtr Dup()

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -266,6 +266,7 @@ namespace Confluent.Kafka
             LibRdKafka.conf_set_stats_cb(configPtr, StatsCallback);
 
             this.kafkaHandle = SafeKafkaHandle.Create(RdKafkaType.Producer, configPtr);
+            configHandle.SetHandleAsInvalid(); // config object is no longer useable.
 
             if (!manualPoll)
             {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -1,0 +1,64 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Confluent.Kafka.Serialization;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public static partial class Tests
+    {
+        /// <summary>
+        ///     Make a Producer and Consumer.
+        ///     Do some stuff with them.
+        ///     Force a garbage collection.
+        ///     Segfault?
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public static void GarbageCollect(string bootstrapServers, string topic)
+        {
+            var producerConfig = new Dictionary<string, object>
+            {
+                { "bootstrap.servers", bootstrapServers }
+            };
+
+            var consumerConfig = new Dictionary<string, object>
+            {
+                { "group.id", "simple-produce-consume" },
+                { "bootstrap.servers", bootstrapServers }
+            };
+
+            using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
+            {
+                producer.ProduceAsync(topic, null, "test string").Wait();
+            }
+
+            using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))
+            {
+                consumer.Subscribe(topic);
+                consumer.Poll(1000);
+            }
+
+            GC.Collect();
+            // if an attempt is made to free an unmanaged resource a second time
+            // in an object finalizer, the call to .Collect() will likely segfault.
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #27.

I have open questions still. Mostly, is there really any value in using SafeHandle to wrap unmanaged config pointers?

1. we don't want ownership semantics (a major service they provide). Also, the resource referenced is just memory allocated by librdkafka (not a win32 handle or anything like that). Does that make all of the advantages noted in https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.safehandle(v=vs.110).aspx irrelevant? 
2. we're grabbing the associated IntPtr and passing it into many of the librdkafka methods anyway (should we change the marshaling of methods like conf_set_error_cb take SafeHandle, not IntPtr ?)

I propose getting this fix in now and deferring careful consideration of the above and related questions to another Issue. At this time, I want to prioritize getting the API locked down.

