### PR TITLE
not subscribed, don't commit offsets

### DIFF
--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -59,8 +59,6 @@ namespace Confluent.Kafka.IntegrationTests
                 Message<Null, string> msg;
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromSeconds(10)));
                 Assert.Equal(msg.Value, testString);
-                var committedOffsets = consumer.CommitAsync().Result;
-                Assert.True(!committedOffsets.Error);
 
                 // Determine offset to consume from automatically.
                 consumer.Assign(new List<TopicPartition>() { dr.TopicPartition });


### PR DESCRIPTION
this blocks indefinitely causing tests to hang.
I believe that is actually intended operation given current implementation.