### PR TITLE
tweaks to docfx api doc generation

### DIFF
--- a/doc/docfx.json
+++ b/doc/docfx.json
@@ -11,13 +11,13 @@
       ],
       "dest": "api"
     }
+    
   ],
   "build": {
     "content": [
       {
         "files": [
           "api/**.yml",
-          "toc.yml",
           "*.md"
         ]
       }

--- a/doc/template/partials/navbar.tmpl.partial
+++ b/doc/template/partials/navbar.tmpl.partial
@@ -7,7 +7,7 @@
            <span class="icon-bar"></span>
            <span class="icon-bar"></span>
          </button>
-         <a class="navbar-brand" href="{{_rel}}"><span class="dotnet">confluent-kafka-dotnet</span></a>
+         <a class="navbar-brand" href="Confluent.Kafka.html"><span class="dotnet">confluent-kafka-dotnet</span></a>
        </div>
        <div id="navbar" class="collapse navbar-collapse">
        </div><!--/.nav-collapse -->

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -1,2 +1,0 @@
-- name: Api reference
-  homepage: api/Confluent.Kafka.yml


### PR DESCRIPTION
@aayars - post release i guess.
 
This PR (I'm 90% sure) will ensure docfx makes API docs that are suitable to be placed in any path (links are all relative, and don't reference 'up' the tree). html files will be all under api/.. i.e. we'll have:

http://docs.confluent.io/[version]/clients/confluent-kafka-dotnet/api/Conflunet.Kafka.html

.css etc are one level up from api. it might be better to not have the 'api' component in the path, but i couldn't easily see how to make docfx do that.