### PR TITLE
Remove redundant awaits

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -1041,8 +1041,8 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Commit offsets for the current assignment.
         /// </summary>
-        public async Task<CommittedOffsets> CommitAsync()
-            => await kafkaHandle.CommitAsync();
+        public Task<CommittedOffsets> CommitAsync()
+            => kafkaHandle.CommitAsync();
 
         /// <summary>
         ///     Commits an offset based on the topic/partition/offset of a message.
@@ -1055,20 +1055,20 @@ namespace Confluent.Kafka
         ///     A consumer which has position N has consumed records with offsets 0 through N-1 and will next receive the record with offset N.
         ///     Hence, this method commits an offset of <paramref name="message" />.Offset + 1.
         /// </remarks>
-        public async Task<CommittedOffsets> CommitAsync(Message message)
+        public Task<CommittedOffsets> CommitAsync(Message message)
         {
             if (message.Error.Code != ErrorCode.NoError)
             {
                 throw new InvalidOperationException("Must not commit offset for errored message");
             }
-            return await CommitAsync(new[] { new TopicPartitionOffset(message.TopicPartition, message.Offset + 1) });
+            return CommitAsync(new[] { new TopicPartitionOffset(message.TopicPartition, message.Offset + 1) });
         }
 
         /// <summary>
         ///     Commit an explicit list of offsets.
         /// </summary>
-        public async Task<CommittedOffsets> CommitAsync(IEnumerable<TopicPartitionOffset> offsets)
-            => await kafkaHandle.CommitAsync(offsets);
+        public Task<CommittedOffsets> CommitAsync(IEnumerable<TopicPartitionOffset> offsets)
+            => kafkaHandle.CommitAsync(offsets);
 
         /// <summary>
         ///     Retrieve current committed offsets for topics + partitions.

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -452,11 +452,11 @@ namespace Confluent.Kafka.Impl
             return committedOffsets;
         }
 
-        internal async Task<CommittedOffsets> CommitAsync()
-            => await Task.Run(() => commitSync(null));
+        internal Task<CommittedOffsets> CommitAsync()
+            => Task.Run(() => commitSync(null));
 
-        internal async Task<CommittedOffsets> CommitAsync(IEnumerable<TopicPartitionOffset> offsets)
-            => await Task.Run(() => commitSync(offsets));
+        internal Task<CommittedOffsets> CommitAsync(IEnumerable<TopicPartitionOffset> offsets)
+            => Task.Run(() => commitSync(offsets));
 
         /// <summary>
         ///     for each topic/partition returns the current committed offset


### PR DESCRIPTION
Removed redundant `await`'s and `async` modifiers:
- There is no need to await call results, if they are not used in the continuation. Methods will be awaited by the caller. Also removing `async` modifier allows to gain some additional performance, since the compiler now won't generate state machines for these methods.
- Library code anyway shouldn't capture client's synchronization context ([details](https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async/Async-library-methods-should-consider-using-Task-ConfigureAwait-false-)).