### PR TITLE
[WIP] Integration tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ matrix:
     env: DOTNETCORE=1
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -n 1024 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --with-openssl curl ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ulimit -n 1024 ; fi
 
 install:
    - dotnet restore
@@ -29,4 +28,5 @@ install:
 script:
    - make build
    - make unit_test
+   - make install_kafka
    - make integration_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: csharp
 env:
   global:
     - CONFIGURATION=Release
+    - INSTALL_KAFKA=True
 
 matrix:
   include:
@@ -18,9 +19,14 @@ matrix:
     mono: none
     env: DOTNETCORE=1
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -n 1024 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --with-openssl curl ; fi
+
 install:
    - dotnet restore
 
 script:
    - make build
-   - make test
+   - make unit_test
+   - make integration_test

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,15 @@ TEST_DIRS==$(shell find ./test -name '*.csproj' -exec dirname {} \;)
 LINUX_FRAMEWORK=netcoreapp1.1
 DEFAULT_FRAMEWORK?=$(LINUX_FRAMEWORK)
 
+CONFLUENT_VERSION=3.2
+CONFLUENT_OSS=confluent-oss-3.2.0-2.11
+CONFLUENT_DIR=confluent-3.2.0
+
 all:
 	@echo "Usage:   make <dotnet-command>"
 	@echo "Example: make build - runs 'dotnet build' for all projects"
 
-.PHONY: test
+.PHONY: unit_test integration_test
 
 build:
 	# Assuming .NET Core on Linux (net451 will not work).
@@ -28,9 +32,26 @@ build:
 		for d in $(TEST_DIRS) ; do dotnet $@ -f $(DEFAULT_FRAMEWORK) $$d; done ; \
 	fi)
 
-test:
+unit_test:
 	@(if [ "$(OS)" = "Linux" ]] ; then \
 		dotnet test -f $(LINUX_FRAMEWORK) test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj ; \
 	else \
 		dotnet test -f $(DEFAULT_FRAMEWORK) test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj ; \
+	fi)
+	
+integration_test:
+	#install and run zookeeper / kafka if necessary
+	@(if [ "$(INSTALL_KAFKA)" ]] ; then \
+		echo "Installing kafka" ; \
+		wget http://packages.confluent.io/archive/$(CONFLUENT_VERSION)/$(CONFLUENT_OSS).tar.gz ; \
+		tar xzf confluent-oss-3.2.0-2.11.tar.gz ; \
+		$(CONFLUENT_DIR)/bin/zookeeper-server-start -daemon $(CONFLUENT_DIR)/etc/kafka/zookeeper.properties ; \
+		$(CONFLUENT_DIR)/bin/kafka-server-start -daemon $(CONFLUENT_DIR)/etc/kafka/server.properties ; \
+		sleep 10 ; \
+		sh test/Confluent.Kafka.IntegrationTests/bootstrap-topics.sh $(CONFLUENT_DIR) "localhost:2181" ; \
+	fi)
+	@(if [ "$(OS)" = "Linux" ]] ; then \
+		dotnet test -f $(LINUX_FRAMEWORK) test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj ; \
+	else \
+		dotnet test -f $(DEFAULT_FRAMEWORK) test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj ; \
 	fi)

--- a/Makefile
+++ b/Makefile
@@ -9,49 +9,41 @@ OS=$(shell uname -s)
 EXAMPLE_DIRS=$(shell find ./examples -name '*.csproj' -exec dirname {} \;)
 TEST_DIRS==$(shell find ./test -name '*.csproj' -exec dirname {} \;)
 
-LINUX_FRAMEWORK=netcoreapp1.1
-DEFAULT_FRAMEWORK?=$(LINUX_FRAMEWORK)
+#framework can be change to net45 or similar
+FRAMEWORK?=netcoreapp1.1
 
-CONFLUENT_VERSION=3.2
-CONFLUENT_OSS=confluent-oss-3.2.0-2.11
-CONFLUENT_DIR=confluent-3.2.0
+CONFLUENT_VERSION?=3.2
+CONFLUENT_OSS?=confluent-oss-3.2.0-2.11
+CONFLUENT_DIR?=confluent-3.2.0
 
 all:
-	@echo "Usage:   make <dotnet-command>"
+	@echo "Usage:   make <command> (build, unit_test, integration_test, install_kafka)"
 	@echo "Example: make build - runs 'dotnet build' for all projects"
 
 .PHONY: unit_test integration_test
 
 build:
