### PR TITLE
[WIP] Call SetResult on threadpool for Task ProduceAsync variants

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -13,7 +13,7 @@
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
     <VersionPrefix>0.9.5</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netstandard1.3</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -21,7 +21,7 @@ using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
 using Confluent.Kafka.Internal;
-#if NET45
+#if NET45 || NET46
 using System.Reflection;
 using System.ComponentModel;
 #endif
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.Impl
         //min librdkafka version, to change when binding to new function are added
         const long minVersion = 0x000903ff;
 
-#if NET45
+#if NET45 || NET46
         [Flags]
         public enum LoadLibraryFlags : uint
         {
@@ -84,7 +84,7 @@ namespace Confluent.Kafka.Impl
 
         static LibRdKafka()
         {
-#if NET45
+#if NET45 || NET46
             try
             {
                 // In net45, we don't put the native dlls in the assembly directory

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -182,11 +182,19 @@ namespace Confluent.Kafka
 
         private sealed class TaskDeliveryHandler : TaskCompletionSource<Message>, IDeliveryHandler
         {
+#if !NET45
+            public TaskDeliveryHandler() : base(TaskContinuationOptions.RunContinuationsAsynchronously)
+            { }
+#endif
             public bool MarshalData { get { return true; } }
 
             public void HandleDeliveryReport(Message message)
             {
+#if NET45
                 System.Threading.Tasks.Task.Run(() => SetResult(message));
+#else
+                SetResult(message);
+#endif
             }
         }
 
@@ -825,6 +833,9 @@ namespace Confluent.Kafka
         private class TypedTaskDeliveryHandlerShim : TaskCompletionSource<Message<TKey, TValue>>, IDeliveryHandler
         {
             public TypedTaskDeliveryHandlerShim(TKey key, TValue val)
+#if !NET45
+                : base(TaskContinuationOptions.RunContinuationsAsynchronously)
+#endif
             {
                 Key = key;
                 Value = val;
@@ -848,7 +859,11 @@ namespace Confluent.Kafka
                     message.Error
                 );
 
+#if NET45
                 System.Threading.Tasks.Task.Run(() => SetResult(mi));
+#else
+                SetResult(mi);
+#endif
             }
         }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -186,7 +186,7 @@ namespace Confluent.Kafka
 
             public void HandleDeliveryReport(Message message)
             {
-                SetResult(message);
+                System.Threading.Tasks.Task.Run(() => SetResult(message));
             }
         }
 
@@ -848,7 +848,7 @@ namespace Confluent.Kafka
                     message.Error
                 );
 
-                SetResult(mi);
+                System.Threading.Tasks.Task.Run(() => SetResult(mi));
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
@@ -44,7 +44,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 firstProduced = producer.ProduceAsync(topic, Encoding.UTF8.GetBytes("key"), null).Result.TopicPartitionOffset;
                 producer.ProduceAsync(topic, null, Encoding.UTF8.GetBytes("val"));
-                producer.Flush();
+                producer.Flush(30);
             }
 
             var consumerConfig = new Dictionary<string, object>

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -1,0 +1,53 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    /// <summary>
+    ///     Ensures that awaiting ProduceAsync does not deadlock.
+    /// </summary>
+    public static partial class Tests
+    {
+        public static async Task Producer_ProduceAsync_Await_Task(Dictionary<string, object> config, string topic)
+        {
+            using (var producer = new Producer(config))
+            {
+                var dr = await producer.ProduceAsync(topic, new byte[] {42}, new byte[] {44});
+                Assert.Equal(ErrorCode.NoError, dr.Error.Code);
+                producer.Flush();
+            }
+        }
+
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public static void Producer_ProduceAsync_Await(string bootstrapServers, string topic, string partitionedTopic)
+        {
+            var producerConfig = new Dictionary<string, object> 
+            { 
+                { "bootstrap.servers", bootstrapServers },
+                { "api.version.request", true }
+            };
+
+            var task = Producer_ProduceAsync_Await_Task(producerConfig, topic);
+            task.Wait();
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = await producer.ProduceAsync(topic, new byte[] {42}, new byte[] {44});
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
-                producer.Flush();
+                producer.Flush(30);
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
@@ -1,0 +1,55 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Confluent.Kafka.Serialization;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    /// <summary>
+    ///     Ensures that awaiting ProduceAsync does not deadlock.
+    /// </summary>
+    public static partial class Tests
+    {
+        public static async Task SerializingProducer_ProduceAsync_Await_Task(Dictionary<string, object> config, string topic)
+        {
+            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(Encoding.UTF8)))
+            {
+                var dr = await producer.ProduceAsync(topic, null, "test string");
+                Assert.Equal(ErrorCode.NoError, dr.Error.Code);
+                producer.Flush();
+            }
+        }
+
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public static void SerializingProducer_ProduceAsync_Await(string bootstrapServers, string topic, string partitionedTopic)
+        {
+            var producerConfig = new Dictionary<string, object> 
+            { 
+                { "bootstrap.servers", bootstrapServers },
+                { "api.version.request", true }
+            };
+
+            var task = SerializingProducer_ProduceAsync_Await_Task(producerConfig, topic);
+            task.Wait();
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = await producer.ProduceAsync(topic, null, "test string");
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
-                producer.Flush();
+                producer.Flush(30);
             }
         }
 


### PR DESCRIPTION
This is a quick fix for #92.

The performance hit is unfortunately very high - scheduling on the thread pool results in a 4x slow down compared to the `IDeliveryHandler` variants of `ProduceAsync` (as @ah- warned).

I'm wondering if there is a way of solving this on the poll loop side of things - some fancy dual-thread arrangement or something (but i'm a bit wary - it's less straightforward to analyse).

finally: the tests actually work even without the fix in place for some reason. I haven't tried to work out why. I've verified the fix is effective in a console app.

Considering this a Work-In-Progress - putting it out there as a start.