### PR TITLE
Fixed: ListGroup throws exception if group doesn't exist

### DIFF
--- a/src/Confluent.Kafka/IDeliveryHandler.cs
+++ b/src/Confluent.Kafka/IDeliveryHandler.cs
@@ -16,8 +16,6 @@
 //
 // Refer to LICENSE for more information.
 
-using System;
-
 
 namespace Confluent.Kafka
 {

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -590,7 +590,7 @@ namespace Confluent.Kafka.Impl
         }
 
         internal GroupInfo ListGroup(string group, int millisecondsTimeout)
-            =>  ListGroupsImpl(group, millisecondsTimeout).Single();
+            =>  ListGroupsImpl(group, millisecondsTimeout).FirstOrDefault();
 
         internal List<GroupInfo> ListGroups(int millisecondsTimeout)
             => ListGroupsImpl(null, millisecondsTimeout);

--- a/src/Confluent.Kafka/Structs/GroupInfo.cs
+++ b/src/Confluent.Kafka/Structs/GroupInfo.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 
 namespace Confluent.Kafka
 {
-    public struct GroupInfo
+    public class GroupInfo
     {
         public GroupInfo(BrokerMetadata broker, string grp, Error error, string state, string protocolType, string protocol, List<GroupMemberInfo> members)
         {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
@@ -1,0 +1,80 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+using Confluent.Kafka.Serialization;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public static partial class Tests
+    {
+        /// <summary>
+        ///     Test getting group information for existant and non-existant
+        ///     group using the ListGroup method (on a Consumer).
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public static void ListGroup(string bootstrapServers, string topic)
+        {
+            int N = 2;
+            var firstProduced = Util.ProduceMessages(bootstrapServers, topic, 100, N);
+
+            var consumerConfig = new Dictionary<string, object>
+            {
+                { "group.id", "list-group-cg" },
+                { "bootstrap.servers", bootstrapServers },
+                { "session.timeout.ms", 6000 }
+            };
+
+            using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))
+            {
+                bool done = false;
+
+                consumer.OnMessage += (_, msg)
+                    => done = true;
+
+                consumer.OnPartitionsAssigned += (_, partitions) =>
+                {
+                    Assert.Equal(partitions.Count, 1);
+                    Assert.Equal(partitions[0], firstProduced.TopicPartition);
+                    consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                };
+
+                consumer.Subscribe(topic);
+
+                while (!done)
+                {
+                    consumer.Poll(TimeSpan.FromMilliseconds(100));
+                }
+
+                var g = consumer.ListGroup("list-group-cg");
+                Assert.NotNull(g);
+                Assert.Equal(ErrorCode.NO_ERROR, g.Error.Code);
+                Assert.Equal("list-group-cg", g.Group);
+                Assert.Equal("consumer", g.ProtocolType);
+                Assert.Equal(1, g.Members.Count);
+
+                g = consumer.ListGroup("non-existent-cg");
+                Assert.Null(g);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes issue: #34 as suggested by @bschmidtbauer 

Note: `GroupInfo` is now a class, not a struct which allows `ListGroup` to return `null` if the group doesn't exist.

TODO: as part of this PR let's re-consider whether any of our other structs would be better off as classes (almost certainly yes). https://msdn.microsoft.com/en-us/library/ms229017.aspx 

Also re-think organization of files (struct folder is getting less appropriate).

Also: are `QueryGroup` and `QueryGroups` better names for methods `ListGroup` and `ListGroups`? (is `ListGroup` a bit wrong?). The 'Query' names would be consistent with `QueryWatermarkOffsets`. A problem with this idea is the corresponding function in librdkafka is list_groups. So maybe `QueryGroup` and `ListGroups`? don't like the inconsistency. I guess the current names are the best given all the constraints.