-	# Assuming .NET Core on Linux (net451 will not work).
-	@(if [ "$(OS)" = "Linux" ]] ; then \
-		for d in $(EXAMPLE_DIRS) ; do dotnet $@ -f $(LINUX_FRAMEWORK) $$d; done ; \
-		for d in $(TEST_DIRS) ; do dotnet $@ -f $(LINUX_FRAMEWORK) $$d; done ; \
-	else \
-		for d in $(EXAMPLE_DIRS) ; do dotnet $@ -f $(DEFAULT_FRAMEWORK) $$d; done ; \
-		for d in $(TEST_DIRS) ; do dotnet $@ -f $(DEFAULT_FRAMEWORK) $$d; done ; \
-	fi)
+	# will also build Confluent.Kafka fot netstandard1.3
+	# we can't make a build on the solution as net45 will not work
+	# and we can't build it specifying netcoreapp as netstandard is used also
+	@for d in $(EXAMPLE_DIRS) ; do dotnet $@ -f $(FRAMEWORK) $$d; done
+	@for d in $(TEST_DIRS) ; do dotnet $@ -f $(FRAMEWORK) $$d; done
 
 unit_test:
-	@(if [ "$(OS)" = "Linux" ]] ; then \
-		dotnet test -f $(LINUX_FRAMEWORK) test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj ; \
-	else \
-		dotnet test -f $(DEFAULT_FRAMEWORK) test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj ; \
-	fi)
-	
+	@dotnet test -f $(FRAMEWORK) test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+
 integration_test:
-	#install and run zookeeper / kafka if necessary
-	@(if [ "$(INSTALL_KAFKA)" ]] ; then \
-		echo "Installing kafka" ; \
-		wget http://packages.confluent.io/archive/$(CONFLUENT_VERSION)/$(CONFLUENT_OSS).tar.gz ; \
-		tar xzf confluent-oss-3.2.0-2.11.tar.gz ; \
-		$(CONFLUENT_DIR)/bin/zookeeper-server-start -daemon $(CONFLUENT_DIR)/etc/kafka/zookeeper.properties ; \
-		$(CONFLUENT_DIR)/bin/kafka-server-start -daemon $(CONFLUENT_DIR)/etc/kafka/server.properties ; \
-		sleep 10 ; \
-		sh test/Confluent.Kafka.IntegrationTests/bootstrap-topics.sh $(CONFLUENT_DIR) "localhost:2181" ; \
-	fi)
-	@(if [ "$(OS)" = "Linux" ]] ; then \
-		dotnet test -f $(LINUX_FRAMEWORK) test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj ; \
-	else \
-		dotnet test -f $(DEFAULT_FRAMEWORK) test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj ; \
-	fi)
+	@dotnet test -f $(FRAMEWORK) test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
+
+install_kafka:
+	@echo "Installing kafka"
+	@wget http://packages.confluent.io/archive/$(CONFLUENT_VERSION)/$(CONFLUENT_OSS).tar.gz
+	@tar xzf $(CONFLUENT_OSS).tar.gz
+	@echo "starting zookeeper"
+	@$(CONFLUENT_DIR)/bin/zookeeper-server-start -daemon $(CONFLUENT_DIR)/etc/kafka/zookeeper.properties
+	@echo "starting kafka"
+	@$(CONFLUENT_DIR)/bin/kafka-server-start -daemon $(CONFLUENT_DIR)/etc/kafka/server.properties
+	@echo "wait arbitrary 10s for kafka to launch"
+	@sleep 10
+	@echo "create topics necessary for the tests"
+	@sh test/Confluent.Kafka.IntegrationTests/bootstrap-topics.sh $(CONFLUENT_DIR) "localhost:2181"


### PR DESCRIPTION
See #136 

Add integration tests in travis

This download and install zookeeper / librdkafka from confluent-oss package

As this add almost 8 minutes to the build, it's perhaps not good to run it always. We might also try to cache the zookeeper/kafka directory to accelerate the installation.

An other solution would be to test against some remote cluster which would always be up on confluent side (this would also allow to test in appveyor also) but not an easy go

Concerning appveyor, we could install kafka and zookeeper as well, but it's not officialy supported by confluent platform.

Also set ulimit for osx to correct  dotnet restore on osx