### PR TITLE
How to think about Consumers and Producers [Experiment]

### DIFF
--- a/examples/Misc/Program.cs
+++ b/examples/Misc/Program.cs
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.Examples.Misc
 
             using (var producer = new Producer(config))
             {
-                var groups = producer.ListGroups(TimeSpan.FromSeconds(10));
+                var groups = producer.ClientInstance.ListGroups(TimeSpan.FromSeconds(10));
                 Console.WriteLine($"Consumer Groups:");
                 foreach (var g in groups)
                 {
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.Examples.Misc
             var config = new Dictionary<string, object> { { "bootstrap.servers", brokerList } };
             using (var producer = new Producer(config))
             {
-                var meta = producer.GetMetadata();
+                var meta = producer.ClientInstance.GetMetadata();
                 Console.WriteLine($"{meta.OriginatingBrokerId} {meta.OriginatingBrokerName}");
                 meta.Brokers.ForEach(broker =>
                     Console.WriteLine($"Broker: {broker.BrokerId} {broker.Host}:{broker.Port}"));

--- a/src/Confluent.Kafka/Client.cs
+++ b/src/Confluent.Kafka/Client.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Confluent.Kafka.Impl;
+
+
+namespace Confluent.Kafka
+{
+    public class Client
+    {
+        private SafeKafkaHandle kafkaHandle;
+
+        internal Client(SafeKafkaHandle kafkaHandle)
+        {
+            this.kafkaHandle = kafkaHandle;
+        }
+
+        public List<GroupInfo> ListGroups(TimeSpan timeout)
+            => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
+
+        // TODO: is a version of this with infinite timeout really required? (same question elsewhere)
+        public List<GroupInfo> ListGroups()
+            => kafkaHandle.ListGroups(-1);
+
+
+        public GroupInfo ListGroup(string group, TimeSpan timeout)
+            => kafkaHandle.ListGroup(group, timeout.TotalMillisecondsAsInt());
+
+        public GroupInfo ListGroup(string group)
+            => kafkaHandle.ListGroup(group, -1);
+
+
+        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
+            => kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
+
+
+        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
+            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
+
+        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition)
+            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, -1);
+
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="allTopics">
+        ///     true - request all topics from cluster
+        ///     false - request only locally known topics (topic_new():ed topics or otherwise locally referenced once, such as consumed topics)
+        /// </param>
+        /// <remarks>
+        ///     TODO: Topic handles are not exposed to users of the library (they are internal to producer).
+        ///           Is it possible to get a topic handle given a topic name?
+        ///           If so, include topic parameter in this method.
+        /// </remaarks>
+        public Metadata GetMetadata(bool allTopics, TimeSpan timeout)
+            => kafkaHandle.GetMetadata(allTopics, null, timeout.TotalMillisecondsAsInt());
+
+        public Metadata GetMetadata(bool allTopics)
+            => kafkaHandle.GetMetadata(allTopics, null, -1);
+
+    }
+}

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -322,37 +322,8 @@ namespace Confluent.Kafka
         public long OutQueueLength
             => consumer.OutQueueLength;
 
-
-        public List<GroupInfo> ListGroups(TimeSpan timeout)
-            => consumer.ListGroups(timeout);
-
-        public List<GroupInfo> ListGroups()
-            => consumer.ListGroups();
-
-
-        public GroupInfo ListGroup(string group, TimeSpan timeout)
-            => consumer.ListGroup(group, timeout);
-
-        public GroupInfo ListGroup(string group)
-            => consumer.ListGroup(group);
-
-
-        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-            => consumer.GetWatermarkOffsets(topicPartition);
-
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
-            => consumer.QueryWatermarkOffsets(topicPartition, timeout);
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition)
-            => consumer.QueryWatermarkOffsets(topicPartition);
-
-
-        public Metadata GetMetadata(bool allTopics, TimeSpan timeout)
-            => consumer.GetMetadata(allTopics, timeout);
-
-        public Metadata GetMetadata(bool allTopics)
-            => consumer.GetMetadata(allTopics);
+        public Client ClientInstance
+            => consumer.ClientInstance;
     }
 
     public class Consumer : IDisposable
