### PR TITLE
Fix" Too many open files" in travis osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
     mono: none
     env: DOTNETCORE=1
 
+before_install:
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ulimit -n 1024 ; fi
+
 install:
    - dotnet restore
 


### PR DESCRIPTION
Now that curl is fixed on travis-osx for .net core, there shouldn't be any more random error on build