### PR TITLE
Use unix timestamp rather than DateTime in Timestamp structure

### DIFF
--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -320,11 +320,6 @@ namespace Confluent.Kafka.Impl
 
             IntPtr timestampType;
             long timestamp = LibRdKafka.message_timestamp(msgPtr, out timestampType);
-            var dateTime = new DateTime(0);
-            if ((TimestampType)timestampType != TimestampType.NotAvailable)
-            {
-                dateTime = Timestamp.UnixTimestampMsToDateTime(timestamp);
-            }
 
             LibRdKafka.message_destroy(msgPtr);
 
@@ -334,7 +329,7 @@ namespace Confluent.Kafka.Impl
                 msg.offset,
                 key,
                 val,
-                new Timestamp(dateTime, (TimestampType)timestampType),
+                new Timestamp(timestamp, (TimestampType)timestampType),
                 msg.err
             );
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -164,11 +164,6 @@ namespace Confluent.Kafka
 
             IntPtr timestampType;
             long timestamp = LibRdKafka.message_timestamp(rkmessage, out timestampType);
-            var dateTime = new DateTime(0);
-            if ((TimestampType)timestampType != TimestampType.NotAvailable)
-            {
-                dateTime = Timestamp.UnixTimestampMsToDateTime(timestamp);
-            }
 
             deliveryHandler.HandleDeliveryReport(
                 new Message (
@@ -179,7 +174,7 @@ namespace Confluent.Kafka
                     msg.offset,
                     key,
                     val,
-                    new Timestamp(dateTime, (TimestampType)timestampType),
+                    new Timestamp(timestamp, (TimestampType)timestampType),
                     msg.err
                 )
             );

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -84,8 +84,15 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Gets the Utc DateTime corresponding to the <see cref="UnixTimestampMs"/>.
         /// </summary>
+        [Obsolete("Prefer DateTimeOffset to avoid DateTimeKind issue, this may be removed in a future release")]
         public DateTime DateTime
