### PR TITLE
Obsoleting or removing methods that can potentially block indefinitely

### DIFF
--- a/examples/Misc/Program.cs
+++ b/examples/Misc/Program.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 
 namespace Confluent.Kafka.Examples.Misc

--- a/examples/MultiProducer/Program.cs
+++ b/examples/MultiProducer/Program.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using System.Text;
 using System.Collections.Generic;
 using Confluent.Kafka.Serialization;
@@ -60,7 +61,7 @@ namespace Confluent.Kafka.Examples.MultiProducer
 
                 // ProducerAsync tasks are not waited on - there is a good chance they are still
                 // in flight.
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
         }
     }

--- a/examples/SimpleConsumer/Program.cs
+++ b/examples/SimpleConsumer/Program.cs
@@ -45,7 +45,7 @@ namespace Confluent.Kafka.Examples.SimpleConsumer
                 while (true)
                 {
                     Message<Null, string> msg;
-                    if (consumer.Consume(out msg))
+                    if (consumer.Consume(out msg, TimeSpan.FromSeconds(1)))
                     {
                         Console.WriteLine($"Topic: {msg.Topic} Partition: {msg.Partition} Offset: {msg.Offset} {msg.Value}");
                     }

--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.Examples.SimpleProducer
 
                 // Tasks are not waited on synchronously (ContinueWith is not synchronous),
                 // so it's possible they may still in progress here.
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
         }
     }

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -151,13 +151,6 @@ namespace Confluent.Kafka
         public bool Consume(out Message<TKey, TValue> message, TimeSpan timeout)
             => Consume(out message, timeout.TotalMillisecondsAsInt());
 
-        /// <summary>
-        ///     Refer to <see cref="Consume(out Message{TKey, TValue}, int)" />.
-        ///     
-        ///     [UNSTABLE-API] - prefer to use <see cref="Poll()"/> / <see cref="OnMessage"/> instead of this method.
-        /// </summary>
-        public bool Consume(out Message<TKey, TValue> message)
-            => Consume(out message, -1);
 
         /// <summary>
         ///     Poll for new consumer events, including new messages
@@ -165,7 +158,7 @@ namespace Confluent.Kafka
         ///     event).
         /// </summary>
         /// <param name="millisecondsTimeout"> 
