### PR TITLE
Run unit tests under standard net framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
     env: DOTNETCORE=1
 
 install:
-   - sed -i.bak 's/net451;netstandard/netstandard/g' src/Confluent.Kafka/Confluent.Kafka.csproj
    - dotnet restore
 
 script:

--- a/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+++ b/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <AssemblyName>Confluent.Kafka.UnitTests</AssemblyName>
     <PackageId>Confluent.Kafka.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
The unit tests were only run under .net core, we should run them under netframework too.
We can only use net452+ due to xunit reference, better than nothing

VS2017 is buggy when multiple frameworks are used for now and tests won't be discovered anymore in the test explorer (because of multiple frameworks). They can still be run from CLI though so not an issue

I don't know how integration tests / benchmarking are run on confluent side so only included the unit tests

Also removed the sed in travis CI, it's not necessary now that we have the frawmeork specified when building/testing (and it would prevent the restore with the changes in Kafka.UnitTests)