### PR TITLE
Fix loading of librdkafka dependencies in .NET Framework 

### DIFF
--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -23,6 +23,7 @@ using System.Runtime.InteropServices;
 using Confluent.Kafka.Internal;
 #if NET45
 using System.Reflection;
+using System.ComponentModel;
 #endif
 
 
@@ -30,25 +31,49 @@ namespace Confluent.Kafka.Impl
 {
     internal static class LibRdKafka
     {
-        const long minVersion = 0x000901ff;
+        //min librdkafka version, to change when binding to new function are added
+        const long minVersion = 0x000904ff;
 
 #if NET45
+        [Flags]
+        public enum LoadLibraryFlags : uint
+        {     
+            DONT_RESOLVE_DLL_REFERENCES = 0x00000001,
+            LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010,
+            LOAD_LIBRARY_AS_DATAFILE = 0x00000002,
+            LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040,
+            LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020,
+            LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200,
+            LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000,
+            LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100,
+            LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800,
+            LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400,
+            LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+        }
+
         [DllImport("kernel32", SetLastError = true)]
-        private static extern IntPtr LoadLibrary(string lpFileName);
+        private static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, LoadLibraryFlags dwFlags);
 #endif
 
         static LibRdKafka()
         {
 #if NET45
+            // in net45, librdkafka.dll is not in the process directory, we have to load it manually
+            // and also search in the same folder for its dependencies (LOAD_WITH_ALTERED_SEARCH_PATH)
             var is64 = IntPtr.Size == 8;
-            try {
-                var baseUri = new Uri(Assembly.GetExecutingAssembly().GetName().CodeBase);
-                var baseDirectory = Path.GetDirectoryName(baseUri.LocalPath);
+            var baseDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-                LoadLibrary(Path.Combine(baseDirectory, is64 ? "x64/zlib.dll" : "x86/zlib.dll"));
-                LoadLibrary(Path.Combine(baseDirectory, is64 ? "x64/librdkafka.dll" : "x86/librdkafka.dll"));
+            if (LoadLibraryEx(Path.Combine(baseDirectory, is64 ? "x64" : "x86", "librdkafka.dll"),
+                IntPtr.Zero, LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
+            {
+                //catch the last win32 error by default and keep the associated default message
+                var win32Exception = new Win32Exception();
+                var additionalMessage = 
+                    $"Error while loading librdkafka.dll or its dependencies from {baseDirectory}. " +
+                    $"Check the directory exists, if not check your deployment process";
+
+                throw new InvalidOperationException(additionalMessage, win32Exception);
             }
-            catch (Exception) { }
 #endif
 
             _version = NativeMethods.rd_kafka_version;

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -61,7 +61,8 @@ namespace Confluent.Kafka.Impl
             // in net45, librdkafka.dll is not in the process directory, we have to load it manually
             // and also search in the same folder for its dependencies (LOAD_WITH_ALTERED_SEARCH_PATH)
             var is64 = IntPtr.Size == 8;
-            var baseDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var baseUri = new Uri(Assembly.GetExecutingAssembly().GetName().CodeBase);
+            var baseDirectory = Path.GetDirectoryName(baseUri.LocalPath);
 
             if (LoadLibraryEx(Path.Combine(baseDirectory, is64 ? "x64" : "x86", "librdkafka.dll"),
                 IntPtr.Zero, LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)


### PR DESCRIPTION
Fix #115 : make 0.9.4 as min version (for producev even if it's not used for now)
We may want to have fallbacks, but for now this will help to not have people targeting Internal.Rdkafka 0.9.1 I think only 0.9.2 is a minimum for now (with flush). Perhaps we could add an attribute on each method in NativeMethods to say what is the minimal supported version and what version are deprecated (for example due to a bug) We could then parse them all when starting given the version loaded and provide some logs on this. This would be an other enhancement though

Fix #145 #72 : now load with LoadLibraryEx with a custom flag so that dependencies are searched in the same folder (this was not the case for msvcr120.dll) Also throw a more meaningful exception