-            => UnixTimestampMsToDateTime(UnixTimestampMs);
+            => DateTimeOffset.UtcDateTime;
+
+        /// <summary>
+        ///     Gets the DateTimeOffset corresponding to the <see cref="UnixTimestampMs"/>.
+        /// </summary>
+        public DateTimeOffset DateTimeOffset
+            => new DateTimeOffset(UnixTimestampMsToDateTime(UnixTimestampMs));
 
         public override bool Equals(object obj)
         {
@@ -128,7 +135,7 @@ namespace Confluent.Kafka
         ///     The milliseconds unix timestamp to convert.
         /// </param>
         /// <returns>
-        ///     The DateTime value associated with <paramref name="unixMillisecondsTimestamp"/>
+        ///     The DateTime value associated with <paramref name="unixMillisecondsTimestamp"/> with Utc Kind.
         /// </returns>
         public static DateTime UnixTimestampMsToDateTime(long unixMillisecondsTimestamp)
             => UnixTimeEpoch + TimeSpan.FromMilliseconds(unixMillisecondsTimestamp);

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -32,7 +32,7 @@ namespace Confluent.Kafka
         /// </summary>
         public static readonly DateTime UnixTimeEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        private const long UnixEpochMilliseconds = 62135596800000; // = UnixEpochUtcDateTime.TotalMiliseconds
+        private const long UnixEpochMilliseconds = 62135596800000; // = UnixTimeEpoch.TotalMiliseconds
 
         /// <summary>
         ///     Initializes a new instance of the Timestamp structure.
@@ -84,7 +84,8 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Gets the Utc DateTime corresponding to the <see cref="UnixTimestampMs"/>.
         /// </summary>
-        public DateTime DateTime => UnixTimestampMsToDateTime(UnixTimestampMs);
+        public DateTime DateTime
+            => UnixTimestampMsToDateTime(UnixTimestampMs);
 
         public override bool Equals(object obj)
         {
@@ -98,7 +99,7 @@ namespace Confluent.Kafka
         }
 
         public override int GetHashCode()
-            => Type.GetHashCode()*251 + UnixTimestampMs.GetHashCode();  // x by prime number is quick and gives decent distribution.
+            => Type.GetHashCode() * 251 + UnixTimestampMs.GetHashCode();  // x by prime number is quick and gives decent distribution.
 
         public static bool operator ==(Timestamp a, Timestamp b)
             => a.Equals(b);
@@ -115,15 +116,10 @@ namespace Confluent.Kafka
         /// </param>
         /// <returns>
         ///     The milliseconds unix timestamp corresponding to <paramref name="dateTime"/>
-        ///     rounded to the previous millisecond if dateTime precision is below millisecond
+        ///     rounded down to the previous millisecond.
         /// </returns>
         public static long DateTimeToUnixTimestampMs(DateTime dateTime)
-        {
-            checked
-            {
-                return dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
-            }
-        }
+            => dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
 
         /// <summary>
         ///     Convert a milliseconds unix timestamp to a DateTime value.

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -31,6 +31,8 @@ namespace Confluent.Kafka
         /// </summary>
         public static readonly DateTime UnixEpochUtcDateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        private const long UnixEpochMilliseconds = 62135596800000; // = UnixEpochUtcDateTime.TotalMiliseconds
+
         /// <summary>
         ///     Initializes a new instance of the Timestamp structure.
         /// </summary>
@@ -85,12 +87,13 @@ namespace Confluent.Kafka
         /// </param>
         /// <returns>
         ///     The milliseconds unix timestamp corresponding to <paramref name="dateTime"/>
+        ///     rounded to the previous millisecond if dateTime precision is below millisecond
         /// </returns>
         public static long DateTimeToUnixTimestampMs(DateTime dateTime)
         {
             checked
             {
-                return (long)(dateTime.ToUniversalTime() - UnixEpochUtcDateTime).TotalMilliseconds;
+                return dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond - UnixEpochMilliseconds;
             }
         }
 

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -27,9 +27,10 @@ namespace Confluent.Kafka
     public struct Timestamp
     {
         /// <summary>
-        ///     Unix epoch as UTC DateTime
+        ///     Unix epoch as UTC DateTime. Unix time is defined as 
+        ///     the number of seconds past this UTC time, excluding leap seconds
         /// </summary>
-        public static readonly DateTime UnixEpochUtcDateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public static readonly DateTime UnixTimeEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private const long UnixEpochMilliseconds = 62135596800000; // = UnixEpochUtcDateTime.TotalMiliseconds
 
@@ -134,6 +135,6 @@ namespace Confluent.Kafka
         ///     The DateTime value associated with <paramref name="unixMillisecondsTimestamp"/>
         /// </returns>
         public static DateTime UnixTimestampMsToDateTime(long unixMillisecondsTimestamp)
-            => UnixEpochUtcDateTime + TimeSpan.FromMilliseconds(unixMillisecondsTimestamp);
+            => UnixTimeEpoch + TimeSpan.FromMilliseconds(unixMillisecondsTimestamp);
     }
 }

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -27,6 +27,11 @@ namespace Confluent.Kafka
     public struct Timestamp
     {
         /// <summary>
+        ///     Unix epoch as UTC DateTime
+        /// </summary>
+        public static readonly DateTime UnixEpochUtcDateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
         ///     Initializes a new instance of the Timestamp structure.
         /// </summary>
         /// <param name="dateTime">
@@ -85,7 +90,7 @@ namespace Confluent.Kafka
         {
             checked
             {
-                return (long)(dateTime.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc)).TotalMilliseconds;
+                return (long)(dateTime.ToUniversalTime() - UnixEpochUtcDateTime).TotalMilliseconds;
             }
         }
 
@@ -99,7 +104,6 @@ namespace Confluent.Kafka
         ///     The DateTime value associated with <paramref name="unixMillisecondsTimestamp"/>
         /// </returns>
         public static DateTime UnixTimestampMsToDateTime(long unixMillisecondsTimestamp)
-            => new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc)
-                + TimeSpan.FromMilliseconds(unixMillisecondsTimestamp);
+            => UnixEpochUtcDateTime + TimeSpan.FromMilliseconds(unixMillisecondsTimestamp);
     }
 }

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -60,11 +60,16 @@ namespace Confluent.Kafka
         public long UnixTimestampMs { get; }
 
         /// <summary>