-        ///     The maximum time to block (in milliseconds).
+        ///     The maximum time to block (in milliseconds), or -1 to block indefinitely.
         /// </param>
         public void Poll(int millisecondsTimeout)
         {
@@ -195,12 +188,13 @@ namespace Confluent.Kafka
 
         /// <summary>
         ///     Poll for new consumer events, including new messages
-        ///     ready to be consumed(which will trigger the OnMessage
+        ///     ready to be consumed (which will trigger the OnMessage
         ///     event).
         /// </summary> 
         /// <remarks>
         ///     Blocks indefinitely until a new event is ready.
         /// </remarks>
+        [Obsolete("Indefinite polling cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
         public void Poll()
             => Poll(-1);
 
@@ -500,13 +494,6 @@ namespace Confluent.Kafka
         public List<GroupInfo> ListGroups(TimeSpan timeout)
             => consumer.ListGroups(timeout);
 
-        /// <summary>
-        ///     Get information pertaining to all groups in the Kafka cluster (blocks, potentially indefinitely).
-        ///
-        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
-        /// </summary>
-        public List<GroupInfo> ListGroups()
-            => consumer.ListGroups();
 
         /// <summary>
         ///     Get information pertaining to a particular group in the
@@ -984,13 +971,6 @@ namespace Confluent.Kafka
         public bool Consume(out Message message, TimeSpan timeout)
             => Consume(out message, timeout.TotalMillisecondsAsInt());
 
-        /// <summary>
-        ///     Refer to <see cref="Consume(out Message, int)" />
-        ///     
-        ///     [UNSTABLE-API] - prefer to use <see cref="Poll()"/> / <see cref="OnMessage"/> instead of this method.
-        /// </summary>
-        public bool Consume(out Message message)
-            => Consume(out message, -1);
 
         /// <summary>
         ///     Poll for new consumer events, including new messages
@@ -1015,7 +995,7 @@ namespace Confluent.Kafka
         ///     event).
         /// </summary>
         /// <param name="millisecondsTimeout"> 
-        ///     The maximum time to block (in milliseconds)
+        ///     The maximum time to block (in milliseconds), or -1 to block indefinitely.
         /// </param>
         public void Poll(int millisecondsTimeout)
         {
@@ -1034,6 +1014,7 @@ namespace Confluent.Kafka
         /// <remarks>
         ///     Blocks indefinitely until a new event is ready.
         /// </remarks>
+        [Obsolete("Indefinite polling cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
         public void Poll()
             => Poll(-1);
 
@@ -1142,15 +1123,6 @@ namespace Confluent.Kafka
         /// </param>
         public List<GroupInfo> ListGroups(TimeSpan timeout)
             => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
-
-        /// <summary>
-        ///     Get information pertaining to all groups in the Kafka
-        ///     cluster (blocks, potentially indefinitely).
-        ///
-        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
-        /// </summary>
-        public List<GroupInfo> ListGroups()
-            => kafkaHandle.ListGroups(-1);
 
 
         /// <summary>

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -104,22 +104,25 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Poll for new messages / consumer events.
+        ///     Poll for new messages / consumer events. Blocks until a new 
+        ///     message or event is ready to be handled or the timeout period
+        ///     <paramref name="millisecondsTimeout" /> has elapsed.
         ///     
         ///     [UNSTABLE-API] - prefer to use <see cref="Poll()"/> / 
         ///     <see cref="OnMessage"/> instead of Consume. We may remove
-        ///     this method in the future
-        ///     to limit API surface area. Please let us know if 
-        ///     you have a use case where Consume more convenient 
-        ///     than Poll.
+        ///     this method in the future to limit API surface area. 
+        ///     Please let us know if you have a use case where Consume 
+        ///     more convenient than Poll.
         /// </summary>
         /// <param name="message">
         ///     A consumed message, or null if no messages are 
         ///     available for consumption.
         /// </param>
         /// <param name="millisecondsTimeout">
-        ///     The maximum time to block for messages to become
-        ///     available for consumption.
+        ///     The maximum time to block (in milliseconds), or -1 to 
+        ///     block indefinitely. You should typically use a
+        ///     relatively short timout period because this operation
+        ///     cannot be cancelled.
         /// </param>
         /// <returns>
         ///     true: a message (with non-error state) was consumed.
@@ -155,10 +158,15 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Poll for new consumer events, including new messages
         ///     ready to be consumed (which will trigger the OnMessage
-        ///     event).
+        ///     event). Blocks until a new event is available to be 
+        ///     handled or the timeout period <paramref name="millisecondsTimeout" /> 
+        ///     has elapsed.
         /// </summary>
         /// <param name="millisecondsTimeout"> 
-        ///     The maximum time to block (in milliseconds), or -1 to block indefinitely.
+        ///     The maximum time to block (in milliseconds), or -1 to 
+        ///     block indefinitely. You should typically use a
+        ///     relatively short timout period because this operation
+        ///     cannot be cancelled.
         /// </param>
         public void Poll(int millisecondsTimeout)
         {
@@ -172,10 +180,14 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Poll for new consumer events, including new messages
         ///     ready to be consumed (which will trigger the OnMessage
-        ///     event).
+        ///     event). Blocks until a new event is available to be
+        ///     handled or the timeout period <paramref name="timeout" /> 
+        ///     has elapsed.
         /// </summary>
         /// <param name="timeout"> 
-        ///     The maximum time to block.
+        ///     The maximum time to block. You should typically use a
+        ///     relatively short timout period because this operation
+        ///     cannot be cancelled.
         /// </param>
         public void Poll(TimeSpan timeout)
         {
@@ -194,7 +206,7 @@ namespace Confluent.Kafka
         /// <remarks>
         ///     Blocks indefinitely until a new event is ready.
         /// </remarks>
-        [Obsolete("Indefinite polling cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
+        [Obsolete("Use an overload of Poll with a finite timeout.", false)]
         public void Poll()
             => Poll(-1);
 
@@ -917,22 +929,25 @@ namespace Confluent.Kafka
             => kafkaHandle.Assign(null);
 
         /// <summary>
-        ///     Poll for new messages / consumer events.
+        ///     Poll for new messages / consumer events. Blocks until a new 
+        ///     message or event is ready to be handled or the timeout period
+        ///     <paramref name="millisecondsTimeout" /> has elapsed.
         ///     
-        ///     [UNSTABLE-API] -  prefer to use <see cref="Poll()"/> / 
-        ///     <see cref="OnMessage"/> instead of Consume. We may 
-        ///     remove this method in the future
-        ///     to limit API surface area. Please let us know if 
-        ///     you have a use case where Consume more convenient 
-        ///     than Poll.
+        ///     [UNSTABLE-API] - prefer to use <see cref="Poll()"/> / 
+        ///     <see cref="OnMessage"/> instead of Consume. We may remove
+        ///     this method in the future to limit API surface area. 
+        ///     Please let us know if you have a use case where Consume 
+        ///     more convenient than Poll.
         /// </summary>
         /// <param name="message">
         ///     A consumed message, or null if no messages are 
         ///     available for consumption.
         /// </param>
         /// <param name="millisecondsTimeout">
-        ///     The maximum time to block for messages to become
-        ///     available for consumption.
+        ///     The maximum time to block (in milliseconds), or -1 to 
+        ///     block indefinitely. You should typically use a
+        ///     relatively short timout period because this operation
+        ///     cannot be cancelled.
         /// </param>
         /// <returns>
         ///     true: a message (with non-error state) was consumed.
@@ -978,7 +993,9 @@ namespace Confluent.Kafka
         ///     event).
         /// </summary>
         /// <param name="timeout"> 
-        ///     The maximum time to block.
+        ///     The maximum time to block. You should typically use a
+        ///     relatively short timout period because this operation
+        ///     cannot be cancelled.
         /// </param>
         public void Poll(TimeSpan timeout)
         {
@@ -992,10 +1009,15 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Poll for new consumer events, including new messages
         ///     ready to be consumed (which will trigger the OnMessage
-        ///     event).
+        ///     event). Blocks until a new event is available to be 
+        ///     handled or the timeout period <paramref name="millisecondsTimeout" /> 
+        ///     has elapsed.
         /// </summary>
         /// <param name="millisecondsTimeout"> 
-        ///     The maximum time to block (in milliseconds), or -1 to block indefinitely.
+        ///     The maximum time to block (in milliseconds), or -1 to 
+        ///     block indefinitely. You should typically use a
+        ///     relatively short timout period because this operation
+        ///     cannot be cancelled.
         /// </param>
         public void Poll(int millisecondsTimeout)
         {
@@ -1014,7 +1036,7 @@ namespace Confluent.Kafka
         /// <remarks>
         ///     Blocks indefinitely until a new event is ready.
         /// </remarks>
-        [Obsolete("Indefinite polling cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
+        [Obsolete("Use an overload of Poll with a finite timeout.", false)]
         public void Poll()
             => Poll(-1);
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -617,6 +617,24 @@ namespace Confluent.Kafka
             => kafkaHandle.Flush(millisecondsTimeout);
 
         /// <summary>
+        ///     Wait until all outstanding produce requests and delievery report
+        ///     callbacks are completed. Refer to <see cref="Flush(int)" /> for
+        ///     more information.
+        /// 
+        ///     [UNSTABLE-API] - the semantics and/or type of the return value is
+        ///     subject to change.
+        /// </summary>
+        /// <param name="timeout">
+        ///     The maximum length of time to block.
+        /// </param>
+        /// <returns>
+        ///     The current librdkafka out queue length. Refer to <see cref="Flush(int)" />
+        ///     for more information.
+        /// </returns>
+        public int Flush(TimeSpan timeout)
+            => kafkaHandle.Flush(timeout.TotalMillisecondsAsInt());
+
+        /// <summary>
         ///     Equivalent to <see cref="Flush(int)" /> with infinite timeout.
         ///
         ///     [UNSTABLE-API] - the semantics and/or type of the return value is
@@ -1203,6 +1221,24 @@ namespace Confluent.Kafka
         /// </remarks>
         public int Flush(int millisecondsTimeout)
             => producer.Flush(millisecondsTimeout);
+
+        /// <summary>
+        ///     Wait until all outstanding produce requests and delievery report
+        ///     callbacks are completed. Refer to <see cref="Flush(int)" /> for
+        ///     more information.
+        /// 
+        ///     [UNSTABLE-API] - the semantics and/or type of the return value is
+        ///     subject to change.
+        /// </summary>
+        /// <param name="timeout">
+        ///     The maximum length of time to block.
+        /// </param>
+        /// <returns>
+        ///     The current librdkafka out queue length. Refer to <see cref="Flush(int)" />
+        ///     for more information.
+        /// </returns>
+        public int Flush(TimeSpan timeout)
+            => producer.Flush(timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -322,7 +322,9 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name="millisecondsTimeout">
         ///     The maximum period of time to block (in milliseconds) if no
-        ///     callback events are waiting.
+        ///     callback events are waiting or -1 to block indefinitely. 
+        ///     You should typically use a relatively short timout period 
+        ///     because this operation cannot be cancelled.
         /// </param>
         /// <returns>
         ///     Returns the number of events served.
@@ -343,7 +345,8 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name="timeout">
         ///     The maximum period of time to block if no callback events
-        ///     are waiting.
+        ///     are waiting. You should typically use a relatively short 
+        ///     timout period because this operation cannot be cancelled.
         /// </param>
         /// <returns>
         ///     Returns the number of events served.
@@ -360,7 +363,7 @@ namespace Confluent.Kafka
         /// <returns>
         ///     Returns the number of events served.
         /// </returns>
-        [Obsolete("Indefinite polling cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
+        [Obsolete("Use an overload of Poll with a finite timeout.", false)]
         public int Poll()
             => Poll(-1);
 
@@ -590,7 +593,9 @@ namespace Confluent.Kafka
         ///     subject to change.
         /// </summary>
         /// <param name="millisecondsTimeout">
-        ///     The maximum time to block in milliseconds.
+        ///     The maximum time to block in milliseconds or -1 to block
+        ///     indefinitely. You should typically use a relatively short timout 
+        ///     period because this operation cannot be cancelled.
         /// </param>
         /// <returns>
         ///     The current librdkafka out queue length. This should be interpreted
@@ -625,7 +630,9 @@ namespace Confluent.Kafka
         ///     subject to change.
         /// </summary>
         /// <param name="timeout">
-        ///     The maximum length of time to block.
+        ///     The maximum length of time to block. You should typically use a
+        ///     relatively short timout period because this operation cannot be 
+        ///     cancelled.
         /// </param>
         /// <returns>
         ///     The current librdkafka out queue length. Refer to <see cref="Flush(int)" />
@@ -643,7 +650,7 @@ namespace Confluent.Kafka
         /// <returns>
         ///     Refer to <see cref="Flush(int)" />.
         /// </returns>
-        [Obsolete("This method cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
+        [Obsolete("Use an overload of Flush with a finite timeout.", false)]
         public int Flush()
             => kafkaHandle.Flush(-1);
 
@@ -1187,7 +1194,6 @@ namespace Confluent.Kafka
         }
 
 
-
         /// <summary>
         ///     Wait until all outstanding produce requests and delievery report
         ///     callbacks are completed.
@@ -1196,7 +1202,9 @@ namespace Confluent.Kafka
         ///     subject to change.
         /// </summary>
         /// <param name="millisecondsTimeout">
-        ///     The maximum time to block in milliseconds.
+        ///     The maximum time to block in milliseconds, or -1 to block
+        ///     indefinitely. You should typically use a relatively short timout 
+        ///     period because this operation cannot be cancelled.
         /// </param>
         /// <returns>
         ///     The current librdkafka out queue length. This should be interpreted
@@ -1231,7 +1239,9 @@ namespace Confluent.Kafka
         ///     subject to change.
         /// </summary>
         /// <param name="timeout">
-        ///     The maximum length of time to block.
+        ///     The maximum length of time to block. You should typically use a
+        ///     relatively short timout period because this operation cannot be 
+        ///     cancelled.
         /// </param>
         /// <returns>
         ///     The current librdkafka out queue length. Refer to <see cref="Flush(int)" />

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -360,6 +360,7 @@ namespace Confluent.Kafka
         /// <returns>
         ///     Returns the number of events served.
         /// </returns>
+        [Obsolete("Indefinite polling cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
         public int Poll()
             => Poll(-1);
 
@@ -624,6 +625,7 @@ namespace Confluent.Kafka
         /// <returns>
         ///     Refer to <see cref="Flush(int)" />.
         /// </returns>
+        [Obsolete("This method cannot be cancelled so it's usually not what you want. Removing this method to discourage.", false)]
         public int Flush()
             => kafkaHandle.Flush(-1);
 
@@ -659,14 +661,6 @@ namespace Confluent.Kafka
         public List<GroupInfo> ListGroups(TimeSpan timeout)
             => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
 
-        /// <summary>
-        ///     Get information pertaining to all groups in the Kafka
-        ///     cluster (blocks, potentially indefinitely)
-        ///
-        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
-        /// </summary>
-        public List<GroupInfo> ListGroups()
-            => kafkaHandle.ListGroups(-1);
 
         /// <summary>
         ///     Get information pertaining to a particular group in the
@@ -1210,21 +1204,12 @@ namespace Confluent.Kafka
         public int Flush(int millisecondsTimeout)
             => producer.Flush(millisecondsTimeout);
 
-        /// <summary>
-        ///     Equivalent to <see cref="Flush(int)" /> with infinite timeout.
-        ///
-        ///     [UNSTABLE-API] - the semantics and/or type of the return value is
-        ///     subject to change.
-        /// </summary>
-        public int Flush()
-            => producer.Flush();
-
 
         /// <summary>
         ///     Releases all resources used by this Producer.
         /// </summary>
         /// <remarks>
-        ///     You will often want to call <see cref="Flush()" />
+        ///     You will often want to call <see cref="Flush(int)" />
         ///     before disposing a Producer instance.
         /// </remarks>
         public void Dispose()
@@ -1241,15 +1226,6 @@ namespace Confluent.Kafka
         /// </param>
         public List<GroupInfo> ListGroups(TimeSpan timeout)
             => producer.ListGroups(timeout);
-
-        /// <summary>
-        ///     Get information pertaining to all groups in the Kafka
-        ///     cluster (blocks, potentially indefinitely).
-        ///
-        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
-        /// </summary>
-        public List<GroupInfo> ListGroups()
-            => producer.ListGroups();
 
 
         /// <summary>

--- a/test/Confluent.Kafka.Benchmark/BenchmarkConsumer.cs
+++ b/test/Confluent.Kafka.Benchmark/BenchmarkConsumer.cs
@@ -41,7 +41,7 @@ namespace Confluent.Kafka.Benchmark
 
                     // consume 1 message before starting the timer to avoid including potential one-off delays.
                     Message msg;
-                    consumer.Consume(out msg);
+                    consumer.Consume(out msg, TimeSpan.FromSeconds(10));
 
                     long startTime = DateTime.Now.Ticks;
 

--- a/test/Confluent.Kafka.Benchmark/BenchmarkProducer.cs
+++ b/test/Confluent.Kafka.Benchmark/BenchmarkProducer.cs
@@ -101,7 +101,7 @@ namespace Confluent.Kafka.Benchmark
                     Console.WriteLine($"{nMessages / (duration/10000.0):F0} messages/ms");
                 }
 
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             return firstDeliveryReport.Offset;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.False(dr.Error.HasError);
                 var dr2 = producer.ProduceAsync(topic, null, testString2).Result;
                 Assert.False(dr2.Error.HasError);
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -47,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 dr = producer.ProduceAsync(topic, null, testString).Result;
                 Assert.True(dr.Offset >= 0);
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             consumerConfig["default.topic.config"] = new Dictionary<string, object>() { { "auto.offset.reset", "latest" } };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 dr = producer.ProduceAsync(topic, null, testString).Result;
                 Assert.NotNull(dr);
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             using (var consumer1 = new Consumer(consumerConfig))

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 using Newtonsoft.Json.Linq;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.ProduceAsync(topic, null, new byte[0]).Wait();
                 producer.ProduceAsync(topic, new byte[0], null).Wait();
                 producer.ProduceAsync(topic, new byte[0], new byte[0]).Wait();
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             using (var consumer = new Consumer(consumerConfig))

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
@@ -54,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
                   => logCount += 1;
 
                 producer.ProduceAsync(topic, null, (byte[])null).Wait();
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);
 
@@ -67,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
                   => logCount += 1;
 
                 dr = producer.ProduceAsync(topic, null, "test value").Result;
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);
 
@@ -81,7 +81,7 @@ namespace Confluent.Kafka.IntegrationTests
                 var sProducer = producer.GetSerializingProducer<Null, string>(null, new StringSerializer(Encoding.UTF8));
                 
                 sProducer.ProduceAsync(topic, null, "test value").Wait();
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -47,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = producer.ProduceAsync(topic, null, "test string").Result;
                 Assert.NotEqual((long)dr.Offset, (long)Offset.Invalid); // TODO: remove long cast. this is fixed in PR #29
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_DeliveryHandler.cs
@@ -117,7 +117,7 @@ namespace Confluent.Kafka.IntegrationTests
                     dh
                 );
 
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             Assert.Equal(6, dh.Count);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_DeliveryHandler.cs
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.ProduceAsync(topic, null, 0, 0, null, 0, 0, dh);
                 producer.ProduceAsync(topic, null, null, dh);
                 Assert.Throws<ArgumentException>(() => producer.ProduceAsync(topic, null, -123, int.MinValue, null, int.MaxValue, 44, dh));
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             Assert.Equal(5, dh.Count);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
@@ -47,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
                 drs.Add(producer.ProduceAsync(partitionedTopic, null, 0, 0, null, 0, 0));
                 drs.Add(producer.ProduceAsync(partitionedTopic, null, null));
                 Assert.Throws<ArgumentException>(() => { producer.ProduceAsync(partitionedTopic, null, 8, 100, null, -33, int.MaxValue); });
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             for (int i=0; i<5; ++i)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 drs.Add(producer.ProduceAsync(partitionedTopic, key, 0, key.Length, val, 0, val.Length));
                 drs.Add(producer.ProduceAsync(partitionedTopic, key, val));
                 drs.Add(producer.ProduceAsync(partitionedTopic, key, 1, key.Length-1, val, 2, val.Length-2));
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             for (int i=0; i<5; ++i)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_DeliveryHandler.cs
@@ -73,7 +73,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.ProduceAsync(topic, "test key 1", "test val 1", 0, dh);
                 producer.ProduceAsync(topic, "test key 2", "test val 2", true, dh);
                 producer.ProduceAsync(topic, "test key 3", "test val 3", dh);
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             Assert.Equal(4, dh.Count);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_DeliveryHandler.cs
@@ -72,7 +72,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.ProduceAsync(topic, null, null, 0, dh);
                 producer.ProduceAsync(topic, null, null, true, dh);
                 producer.ProduceAsync(topic, null, null, dh);
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             Assert.Equal(4, dh.Count);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_Task.cs
@@ -45,7 +45,7 @@ namespace Confluent.Kafka.IntegrationTests
                 drs.Add(producer.ProduceAsync(partitionedTopic, null, null, 0));
                 drs.Add(producer.ProduceAsync(partitionedTopic, null, null, true));
                 drs.Add(producer.ProduceAsync(partitionedTopic, null, null));
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             for (int i=0; i<4; ++i)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Task.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
                 drs.Add(producer.ProduceAsync(partitionedTopic, "test key 1", "test val 1", 1));
                 drs.Add(producer.ProduceAsync(partitionedTopic, "test key 2", "test val 2", true));
                 drs.Add(producer.ProduceAsync(partitionedTopic, "test key 3", "test val 3"));
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             for (int i=0; i<4; ++i)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -87,7 +87,7 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.NotEqual<long>(result.Offset, Offset.Invalid);
             Assert.Equal(TimestampType.CreateTime, result.Timestamp.Type);
             Assert.True(Math.Abs((DateTime.UtcNow - result.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
-            producer.Flush();
+            producer.Flush(TimeSpan.FromSeconds(10));
             return result;
         }
     }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -43,7 +43,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
                 dr = producer.ProduceAsync(topic, null, testString).Result;
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
 
                 var queryOffsets = producer.QueryWatermarkOffsets(new TopicPartition(topic, 0));
                 Assert.NotEqual(queryOffsets.Low, Offset.Invalid);

--- a/test/Confluent.Kafka.IntegrationTests/Util.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Util.cs
@@ -62,7 +62,7 @@ namespace Confluent.Kafka.IntegrationTests
                     Assert.NotEqual<long>(dr.Offset, Offset.Invalid);
                 }
 
-                producer.Flush();
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             return firstDeliveryReport.TopicPartitionOffset;

--- a/test/Confluent.Kafka.VerifiableClient/Program.cs
+++ b/test/Confluent.Kafka.VerifiableClient/Program.cs
@@ -266,7 +266,7 @@ namespace Confluent.Kafka.VerifiableClient
             ProduceTimer.Dispose();
 
             Dbg("Flushing Producer");
-            var remain = Handle.Flush(10000);
+            var remain = Handle.Flush(TimeSpan.FromSeconds(10));
             Dbg($"{remain} messages remain in queue after flush");
 
             // Explicitly handle dispose to catch hang-on-dispose errors


### PR DESCRIPTION
@treziac @edenhill @ewencp 

People who use variants of these methods with an infinite timeout usually don't realize they can't cancel out of them or even that they generally might want to - better if they don't exist.

Actually we should add variants that take a `CancellationToken` as well, but that can happen in a latter PR.
