### PR TITLE
Add  serialializer/deserializer and related unit tests for float and byte[]

### DIFF
--- a/src/Confluent.Kafka/Serialization/ByteArrayDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/ByteArrayDeserializer.cs
@@ -17,32 +17,22 @@
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
-    ///     System.Single serializer. Byte order of serialized data is big endian (network byte order).
+    ///     A deserializer for System.Byte[] values. 
     /// </summary>
-    public class FloatSerializer : ISerializer<float>
+    public class ByteArrayDeserializer : IDeserializer<byte[]>
     {
         /// <summary>
-        ///     Serializes the specified System.Single value to a byte array of length 4. Byte order is big endian (network byte order).
+        ///     Deserializes a System.Byte[] value from a byte array.
         /// </summary>
         /// <param name="data">
-        ///     The System.Single value to serialize.
+        ///     A byte array containing the serialized System.Byte[] value
         /// </param>
         /// <returns>
-        ///     The System.Single value <paramref name="data" /> encoded as a byte array of length 4 (network byte order).
+        ///     The deserialized System.Byte[] value.
         /// </returns>
-        public byte[] Serialize(float data)
+        public byte[] Deserialize(byte[] data)
         {
-            byte[] result = new byte[4];
-            unsafe
-            {
-                byte* p = (byte*)(&data);
-                result[3] = *p++;
-                result[2] = *p++;
-                result[1] = *p++;
-                result[0] = *p++;
-            }
-
-            return result;
+            return data;
         }
     }
 }

--- a/src/Confluent.Kafka/Serialization/ByteArraySerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ByteArraySerializer.cs
@@ -17,32 +17,22 @@
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
-    ///     System.Single serializer. Byte order of serialized data is big endian (network byte order).
+    ///     System.Byte[] serializer. serialized data is original data.
     /// </summary>
-    public class FloatSerializer : ISerializer<float>
+    public class ByteArraySerializer : ISerializer<byte[]>
     {
         /// <summary>
-        ///     Serializes the specified System.Single value to a byte array of length 4. Byte order is big endian (network byte order).
+        ///     Serializes the specified System.Byte[] value to a byte array. Byte order is original order.
         /// </summary>
         /// <param name="data">
-        ///     The System.Single value to serialize.
+        ///     The System.Byte[] value to serialize.
         /// </param>
         /// <returns>
-        ///     The System.Single value <paramref name="data" /> encoded as a byte array of length 4 (network byte order).
+        ///     The System.Byte[] value <paramref name="data" /> encoded as a byte array. 
         /// </returns>
-        public byte[] Serialize(float data)
+        public byte[] Serialize(byte[] data)
         {
-            byte[] result = new byte[4];
-            unsafe
-            {
-                byte* p = (byte*)(&data);
-                result[3] = *p++;
-                result[2] = *p++;
-                result[1] = *p++;
-                result[0] = *p++;
-            }
-
-            return result;
+            return data;
         }
     }
 }

--- a/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
@@ -44,18 +44,24 @@ namespace Confluent.Kafka.Serialization
                 throw new ArgumentException($"Size of {nameof(data)} received by {nameof(FloatDeserializer)} is not 4");
             }
 
-            float result = default(float);
             // network byte order -> big endian -> most significant byte in the smallest address.
-            unsafe
+            if (BitConverter.IsLittleEndian)
             {
-                byte* p = (byte*)(&result);
-                *p++ = data[3];
-                *p++ = data[2];
-                *p++ = data[1];
-                *p++ = data[0];
+                unsafe
+                {
+                    float result = default(float);
+                    byte* p = (byte*)(&result);
+                    *p++ = data[3];
+                    *p++ = data[2];
+                    *p++ = data[1];
+                    *p++ = data[0];
+                    return result;
+                }
             }
-
-            return result;
+            else
+            {
+                return BitConverter.ToSingle(data);
+            }
         }
     }
 }

--- a/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     A deserializer for big endian encoded (network byte ordered) System.Single values.
+    /// </summary>
+    public class FloatDeserializer : IDeserializer<float>
+    {
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) System.Single value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized System.Single value (big endian encoding)
+        /// </param>
+        /// <returns>
+        ///     The deserialized System.Single value.
+        /// </returns>
+        public float Deserialize(byte[] data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentException($"Arg [{nameof(data)}] is null");
+            }
+
+            if (data.Length != 4)
+            {
+                throw new ArgumentException($"Size of {nameof(data)} received by {nameof(FloatDeserializer)} is not 4");
+            }
+
+            float result = default(float);
+            // network byte order -> big endian -> most significant byte in the smallest address.
+            unsafe
+            {
+                byte* p = (byte*)(&result);
+                *p++ = data[3];
+                *p++ = data[2];
+                *p++ = data[1];
+                *p++ = data[0];
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
@@ -36,7 +36,7 @@ namespace Confluent.Kafka.Serialization
         {
             if (data == null)
             {
-                throw new ArgumentException($"Arg [{nameof(data)}] is null");
+                throw new ArgumentNullException($"Arg {nameof(data)} is null");
             }
 
             if (data.Length != 4)
@@ -60,7 +60,7 @@ namespace Confluent.Kafka.Serialization
             }
             else
             {
-                return BitConverter.ToSingle(data);
+                return BitConverter.ToSingle(data, 0);
             }
         }
     }