+        ///     Gets the local DateTime corresponding to the <see cref="UnixTimestampMs"/>.
+        /// </summary>
+        public DateTime UtcDateTime
+            => DateTimeOffset.UtcDateTime;
+
+        /// <summary>
         ///     Gets the Utc DateTime corresponding to the <see cref="UnixTimestampMs"/>.
         /// </summary>
-        [Obsolete("Prefer DateTimeOffset to avoid DateTimeKind issue, this may be removed in a future release")]
-        public DateTime DateTime
-            => DateTimeOffset.UtcDateTime;
+        public DateTime LocalDateTime
+            => DateTimeOffset.LocalDateTime;
 
         /// <summary>
         ///     Gets the DateTimeOffset corresponding to the <see cref="UnixTimestampMs"/>.

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -65,6 +65,7 @@ namespace Confluent.Kafka
         ///     The <see cref="DateTime"/> property may differ from this datetime
         ///     (it will be UTC with a millisecond precision)
         /// </remarks>
+        [Obsolete("Use the (long, TimestampType) constructor instead, this will be removed in future release")]
         public Timestamp(DateTime dateTime, TimestampType type)
         {
             Type = type;

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -36,16 +36,38 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initializes a new instance of the Timestamp structure.
         /// </summary>
-        /// <param name="dateTime">
-        ///     The timestamp.
+        /// <param name="unixTimestampMs">
+        ///     The unix millisecond timestamp.
         /// </param>
         /// <param name="type">
         ///     The type of the timestamp.
         /// </param>
+        public Timestamp(long unixTimestampMs, TimestampType type)
+        {
+            Type = type;
+            UnixTimestampMs = unixTimestampMs;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the Timestamp structure.
+        ///     Prefer the (long, TimestampType) overload if possible.
+        /// </summary>
+        /// <param name="dateTime">
+        ///     The datetime, which will be converted to
+        ///     the nearest unix millisecond timestamp rounded down
+        ///     via <see cref="DateTimeToUnixTimestampMs"/>.
+        /// </param>
+        /// <param name="type">
+        ///     The type of the timestamp.
+        /// </param>
+        /// <remarks>
+        ///     The <see cref="DateTime"/> property may differ from this datetime
+        ///     (it will be UTC with a millisecond precision)
+        /// </remarks>
         public Timestamp(DateTime dateTime, TimestampType type)
         {
             Type = type;
-            DateTime = dateTime;
+            UnixTimestampMs = DateTimeToUnixTimestampMs(dateTime);
         }
 
         /// <summary>
@@ -54,9 +76,14 @@ namespace Confluent.Kafka
         public TimestampType Type { get; }
 
         /// <summary>
-        ///     Gets the timestamp value.
+        ///     Get the Unix millisecond timestamp.
         /// </summary>
-        public DateTime DateTime { get; }
+        public long UnixTimestampMs { get; }
+
+        /// <summary>
+        ///     Gets the Utc DateTime corresponding to the <see cref="UnixTimestampMs"/>.
+        /// </summary>
+        public DateTime DateTime => UnixTimestampMsToDateTime(UnixTimestampMs);
 
         public override bool Equals(object obj)
         {
@@ -66,11 +93,11 @@ namespace Confluent.Kafka
             }
 
             var ts = (Timestamp)obj;
-            return ts.Type == Type && ts.DateTime == DateTime;
+            return ts.Type == Type && ts.UnixTimestampMs == UnixTimestampMs;
         }
 
         public override int GetHashCode()
-            => Type.GetHashCode()*251 + DateTime.GetHashCode();  // x by prime number is quick and gives decent distribution.
+            => Type.GetHashCode()*251 + UnixTimestampMs.GetHashCode();  // x by prime number is quick and gives decent distribution.
 
         public static bool operator ==(Timestamp a, Timestamp b)
             => a.Equals(b);

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka
     {
         /// <summary>
         ///     Unix epoch as UTC DateTime. Unix time is defined as 
-        ///     the number of seconds past this UTC time, excluding leap seconds
+        ///     the number of seconds past this UTC time, excluding leap seconds.
         /// </summary>
         public static readonly DateTime UnixTimeEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -47,29 +47,6 @@ namespace Confluent.Kafka
         {
             Type = type;
             UnixTimestampMs = unixTimestampMs;
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the Timestamp structure.
-        ///     Prefer the (long, TimestampType) overload if possible.
-        /// </summary>
-        /// <param name="dateTime">
-        ///     The datetime, which will be converted to
-        ///     the nearest unix millisecond timestamp rounded down
-        ///     via <see cref="DateTimeToUnixTimestampMs"/>.
-        /// </param>
-        /// <param name="type">
-        ///     The type of the timestamp.
-        /// </param>
-        /// <remarks>
-        ///     The <see cref="DateTime"/> property may differ from this datetime
-        ///     (it will be UTC with a millisecond precision)
-        /// </remarks>
-        [Obsolete("Use the (long, TimestampType) constructor instead, this will be removed in future release")]
-        public Timestamp(DateTime dateTime, TimestampType type)
-        {
-            Type = type;
-            UnixTimestampMs = DateTimeToUnixTimestampMs(dateTime);
         }
 
         /// <summary>

--- a/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
+++ b/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
@@ -23,9 +23,5 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
+  
 </Project>

--- a/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
+++ b/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Consume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Consume.cs
@@ -69,7 +69,7 @@ namespace Confluent.Kafka.IntegrationTests
                     if (consumer.Consume(out msg, TimeSpan.FromMilliseconds(100)))
                     {
                         Assert.Equal(TimestampType.CreateTime, msg.Timestamp.Type);
-                        Assert.True(Math.Abs((DateTime.UtcNow - msg.Timestamp.DateTime).TotalMinutes) < 1.0);
+                        Assert.True(Math.Abs((DateTime.UtcNow - msg.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
                         msgCnt += 1;
                     }
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
@@ -52,7 +52,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     Assert.Equal(msg.Error.Code, ErrorCode.NoError);
                     Assert.Equal(TimestampType.CreateTime, msg.Timestamp.Type);
-                    Assert.True(Math.Abs((DateTime.UtcNow - msg.Timestamp.DateTime).TotalMinutes) < 1.0);
+                    Assert.True(Math.Abs((DateTime.UtcNow - msg.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
                     msgCnt += 1;
                 };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_DeliveryHandler.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(Topic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
 
                 if (Count < 5)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_DeliveryHandler.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Key);
                 Assert.Null(dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
                 Count += 1;
             }
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
@@ -60,7 +60,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Key);
                 Assert.Null(dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
 
             Assert.Equal(1, drs[0].Result.Partition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -62,7 +62,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(key, dr.Key);
                 Assert.Equal(val, dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
 
             Assert.Equal(new byte[] { 2, 3, 4 }, drs[5].Result.Key);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_DeliveryHandler.cs
@@ -51,7 +51,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal($"test key {Count}", dr.Key);
                 Assert.Equal($"test val {Count}", dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
                 Count += 1;
             }
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_DeliveryHandler.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Key);
                 Assert.Null(dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
                 Count += 1;
             }
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_Task.cs
@@ -58,7 +58,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Key);
                 Assert.Null(dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
 
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Task.cs
@@ -59,7 +59,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal($"test key {i}", dr.Key);
                 Assert.Equal($"test val {i}", dr.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.DateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTime.UtcNow - dr.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
 
             Assert.Equal(1, drs[0].Result.Partition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.Equal(testString, msg.Value == null ? null : Encoding.UTF8.GetString(msg.Value, 0, msg.Value.Length));
             Assert.Equal(null, msg.Key);
             Assert.Equal(msg.Timestamp.Type, dr.Timestamp.Type);
-            Assert.Equal(msg.Timestamp.DateTime, dr.Timestamp.DateTime);
+            Assert.Equal(msg.Timestamp.UnixTimestampMs, dr.Timestamp.UnixTimestampMs);
         }
 
         private static Message<Null, string> ProduceMessage(string topic, Producer<Null, string> producer, string testString)
@@ -86,7 +86,7 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.Equal(topic, result.Topic);
             Assert.NotEqual<long>(result.Offset, Offset.Invalid);
             Assert.Equal(TimestampType.CreateTime, result.Timestamp.Type);
-            Assert.True(Math.Abs((DateTime.UtcNow - result.Timestamp.DateTime).TotalMinutes) < 1.0);
+            Assert.True(Math.Abs((DateTime.UtcNow - result.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             producer.Flush();
             return result;
         }

--- a/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+++ b/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+++ b/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Confluent.Kafka.UnitTests/Message.cs
+++ b/test/Confluent.Kafka.UnitTests/Message.cs
@@ -27,14 +27,14 @@ namespace Confluent.Kafka.Tests
         {
             byte[] key = new byte[0];
             byte[] val = new byte[0];
-            var mi = new Message("tp1", 24, 33, key, val, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime), new Error(ErrorCode.NoError));
+            var mi = new Message("tp1", 24, 33, key, val, new Timestamp(123456789, TimestampType.CreateTime), new Error(ErrorCode.NoError));
 
             Assert.Equal(mi.Topic, "tp1");
             Assert.Equal(mi.Partition, 24);
             Assert.Equal(mi.Offset, 33);
             Assert.Same(mi.Key, key);
             Assert.Same(mi.Value, val);
-            Assert.Equal(mi.Timestamp, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime));
+            Assert.Equal(mi.Timestamp, new Timestamp(123456789, TimestampType.CreateTime));
             Assert.Equal(mi.Error, new Error(ErrorCode.NoError));
             Assert.Equal(mi.TopicPartition, new TopicPartition("tp1", 24));
             Assert.Equal(mi.TopicPartitionOffset, new TopicPartitionOffset("tp1", 24, 33));
@@ -43,14 +43,14 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void ConstuctorAndProps_Generic()
         {
-            var mi = new Message<string, string>("tp1", 24, 33, "mykey", "myval", new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime), new Error(ErrorCode.NoError));
+            var mi = new Message<string, string>("tp1", 24, 33, "mykey", "myval", new Timestamp(123456789, TimestampType.CreateTime), new Error(ErrorCode.NoError));
 
             Assert.Equal(mi.Topic, "tp1");
             Assert.Equal(mi.Partition, 24);
             Assert.Equal(mi.Offset, 33);
             Assert.Equal(mi.Key, "mykey");
             Assert.Equal(mi.Value, "myval");
-            Assert.Equal(mi.Timestamp, new Timestamp(new DateTime(2001, 3, 4), TimestampType.CreateTime));
+            Assert.Equal(mi.Timestamp, new Timestamp(123456789, TimestampType.CreateTime));
             Assert.Equal(mi.Error, new Error(ErrorCode.NoError));
             Assert.Equal(mi.TopicPartition, new TopicPartition("tp1", 24));
             Assert.Equal(mi.TopicPartitionOffset, new TopicPartitionOffset("tp1", 24, 33));

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -23,10 +23,21 @@ namespace Confluent.Kafka.Tests
     public class TimestampTests
     {
         [Fact]
-        public void Constuctor()
+        public void ConstuctorWithDateTime()
         {
             var ts = new Timestamp(new DateTime(2010, 3, 4), TimestampType.CreateTime);
-            Assert.Equal(ts.DateTime, new DateTime(2010, 3, 4));
+            Assert.Equal(new DateTime(2010, 3, 4).ToUniversalTime(), ts.DateTime);
+            Assert.Equal(Timestamp.DateTimeToUnixTimestampMs(new DateTime(2010, 3, 4).ToUniversalTime()), ts.UnixTimestampMs);
+            Assert.Equal(TimestampType.CreateTime, ts.Type);
+        }
+
+
+        [Fact]
+        public void ConstuctorWithTimestamp()
+        {
+            var ts = new Timestamp(123456789, TimestampType.CreateTime);
+            Assert.Equal(123456789, ts.UnixTimestampMs);
+            Assert.Equal(Timestamp.UnixTimestampMsToDateTime(123456789), ts.DateTime);
             Assert.Equal(ts.Type, TimestampType.CreateTime);
         }
 

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -84,22 +84,34 @@ namespace Confluent.Kafka.Tests
             var dateTimeAfterEpoch = new DateTime(2012, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
             var afterEpoch1 = dateTimeAfterEpoch.AddTicks(1);
             var afterEpoch2 = dateTimeAfterEpoch.AddTicks(TimeSpan.TicksPerMillisecond - 1);
+            var afterEpoch3 = dateTimeAfterEpoch.AddTicks(TimeSpan.TicksPerMillisecond);
+            var afterEpoch4 = dateTimeAfterEpoch.AddTicks(-1);
             var unixTimeAfterEpoch1 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch1);
             var unixTimeAfterEpoch2 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch2);
+            var unixTimeAfterEpoch3 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch3);
+            var unixTimeAfterEpoch4 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch4);
             var expectedUnixTimeAfterEpoch = Timestamp.DateTimeToUnixTimestampMs(dateTimeAfterEpoch);
 
             var dateTimeBeforeEpoch = new DateTime(1950, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
             var beforeEpoch1 = dateTimeBeforeEpoch.AddTicks(1);
             var beforeEpoch2 = dateTimeBeforeEpoch.AddTicks(TimeSpan.TicksPerMillisecond - 1);
+            var beforeEpoch3 = dateTimeBeforeEpoch.AddTicks(TimeSpan.TicksPerMillisecond);
+            var beforeEpoch4 = dateTimeBeforeEpoch.AddTicks(-1);
             var unixTimeBeforeEpoch1 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch1);
             var unixTimeBeforeEpoch2 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch2);
+            var unixTimeBeforeEpoch3 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch3);
+            var unixTimeBeforeEpoch4 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch4);
             var expectedUnixTimeBeforeEpoch = Timestamp.DateTimeToUnixTimestampMs(dateTimeBeforeEpoch);
 
             Assert.Equal(expectedUnixTimeAfterEpoch, unixTimeAfterEpoch1);
             Assert.Equal(expectedUnixTimeAfterEpoch, unixTimeAfterEpoch2);
+            Assert.Equal(expectedUnixTimeAfterEpoch + 1, unixTimeAfterEpoch3);
+            Assert.Equal(expectedUnixTimeAfterEpoch - 1, unixTimeAfterEpoch4);
 
             Assert.Equal(expectedUnixTimeBeforeEpoch, unixTimeBeforeEpoch1);
             Assert.Equal(expectedUnixTimeBeforeEpoch, unixTimeBeforeEpoch2);
+            Assert.Equal(expectedUnixTimeBeforeEpoch + 1, unixTimeBeforeEpoch3);
+            Assert.Equal(expectedUnixTimeBeforeEpoch - 1, unixTimeBeforeEpoch4);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -23,31 +23,20 @@ namespace Confluent.Kafka.Tests
     public class TimestampTests
     {
         [Fact]
-        public void ConstuctorWithDateTime()
-        {
-            var ts = new Timestamp(new DateTime(2010, 3, 4), TimestampType.CreateTime);
-            Assert.Equal(new DateTime(2010, 3, 4).ToUniversalTime(), ts.DateTime);
-            Assert.Equal(Timestamp.DateTimeToUnixTimestampMs(new DateTime(2010, 3, 4).ToUniversalTime()), ts.UnixTimestampMs);
-            Assert.Equal(TimestampType.CreateTime, ts.Type);
-        }
-
-
-        [Fact]
-        public void ConstuctorWithTimestamp()
+        public void Constuctor()
         {
             var ts = new Timestamp(123456789, TimestampType.CreateTime);
             Assert.Equal(123456789, ts.UnixTimestampMs);
-            Assert.Equal(Timestamp.UnixTimestampMsToDateTime(123456789), ts.DateTime);
             Assert.Equal(ts.Type, TimestampType.CreateTime);
         }
 
         [Fact]
         public void Equality()
         {
-            var ts1 = new Timestamp(new DateTime(2010, 3, 4), TimestampType.CreateTime);
-            var ts2 = new Timestamp(new DateTime(2010, 3, 4), TimestampType.CreateTime);
-            var ts3 = new Timestamp(new DateTime(2011, 3, 4), TimestampType.CreateTime);
-            var ts4 = new Timestamp(new DateTime(2010, 3, 4), TimestampType.LogAppendTime);
+            var ts1 = new Timestamp(1, TimestampType.CreateTime);
+            var ts2 = new Timestamp(1, TimestampType.CreateTime);
+            var ts3 = new Timestamp(2, TimestampType.CreateTime);
+            var ts4 = new Timestamp(1, TimestampType.LogAppendTime);
 
             Assert.Equal(ts1, ts2);
             Assert.True(ts1.Equals(ts2));

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -64,5 +64,30 @@ namespace Confluent.Kafka.Tests
             Assert.Equal(ts, ts2);
             Assert.Equal(ts2.Kind, DateTimeKind.Utc);
         }
+
+        [Fact]
+        public void Rounding()
+        {
+            // check is to millisecond accuracy, rounding down the value
+            var dateTimeAfterEpoch = new DateTime(2012, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
+            var afterEpoch1 = dateTimeAfterEpoch.AddTicks(1);
+            var afterEpoch2 = dateTimeAfterEpoch.AddTicks(TimeSpan.TicksPerMillisecond - 1);
+            var unixTimeAfterEpoch1 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch1);
+            var unixTimeAfterEpoch2 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch2);
+            var expectedUnixTimeAfterEpoch = Timestamp.DateTimeToUnixTimestampMs(dateTimeAfterEpoch);
+
+            var dateTimeBeforeEpoch = new DateTime(1950, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
+            var beforeEpoch1 = dateTimeBeforeEpoch.AddTicks(1);
+            var beforeEpoch2 = dateTimeBeforeEpoch.AddTicks(TimeSpan.TicksPerMillisecond - 1);
+            var unixTimeBeforeEpoch1 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch1);
+            var unixTimeBeforeEpoch2 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch2);
+            var expectedUnixTimeBeforeEpoch = Timestamp.DateTimeToUnixTimestampMs(dateTimeBeforeEpoch);
+
+            Assert.Equal(expectedUnixTimeAfterEpoch, unixTimeAfterEpoch1);
+            Assert.Equal(expectedUnixTimeAfterEpoch, unixTimeAfterEpoch2);
+
+            Assert.Equal(expectedUnixTimeBeforeEpoch, unixTimeBeforeEpoch1);
+            Assert.Equal(expectedUnixTimeBeforeEpoch, unixTimeBeforeEpoch2);
+        }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -81,37 +81,25 @@ namespace Confluent.Kafka.Tests
         public void Rounding()
         {
             // check is to millisecond accuracy, rounding down the value
+            
             var dateTimeAfterEpoch = new DateTime(2012, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
-            var afterEpoch1 = dateTimeAfterEpoch.AddTicks(1);
-            var afterEpoch2 = dateTimeAfterEpoch.AddTicks(TimeSpan.TicksPerMillisecond - 1);
-            var afterEpoch3 = dateTimeAfterEpoch.AddTicks(TimeSpan.TicksPerMillisecond);
-            var afterEpoch4 = dateTimeAfterEpoch.AddTicks(-1);
-            var unixTimeAfterEpoch1 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch1);
-            var unixTimeAfterEpoch2 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch2);
-            var unixTimeAfterEpoch3 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch3);
-            var unixTimeAfterEpoch4 = Timestamp.DateTimeToUnixTimestampMs(afterEpoch4);
-            var expectedUnixTimeAfterEpoch = Timestamp.DateTimeToUnixTimestampMs(dateTimeAfterEpoch);
-
             var dateTimeBeforeEpoch = new DateTime(1950, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
-            var beforeEpoch1 = dateTimeBeforeEpoch.AddTicks(1);
-            var beforeEpoch2 = dateTimeBeforeEpoch.AddTicks(TimeSpan.TicksPerMillisecond - 1);
-            var beforeEpoch3 = dateTimeBeforeEpoch.AddTicks(TimeSpan.TicksPerMillisecond);
-            var beforeEpoch4 = dateTimeBeforeEpoch.AddTicks(-1);
-            var unixTimeBeforeEpoch1 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch1);
-            var unixTimeBeforeEpoch2 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch2);
-            var unixTimeBeforeEpoch3 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch3);
-            var unixTimeBeforeEpoch4 = Timestamp.DateTimeToUnixTimestampMs(beforeEpoch4);
-            var expectedUnixTimeBeforeEpoch = Timestamp.DateTimeToUnixTimestampMs(dateTimeBeforeEpoch);
 
-            Assert.Equal(expectedUnixTimeAfterEpoch, unixTimeAfterEpoch1);
-            Assert.Equal(expectedUnixTimeAfterEpoch, unixTimeAfterEpoch2);
-            Assert.Equal(expectedUnixTimeAfterEpoch + 1, unixTimeAfterEpoch3);
-            Assert.Equal(expectedUnixTimeAfterEpoch - 1, unixTimeAfterEpoch4);
+            foreach (var datetime in new[] { dateTimeAfterEpoch, dateTimeBeforeEpoch })
+            {
 
-            Assert.Equal(expectedUnixTimeBeforeEpoch, unixTimeBeforeEpoch1);
-            Assert.Equal(expectedUnixTimeBeforeEpoch, unixTimeBeforeEpoch2);
-            Assert.Equal(expectedUnixTimeBeforeEpoch + 1, unixTimeBeforeEpoch3);
-            Assert.Equal(expectedUnixTimeBeforeEpoch - 1, unixTimeBeforeEpoch4);
+                var unixTime1 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(1));
+                var unixTime2 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(TimeSpan.TicksPerMillisecond - 1));
+                var unixTime3 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(TimeSpan.TicksPerMillisecond));
+                var unixTime4 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(-1));
+
+                var expectedUnixTime = Timestamp.DateTimeToUnixTimestampMs(datetime);
+                
+                Assert.Equal(expectedUnixTime, unixTime1);
+                Assert.Equal(expectedUnixTime, unixTime2);
+                Assert.Equal(expectedUnixTime + 1, unixTime3);
+                Assert.Equal(expectedUnixTime - 1, unixTime4);
+            }
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -61,6 +61,7 @@ namespace Confluent.Kafka.Tests
             var ts = new DateTime(2012, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
             var unixTime = Timestamp.DateTimeToUnixTimestampMs(ts);
             var ts2 = Timestamp.UnixTimestampMsToDateTime(unixTime);
+            Assert.Equal(1336305843220, unixTime);
             Assert.Equal(ts, ts2);
             Assert.Equal(ts2.Kind, DateTimeKind.Utc);
         }

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -25,9 +25,14 @@ namespace Confluent.Kafka.Tests
         [Fact]
         public void Constuctor()
         {
-            var ts = new Timestamp(123456789, TimestampType.CreateTime);
-            Assert.Equal(123456789, ts.UnixTimestampMs);
-            Assert.Equal(ts.Type, TimestampType.CreateTime);
+            var ts1 = new Timestamp(123456789, TimestampType.CreateTime);
+            var ts2 = new Timestamp(-123456789, TimestampType.LogAppendTime);
+
+            Assert.Equal(123456789, ts1.UnixTimestampMs);
+            Assert.Equal(-123456789, ts2.UnixTimestampMs);
+
+            Assert.Equal(ts1.Type, TimestampType.CreateTime);
+            Assert.Equal(ts2.Type, TimestampType.LogAppendTime);
         }
 
         [Fact]
