### PR TITLE
removing UNSTABLE designation from non-serializing Producer

### DIFF
--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -31,12 +31,6 @@ namespace Confluent.Kafka
 {
     /// <summary>
     ///     Implements a high-level Apache Kafka producer (without serialization).
-    ///
-    ///     [UNSTABLE-API] We are considering making this class private in a future version 
-    ///     so as to limit API surface area. Prefer to use the serializing producer
-    ///     <see cref="Confluent.Kafka.Producer{TKey,TValue}" /> where possible. Please let us know
-    ///     if you find the <see cref="GetSerializingProducer{TKey,TValue}(ISerializer{TKey},ISerializer{TValue})" /> method
-    ///     useful.
     /// </summary>
     public class Producer : IDisposable
     {


### PR DESCRIPTION
there has been plenty of feedback that people want the non-serializing producer, e.g. #116, so removing the UNSTABLE designation. @ewencp