@@ -493,6 +464,8 @@ namespace Confluent.Kafka
             {
                 throw new KafkaException(pollSetConsumerError, "Failed to redirect the poll queue to consumer_poll queue");
             }
+
+            ClientInstance = new Client(kafkaHandle);
         }
 
         /// <summary>
@@ -817,49 +790,6 @@ namespace Confluent.Kafka
         public long OutQueueLength
             => kafkaHandle.OutQueueLength;
 
-
-        public List<GroupInfo> ListGroups(TimeSpan timeout)
-            => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
-
-        // TODO: is a version of this with infinite timeout really required? (same question elsewhere)
-        public List<GroupInfo> ListGroups()
-            => kafkaHandle.ListGroups(-1);
-
-
-        public GroupInfo ListGroup(string group, TimeSpan timeout)
-            => kafkaHandle.ListGroup(group, timeout.TotalMillisecondsAsInt());
-
-        public GroupInfo ListGroup(string group)
-            => kafkaHandle.ListGroup(group, -1);
-
-
-        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-            => kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
-
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
-            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition)
-            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, -1);
-
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="allTopics">
-        ///     true - request all topics from cluster
-        ///     false - request only locally known topics (topic_new():ed topics or otherwise locally referenced once, such as consumed topics)
-        /// </param>
-        /// <remarks>
-        ///     TODO: Topic handles are not exposed to users of the library (they are internal to producer).
-        ///           Is it possible to get a topic handle given a topic name?
-        ///           If so, include topic parameter in this method.
-        /// </remaarks>
-        public Metadata GetMetadata(bool allTopics, TimeSpan timeout)
-            => kafkaHandle.GetMetadata(allTopics, null, timeout.TotalMillisecondsAsInt());
-
-        public Metadata GetMetadata(bool allTopics)
-            => kafkaHandle.GetMetadata(allTopics, null, -1);
+        public Client ClientInstance { get; }
     }
 }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -280,6 +280,8 @@ namespace Confluent.Kafka
                 callbackCts = new CancellationTokenSource();
                 callbackTask = StartPollTask(callbackCts.Token);
             }
+
+            ClientInstance = new Client(kafkaHandle);
         }
 
         // TODO: think about Poll and flushing.
@@ -404,41 +406,7 @@ namespace Confluent.Kafka
             kafkaHandle.Dispose();
         }
 
-        // TODO: potentially use interface to avoid duplicate method docs.
-
-        public List<GroupInfo> ListGroups(TimeSpan timeout)
-            => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
-
-        public List<GroupInfo> ListGroups()
-            => kafkaHandle.ListGroups(-1);
-
-
-        public GroupInfo ListGroup(string group, TimeSpan timeout)
-            => kafkaHandle.ListGroup(group, timeout.TotalMillisecondsAsInt());
-
-        public GroupInfo ListGroup(string group)
-            => kafkaHandle.ListGroup(group, -1);
-
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
-            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition)
-            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, -1);
-
-
-        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-            => kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
-
-
-        private Metadata GetMetadata(bool allTopics, string topic, int millisecondsTimeout)
-            => kafkaHandle.GetMetadata(allTopics, topic == null ? null : getKafkaTopicHandle(topic), millisecondsTimeout);
-
-        public Metadata GetMetadata(bool allTopics, string topic, TimeSpan timeout)
-            => GetMetadata(allTopics, topic, timeout.TotalMillisecondsAsInt());
-
-        public Metadata GetMetadata(bool allTopics, string topic)
-            => GetMetadata(allTopics, topic, -1);
+        public Client ClientInstance { get; }
     }
 
 
@@ -615,41 +583,7 @@ namespace Confluent.Kafka
         public void Dispose()
             => producer.Dispose();
 