@@ -64,6 +69,27 @@ namespace Confluent.Kafka.Tests
             Assert.Equal(1336305843220, unixTime);
             Assert.Equal(ts, ts2);
             Assert.Equal(ts2.Kind, DateTimeKind.Utc);
+        }
+
+        [Fact]
+        public void UnixTimeEpoch()
+        {
+            Assert.Equal(0, Timestamp.DateTimeToUnixTimestampMs(Timestamp.UnixTimeEpoch));
+            Assert.Equal(DateTimeKind.Utc, Timestamp.UnixTimeEpoch.Kind);
+        }
+        
+        [Fact]
+        public void DateTimeProperties()
+        {
+            var ts = new Timestamp(1, TimestampType.CreateTime);
+            
+            Assert.Equal(DateTimeKind.Utc, ts.UtcDateTime.Kind);
+            Assert.Equal(DateTimeKind.Local, ts.LocalDateTime.Kind);
+
+            Assert.Equal(ts.UtcDateTime, ts.DateTimeOffset.UtcDateTime);
+            Assert.Equal(ts.LocalDateTime, ts.DateTimeOffset.LocalDateTime);
+
+            Assert.Equal(1, (ts.UtcDateTime - Timestamp.UnixTimeEpoch).TotalMilliseconds);
         }
 
         [Fact]


### PR DESCRIPTION
Timestamp is only created from librdkafka values (message notification and message consumed) so it's better to use the timestamp to define it.

DateTime is misleading given its kind (to datetime with different kind are not equal even if they have the same timestamp) and that it can't always be converted to a unix timestamp (precision is below the millisecond)
This PR also make the conversion more consistent (the static method DateTime -> timestamp now always round down to the latest millisecond - I like API to be 100% predictable)