--- a/src/Confluent.Kafka/Serialization/FloatSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -32,17 +34,23 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         public byte[] Serialize(float data)
         {
-            byte[] result = new byte[4];
-            unsafe
+            if (BitConverter.IsLittleEndian)
             {
-                byte* p = (byte*)(&data);
-                result[3] = *p++;
-                result[2] = *p++;
-                result[1] = *p++;
-                result[0] = *p++;
+                unsafe
+                {
+                    byte[] result = new byte[4];
+                    byte* p = (byte*)(&data);
+                    result[3] = *p++;
+                    result[2] = *p++;
+                    result[1] = *p++;
+                    result[0] = *p++;
+                    return result;
+                }
             }
-
-            return result;
+            else
+            {
+                return BitConverter.GetBytes(data);
+            }
         }
     }
 }

--- a/src/Confluent.Kafka/Serialization/FloatSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatSerializer.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     System.Single serializer. Byte order of serialized data is big endian (network byte order).
+    /// </summary>
+    public class FloatSerializer : ISerializer<float>
+    {
+        /// <summary>
+        ///     Serializes the specified System.Single value to a byte array of length 4. Byte order is big endian (network byte order).
+        /// </summary>
+        /// <param name="data">
+        ///     The System.Single value to serialize.
+        /// </param>
+        /// <returns>
+        ///     The System.Single value <paramref name="data" /> encoded as a byte array of length 4 (network byte order).
+        /// </returns>
+        public byte[] Serialize(float data)
+        {
+            byte[] result = new byte[4];
+            unsafe
+            {
+                byte* p = (byte*)(&data);
+                result[3] = *p++;
+                result[2] = *p++;
+                result[1] = *p++;
+                result[0] = *p++;
+            }
+
+            return result;
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -1,0 +1,18 @@
+﻿using Confluent.Kafka.Serialization;
+using Xunit;
+
+namespace Confluent.Kafka.UnitTests.Serialization
+{
+    public class ByteArrayTests
+    {
+        [Theory]
+        [InlineData(default(byte[]))]
+        [InlineData(new byte[0])]
+        [InlineData(new byte[] { 1 })]
+        [InlineData(new byte[] { 1, 2, 3, 4, 5 })]
+        public void CanReconstruct(byte[] values)
+        {
+            Assert.Equal(values, new ByteArrayDeserializer().Deserialize(new ByteArraySerializer().Serialize(values)));
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -14,5 +14,11 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             Assert.Equal(values, new ByteArrayDeserializer().Deserialize(new ByteArraySerializer().Serialize(values)));
         }
+
+        [Fact]
+        public void DeserizerNull()
+        {
+            Assert.Null(new ByteArrayDeserializer().Deserialize(null));
+        }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Confluent.Kafka.Serialization;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Confluent.Kafka.UnitTests.Serialization
+{
+    public class FloatTests
+    {
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void CanReconstruct(float value)
+        {
+            Assert.Equal(value, new FloatDeserializer().Deserialize(new FloatSerializer().Serialize(value)));
+        }
+
+        [Fact]
+        public void IsBigEndian()
+        {
+            var buffer = new byte[] { 23, 0, 0, 0 };
+            var value = BitConverter.ToSingle(buffer, 0);
+            var data = new FloatSerializer().Serialize(value);
+            Assert.Equal(23, data[3]);
+            Assert.Equal(0, data[0]);
+        }
+
+        [Fact]
+        public void DeserializeArgNullThrow()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(null));
+        }
+
+        [Fact]
+        public void DeserializeArgLengthNotEqual8Throw()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[0]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[3]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[5]));
+        }
+
+        public static IEnumerable<object[]> TestData()
+        {
+            float[] testData = new float[]
+            {
+                0, 1, -1, 42, -42, 127, 128, 129, -127, -128,
+                -129,254, 255, 256, 257, -254, -255, -256, -257,
+                short.MinValue-1, short.MinValue, short.MinValue+1,
+                short.MaxValue-1, short.MaxValue,short.MaxValue+1,
+                int.MaxValue-1, int.MaxValue, int.MinValue, int.MinValue + 1,
+                float.MaxValue-1,float.MaxValue,float.MinValue,float.MinValue+1,
+                float.NaN,float.PositiveInfinity,float.NegativeInfinity,float.Epsilon,-float.Epsilon
+            };
+
+            foreach (var v in testData)
+            {
+                yield return new object[] { v };
+            }
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -43,11 +43,11 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [Fact]
         public void DeserializeArgNullThrow()
         {
-            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(null));
+            Assert.ThrowsAny<ArgumentNullException>(() => new FloatDeserializer().Deserialize(null));
         }
 
         [Fact]
-        public void DeserializeArgLengthNotEqual8Throw()
+        public void DeserializeArgLengthNotEqual4Throw()
         {
             Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[0]));
             Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[3]));


### PR DESCRIPTION
Add  serialializer/deserializer and related unit tests for float and byte[].  
Same names with java client's types. 
FloatSerializer, FloatDeserializer, ByteArraySerializer, ByteArrayDeserializer