-
-        public List<GroupInfo> ListGroups(TimeSpan timeout)
-            => producer.ListGroups(timeout);
-
-        public List<GroupInfo> ListGroups()
-            => producer.ListGroups();
-
-
-        public GroupInfo ListGroup(string group, TimeSpan timeout)
-            => producer.ListGroup(group, timeout);
-
-        public GroupInfo ListGroup(string group)
-            => producer.ListGroup(group);
-
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
-            => producer.QueryWatermarkOffsets(topicPartition, timeout);
-
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition)
-            => producer.QueryWatermarkOffsets(topicPartition);
-
-
-        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-            => producer.GetWatermarkOffsets(topicPartition);
-
-
-        /// <summary>
-        ///     - allTopics=true - request all topics from cluster
-        ///     - allTopics=false, topic=null - request only locally known topics (topic_new():ed topics or otherwise locally referenced once, such as consumed topics)
-        ///     - allTopics=false, topic=valid - request specific topic
-        /// </summary>
-        public Metadata GetMetadata(bool allTopics, string topic, TimeSpan timeout)
-            => producer.GetMetadata(allTopics, topic, timeout);
-
-        public Metadata GetMetadata(bool allTopics, string topic)
-            => producer.GetMetadata(allTopics, topic);
+        public Client ClientInstance
+            => producer.ClientInstance;
     }
 }

--- a/src/Confluent.Kafka/project.json
+++ b/src/Confluent.Kafka/project.json
@@ -14,7 +14,7 @@
     },
 
     "frameworks": {
-        "net451": { },
+/*        "net451": { },*/
         "netstandard1.3": {
             "dependencies": {
                 "System.Console": "4.0.0",

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Background.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Background.cs
@@ -47,6 +47,8 @@ namespace Confluent.Kafka.IntegrationTests
                 int msgCnt = 0;
                 AutoResetEvent are = new AutoResetEvent(false);
 
+                consumer.ClientInstance.QueryWatermarkOffsets();
+
                 consumer.OnMessage += (_, msg) =>
                 {
                     Assert.Equal(msg.Error.Code, ErrorCode.NO_ERROR);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var producer = new Producer(producerConfig))
             {
-                var metadata = producer.GetMetadata(true, null);
+                var metadata = producer.ClientInstance.GetMetadata(true, null);
                 Assert.NotNull(metadata.Brokers);
                 Assert.True(metadata.Brokers.Count > 0);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -45,7 +45,7 @@ namespace Confluent.Kafka.IntegrationTests
                 dr = producer.ProduceAsync(topic, null, testString).Result;
                 producer.Flush();
 
-                var getOffsets = producer.GetWatermarkOffsets(new TopicPartition(topic, 0));
+                var getOffsets = producer.ClientInstance.GetWatermarkOffsets(new TopicPartition(topic, 0));
 
                 // statistics.interval.ms is not set, so this should always be invalid.
                 Assert.Equal(getOffsets.Low, Offset.Invalid);
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                 // no message has been consumed from broker (this is a producer), so this should always be invalid.
                 Assert.Equal(getOffsets.High, Offset.Invalid);
 
-                var queryOffsets = producer.QueryWatermarkOffsets(new TopicPartition(topic, 0));
+                var queryOffsets = producer.ClientInstance.QueryWatermarkOffsets(new TopicPartition(topic, 0));
                 Assert.NotEqual(queryOffsets.Low, Offset.Invalid);
                 Assert.NotEqual(queryOffsets.High, Offset.Invalid);
 
@@ -78,12 +78,12 @@ namespace Confluent.Kafka.IntegrationTests
                 Message msg;
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromSeconds(10)));
 
-                var getOffsets = consumer.GetWatermarkOffsets(dr.TopicPartition);
+                var getOffsets = consumer.ClientInstance.GetWatermarkOffsets(dr.TopicPartition);
                 Assert.Equal(getOffsets.Low, Offset.Invalid);
                 // the offset of the next message to be read.
                 Assert.Equal((long)getOffsets.High, dr.Offset + 1);
 
-                var queryOffsets = consumer.QueryWatermarkOffsets(dr.TopicPartition);
+                var queryOffsets = consumer.ClientInstance.QueryWatermarkOffsets(dr.TopicPartition);
                 Assert.NotEqual(queryOffsets.Low, Offset.Invalid);
                 Assert.Equal(getOffsets.High, queryOffsets.High);
             }


### PR DESCRIPTION
It might be good if general client functions were split out from `Producer` and `Consumer` as in this PR creating three classes with more focus than the existing two.

this is a quick experiment (not polished, some stuff broken, don't merge) - just putting it out there for general comment.

I'm on the fence on this one. The way things are bugs me a bit, but I don't think it's going to cause anyone too many problems.

I don't know what to call `Client`/`ClientInstance`.
