### PR TITLE
Remove events from SerializingProducer

### DIFF
--- a/src/Confluent.Kafka/ISerializingProducer.cs
+++ b/src/Confluent.Kafka/ISerializingProducer.cs
@@ -52,38 +52,5 @@ namespace Confluent.Kafka
         void ProduceAsync(string topic, TKey key, TValue val, int partition, bool blockIfQueueFull, IDeliveryHandler<TKey, TValue> deliveryHandler);
         void ProduceAsync(string topic, TKey key, TValue val, int partition, IDeliveryHandler<TKey, TValue> deliveryHandler);
         void ProduceAsync(string topic, TKey key, TValue val, bool blockIfQueueFull, IDeliveryHandler<TKey, TValue> deliveryHandler);
-
-        /// <summary>
-        ///     Raised when there is information that should be logged.
-        /// </summary>
-        /// <remarks>
-        ///     You can specify the log level with the 'log_level' configuration
-        ///     property. You also probably want to specify one or more debug
-        ///     contexts using the 'debug' configuration property.
-        ///
-        ///     This event can potentially be raised on any thread.
-        /// </remarks>
-        event EventHandler<LogMessage> OnLog;
-
-        /// <summary>
-        ///     Raised on critical errors, e.g. connection failures or all brokers down.
-        /// </summary>
-        /// <remarks>
-        ///     Called on the Producer poll thread.
-        /// </remarks>
-        event EventHandler<Error> OnError;
-
-        /// <summary>
-        ///     Raised on librdkafka statistics events. JSON formatted
-        ///     string as defined here: https://github.com/edenhill/librdkafka/wiki/Statistics
-        /// </summary>
-        /// <remarks>
-        ///     You can enable statistics and set the statistics interval
-        ///     using the statistics.interval.ms configuration parameter
-        ///     (disabled by default).
-        ///
-        ///     Called on the Producer poll thread.
-        /// </remarks>
-        event EventHandler<string> OnStatistics;
     }
 }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -806,10 +806,6 @@ namespace Confluent.Kafka
                     throw new ArgumentNullException("Value serializer must be specified.");
                 }
             }
-
-            producer.OnLog += (sender, e) => OnLog?.Invoke(sender, e);
-            producer.OnError += (sender, e) => OnError?.Invoke(sender, e);
-            producer.OnStatistics += (sender, e) => OnStatistics?.Invoke(sender, e);
         }
 
         private class TypedTaskDeliveryHandlerShim : TaskCompletionSource<Message<TKey, TValue>>, IDeliveryHandler
@@ -917,12 +913,6 @@ namespace Confluent.Kafka
 
         public string Name
             => producer.Name;
-
-        public event EventHandler<LogMessage> OnLog;
-
-        public event EventHandler<string> OnStatistics;
-
-        public event EventHandler<Error> OnError;
     }
 
 
@@ -965,9 +955,6 @@ namespace Confluent.Kafka
         {
             producer = new Producer(config, manualPoll, disableDeliveryReports);
             serializingProducer = producer.GetSerializingProducer(keySerializer, valueSerializer);
-            producer.OnLog += (sender, e) => OnLog?.Invoke(sender, e);
-            producer.OnError += (sender, e) => OnError?.Invoke(sender, e);
-            producer.OnStatistics += (sender, e) => OnStatistics?.Invoke(sender, e);
         }
 
         /// <summary>
@@ -1154,7 +1141,11 @@ namespace Confluent.Kafka
         ///     threads and the application must not call any Confluent.Kafka APIs from 
         ///     within a log handler or perform any prolonged operations.
         /// </remarks>
-        public event EventHandler<LogMessage> OnLog;
+        public event EventHandler<LogMessage> OnLog
+        {
+            add { producer.OnLog += value; }
+            remove { producer.OnLog -= value; }
+        }
 
         /// <summary>
         ///     Raised on librdkafka statistics events. JSON formatted
@@ -1167,7 +1158,11 @@ namespace Confluent.Kafka
         ///
         ///     Called on the Producer poll thread.
         /// </remarks>
-        public event EventHandler<string> OnStatistics;
+        public event EventHandler<string> OnStatistics
+        {
+            add { producer.OnStatistics += value; }
+            remove { producer.OnStatistics -= value; }
+        }
 
         /// <summary>
         ///     Raised on critical errors, e.g. connection failures or all 
@@ -1178,7 +1173,11 @@ namespace Confluent.Kafka
         /// <remarks>
         ///     Called on the Producer poll thread.
         /// </remarks>
-        public event EventHandler<Error> OnError;
+        public event EventHandler<Error> OnError
+        {
+            add { producer.OnError += value; }
+            remove { producer.OnError -= value; }
+        }
 
 
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
@@ -75,11 +75,11 @@ namespace Confluent.Kafka.IntegrationTests
             logCount = 0;
             using (var producer = new Producer(producerConfig))
             {
-                var sProducer = producer.GetSerializingProducer<Null, string>(null, new StringSerializer(Encoding.UTF8));
-
-                sProducer.OnLog += (_, LogMessage)
+                producer.OnLog += (_, LogMessage)
                   => logCount += 1;
 
+                var sProducer = producer.GetSerializingProducer<Null, string>(null, new StringSerializer(Encoding.UTF8));
+                
                 sProducer.ProduceAsync(topic, null, "test value").Wait();
                 producer.Flush();
             }


### PR DESCRIPTION
Events should come from Producer only. If we create multiple serializedProducer, we don't want to duplicates the log/stats/error (we have only one producer instance and can't know from which Serializingproducer the error came)

Also the constructors made a subscription on Producer.OnLog, thus not logging anything in console when no callbacks were made

Producer<K,V> keeps the events as it create a Producer instance, but events are now just mapped to the Producer instance rather than making an intermediate subscription (same reasons as before)