### PR TITLE
reworking serialization API for schema registry support

### DIFF
--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -31,9 +31,13 @@ namespace Confluent.Kafka.Examples.SimpleProducer
             string brokerList = args[0];
             string topicName = args[1];
 
-            var config = new Dictionary<string, object> { { "bootstrap.servers", brokerList } };
+            var config = new Dictionary<string, object> 
+            { 
+                { "bootstrap.servers", brokerList },
+                { "string.serializer.encoding.key", "UTF8" }
+            };
 
-            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(Encoding.UTF8)))
+            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(config)))
             {
                 Console.WriteLine($"{producer.Name} producing on {topicName}. q to exit.");
 

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -65,8 +65,6 @@ namespace Confluent.Kafka
             KeyDeserializer = keyDeserializer;
             ValueDeserializer = valueDeserializer;
 
-            // TODO: allow deserializers to be set in the producer config IEnumerable<KeyValuePair<string, object>>.
-
             if (KeyDeserializer == null)
             {
                 if (typeof(TKey) != typeof(Null))
@@ -87,7 +85,12 @@ namespace Confluent.Kafka
                 ValueDeserializer = (IDeserializer<TValue>)new NullDeserializer();
             }
 
-            consumer = new Consumer(config);
+            consumer = new Consumer(
+                config.Where(item => 
+                    !keyDeserializer.Configuration.Select(c => c.Key).Contains(item.Key) &&
+                    !valueDeserializer.Configuration.Select(c => c.Key).Contains(item.Key)
+                )
+            );
 
             consumer.OnConsumeError += (sender, msg) 
                 => OnConsumeError?.Invoke(this, msg);

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -855,8 +855,8 @@ namespace Confluent.Kafka
         private Task<Message<TKey, TValue>> Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull)
         {
             var handler = new TypedTaskDeliveryHandlerShim(key, val);
-            var keyBytes = KeySerializer?.Serialize(key);
-            var valBytes = ValueSerializer?.Serialize(val);
+            var keyBytes = KeySerializer?.Serialize(topic, key);
+            var valBytes = ValueSerializer?.Serialize(topic, val);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
             return handler.Task;
         }
@@ -908,8 +908,8 @@ namespace Confluent.Kafka
         private void Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull, IDeliveryHandler<TKey, TValue> deliveryHandler)
         {
             var handler = new TypedDeliveryHandlerShim(key, val, deliveryHandler);
-            var keyBytes = KeySerializer?.Serialize(key);
-            var valBytes = ValueSerializer?.Serialize(val);
+            var keyBytes = KeySerializer?.Serialize(topic, key);
+            var valBytes = ValueSerializer?.Serialize(topic, val);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
         }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -803,8 +803,6 @@ namespace Confluent.Kafka
             KeySerializer = keySerializer;
             ValueSerializer = valueSerializer;
 
-            // TODO: allow serializers to be set in the producer config IEnumerable<KeyValuePair<string, object>>.
-
             if (KeySerializer == null)
             {
                 if (typeof(TKey) != typeof(Null))
@@ -855,8 +853,8 @@ namespace Confluent.Kafka
         private Task<Message<TKey, TValue>> Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull)
         {
             var handler = new TypedTaskDeliveryHandlerShim(key, val);
-            var keyBytes = KeySerializer?.Serialize(topic, key);
-            var valBytes = ValueSerializer?.Serialize(topic, val);
+            var keyBytes = KeySerializer?.Serialize(topic, key, true);
+            var valBytes = ValueSerializer?.Serialize(topic, val, false);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
             return handler.Task;
         }
@@ -908,8 +906,8 @@ namespace Confluent.Kafka
         private void Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull, IDeliveryHandler<TKey, TValue> deliveryHandler)
         {
             var handler = new TypedDeliveryHandlerShim(key, val, deliveryHandler);
-            var keyBytes = KeySerializer?.Serialize(topic, key);
-            var valBytes = ValueSerializer?.Serialize(topic, val);
+            var keyBytes = KeySerializer?.Serialize(topic, key, true);
+            var valBytes = ValueSerializer?.Serialize(topic, val, false);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
         }
 
@@ -967,7 +965,15 @@ namespace Confluent.Kafka
             ISerializer<TValue> valueSerializer,
             bool manualPoll, bool disableDeliveryReports)
         {
-            producer = new Producer(config, manualPoll, disableDeliveryReports);
+            producer = new Producer(
+                config.Where(item => 
+                    !keySerializer.Configuration.Select(ci => ci.Key).Contains(item.Key) &&
+                    !valueSerializer.Configuration.Select(ci => ci.Key).Contains(item.Key)
+                ), 
+                manualPoll, 
+                disableDeliveryReports
+            );
+
             serializingProducer = producer.GetSerializingProducer(keySerializer, valueSerializer);
         }
 

--- a/src/Confluent.Kafka/Serialization/Extensions/Message.cs
+++ b/src/Confluent.Kafka/Serialization/Extensions/Message.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                key = keyDeserializer.Deserialize(message.Key);
+                key = keyDeserializer.Deserialize(message.Topic, message.Key);
             }
             catch (Exception ex)
             {
@@ -55,7 +55,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                val = valueDeserializer.Deserialize(message.Value);
+                val = valueDeserializer.Deserialize(message.Topic, message.Value);
             }
             catch (Exception ex)
             {

--- a/src/Confluent.Kafka/Serialization/Extensions/Message.cs
+++ b/src/Confluent.Kafka/Serialization/Extensions/Message.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                key = keyDeserializer.Deserialize(message.Topic, message.Key);
+                key = keyDeserializer.Deserialize(message.Topic, message.Key, true);
             }
             catch (Exception ex)
             {
@@ -55,7 +55,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                val = valueDeserializer.Deserialize(message.Topic, message.Value);
+                val = valueDeserializer.Deserialize(message.Topic, message.Value, false);
             }
             catch (Exception ex)
             {

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -22,7 +24,7 @@ namespace Confluent.Kafka.Serialization
     ///     Implement this interface to define a deserializer 
     ///     for a particular type T.
     /// </summary>
-    public interface IDeserializer<T> : IDisposable
+    public interface IDeserializer<T>
     {
         /// <summary>
         ///     Deserialize a byte array to an instance of
@@ -35,9 +37,18 @@ namespace Confluent.Kafka.Serialization
         ///     The serialized representation of an instance
         ///     of type T to deserialize.
         /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
         /// <returns>
         ///     The deserialized value.
         /// </returns>
-        T Deserialize(string topic, byte[] data);
+        T Deserialize(string topic, byte[] data, bool isKey);
+
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, object>> Configuration { get; }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -26,6 +26,9 @@ namespace Confluent.Kafka.Serialization
         ///     Deserialize a byte array to an instance of
         ///     type T.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic associated wih the data.
+        /// </param>
         /// <param name="data">
         ///     The serialized representation of an instance
         ///     of type T to deserialize.
@@ -33,6 +36,6 @@ namespace Confluent.Kafka.Serialization
         /// <returns>
         ///     The deserialized value.
         /// </returns>
-        T Deserialize(byte[] data);
+        T Deserialize(string topic, byte[] data);
     }
 }

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -14,13 +14,15 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
     ///     Implement this interface to define a deserializer 
     ///     for a particular type T.
     /// </summary>
-    public interface IDeserializer<T>
+    public interface IDeserializer<T> : IDisposable
     {
         /// <summary>
         ///     Deserialize a byte array to an instance of

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -22,7 +24,7 @@ namespace Confluent.Kafka.Serialization
     ///     Implement this interface to define a serializer 
     ///     for a particular type T.
     /// </summary>
-    public interface ISerializer<T> : IDisposable
+    public interface ISerializer<T>
     {
         /// <summary>
         ///     Serialize an instance of type T to a byte array.
@@ -33,9 +35,18 @@ namespace Confluent.Kafka.Serialization
         /// <param name="data">
         ///     The object to serialize.
         /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
         /// <returns>
         ///     <paramref name="data" /> serialized as a byte array.
         /// </returns>
-        byte[] Serialize(string topic, T data);
+        byte[] Serialize(string topic, T data, bool isKey);
+
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, object>> Configuration { get; }
     }
 }

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -25,12 +25,15 @@ namespace Confluent.Kafka.Serialization
         /// <summary>
         ///     Serialize an instance of type T to a byte array.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic associated wih the data.
+        /// </param>
         /// <param name="data">
-        ///     The object to serialize
+        ///     The object to serialize.
         /// </param>
         /// <returns>
         ///     <paramref name="data" /> serialized as a byte array.
         /// </returns>
-        byte[] Serialize(T data);
+        byte[] Serialize(string topic, T data);
     }
 }

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -14,13 +14,15 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
     ///     Implement this interface to define a serializer 
     ///     for a particular type T.
     /// </summary>
-    public interface ISerializer<T>
+    public interface ISerializer<T> : IDisposable
     {
         /// <summary>
         ///     Serialize an instance of type T to a byte array.

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -39,5 +39,10 @@ namespace Confluent.Kafka.Serialization
                 (((int)data[2]) << 8) |
                 (int)data[3];
         }
+
+        int IDeserializer<int>.Deserialize(string topic, byte[] data)
+        {
+            return Deserialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -44,5 +46,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Deserialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class IntDeserializer : IDeserializer<int>
     {
-        /// <summary>
-        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int32"/> value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     A byte array containing the serialized <see cref="System.Int32"/> value (big endian encoding).
-        /// </param>
-        /// <returns>
-        ///     The deserialized <see cref="System.Int32"/> value.
-        /// </returns>
-        public int Deserialize(byte[] data)
+        private int Deserialize(byte[] data)
         {
             // network byte order -> big endian -> most significant byte in the smallest address.
             return
@@ -42,12 +35,32 @@ namespace Confluent.Kafka.Serialization
                 (int)data[3];
         }
 
-        int IDeserializer<int>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int32"/> value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized <see cref="System.Int32"/> value (big endian encoding).
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The deserialized <see cref="System.Int32"/> value.
+        /// </returns>
+        public int Deserialize(string topic, byte[] data, bool isKey)
         {
             return Deserialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
+   
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -43,5 +43,10 @@ namespace Confluent.Kafka.Serialization
             result[3] = (byte)val; // & 0xff;
             return result;
         }
+
+        byte[] ISerializer<int>.Serialize(string topic, int data)
+        {
+            return Serialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -43,10 +45,13 @@ namespace Confluent.Kafka.Serialization
             result[3] = (byte)val; // & 0xff;
             return result;
         }
-
+        
         byte[] ISerializer<int>.Serialize(string topic, int data)
         {
             return Serialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class IntSerializer : ISerializer<int>
     {
-        /// <summary>
-        ///     Serializes the specified <see cref="System.Int32"/> value to a byte array of length 4. Byte order is big endian (network byte order).
-        /// </summary>
-        /// <param name="val">
-        ///     The <see cref="System.Int32"/> value to serialize.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="System.Int32"/> value <paramref name="val" /> encoded as a byte array of length 8 (network byte order).
-        /// </returns>
-        public byte[] Serialize(int val)
+        private byte[] Serialize(int val)
         {
             var result = new byte[4]; // int is always 32 bits on .NET.
             // network byte order -> big endian -> most significant byte in the smallest address.
@@ -46,12 +39,31 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
         
-        byte[] ISerializer<int>.Serialize(string topic, int data)
+        /// <summary>
+        ///     Serializes the specified <see cref="System.Int32"/> value to a byte array of length 4. Byte order is big endian (network byte order).
+        /// </summary>
+        /// <param name="data">
+        ///     The <see cref="System.Int32"/> value to serialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="System.Int32"/> value <paramref name="data" /> encoded as a byte array of length 8 (network byte order).
+        /// </returns>
+        public byte[] Serialize(string topic, int data, bool isKey)
         {
             return Serialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -61,5 +61,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Deserialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -56,5 +56,10 @@ namespace Confluent.Kafka.Serialization
                 (data[7]);
             return result;
         }
+        
+        long IDeserializer<long>.Deserialize(string topic, byte[] data)
+        {
+            return Deserialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -14,8 +14,9 @@
 //
 // Refer to LICENSE for more information.
 
-
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -24,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class LongDeserializer : IDeserializer<long>
     {
-        /// <summary>
-        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int64"/> value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     A byte array containing the serialized <see cref="System.Int64"/> value (big endian encoding)
-        /// </param>
-        /// <returns>
-        ///     The deserialized <see cref="System.Int64"/> value.
-        /// </returns>
-        public long Deserialize(byte[] data)
+        private long Deserialize(byte[] data)
         {
             if (data == null)
             {
@@ -57,12 +49,31 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
         
-        long IDeserializer<long>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int64"/> value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized <see cref="System.Int64"/> value (big endian encoding)
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The deserialized <see cref="System.Int64"/> value.
+        /// </returns>
+        public long Deserialize(string topic, byte[] data, bool isKey)
         {
             return Deserialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class LongSerializer : ISerializer<long>
     {
-        /// <summary>
-        ///     Serializes the specified <see cref="System.Int64"/> value to a byte array of length 8. Byte order is big endian (network byte order).
-        /// </summary>
-        /// <param name="val">
-        ///     The <see cref="System.Int64"/> value to serialize.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="System.Int64"/> value <paramref name="val" /> encoded as a byte array of length 8 (network byte order).
-        /// </returns>
-        public byte[] Serialize(long val)
+        private byte[] Serialize(long val)
         {
             var result = new byte[8];
             result[0] = (byte)(val >> 56);
@@ -46,12 +39,31 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
         
-        byte[] ISerializer<long>.Serialize(string topic, long data)
+        /// <summary>
+        ///     Serializes the specified <see cref="System.Int64"/> value to a byte array of length 8. Byte order is big endian (network byte order).
+        /// </summary>
+        /// <param name="data">
+        ///     The <see cref="System.Int64"/> value to serialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="System.Int64"/> value <paramref name="data" /> encoded as a byte array of length 8 (network byte order).
+        /// </returns>
+        public byte[] Serialize(string topic, long data, bool isKey)
         {
             return Serialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -43,5 +43,10 @@ namespace Confluent.Kafka.Serialization
             result[7] = (byte)val;
             return result;
         }
+        
+        byte[] ISerializer<long>.Serialize(string topic, long data)
+        {
+            return Serialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -48,5 +50,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Serialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class NullDeserializer : IDeserializer<Null>
     {
-        /// <summary>
-        ///     'Deserializes' a null value to a null value.
-        /// </summary>
-        /// <param name="data">
-        ///     The data to deserialize (must be null).
-        /// </param>
-        /// <returns>
-        ///     null
-        /// </returns>
-        public Null Deserialize(byte[] data)
+        private Null Deserialize(byte[] data)
         {
             if (data != null)
             {
@@ -42,12 +35,31 @@ namespace Confluent.Kafka.Serialization
             return null;
         }
 
-        Null IDeserializer<Null>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     'Deserializes' a null value to a null value.
+        /// </summary>
+        /// <param name="data">
+        ///     The data to deserialize (must be null).
+        /// </param>        
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     null
+        /// </returns>
+        public Null Deserialize(string topic, byte[] data, bool isKey)
         {
             return null;
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -39,5 +39,10 @@ namespace Confluent.Kafka.Serialization
 
             return null;
         }
+
+        Null IDeserializer<Null>.Deserialize(string topic, byte[] data)
+        {
+            return null;
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -44,5 +46,8 @@ namespace Confluent.Kafka.Serialization
         {
             return null;
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -36,5 +38,8 @@ namespace Confluent.Kafka.Serialization
         {
             return null;
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -31,5 +31,10 @@ namespace Confluent.Kafka.Serialization
         {
             return null;
         }
+
+        byte[] ISerializer<Null>.Serialize(string topic, Null data)
+        {
+            return null;
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,23 +25,33 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class NullSerializer : ISerializer<Null>
     {
-        /// <param name="val">
+        private byte[] Serialize(Null val)
+        {
+            return null;
+        }
+
+        /// <param name="data">
         ///     Can only be null (the <see cref="Null"/> class cannot be instantiated).
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
         /// </param>
         /// <returns>
         ///     null
         /// </returns>
-        public byte[] Serialize(Null val)
+        public byte[] Serialize(string topic, Null data, bool isKey)
         {
             return null;
         }
 
-        byte[] ISerializer<Null>.Serialize(string topic, Null data)
-        {
-            return null;
-        }
-
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -53,5 +53,10 @@ namespace Confluent.Kafka.Serialization
             }
             return encoding.GetString(data);
         }
+
+        string IDeserializer<string>.Deserialize(string topic, byte[] data)
+        {
+            return Deserialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using System.Text;
 
 namespace Confluent.Kafka.Serialization
@@ -58,5 +59,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Deserialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Text;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -37,16 +39,7 @@ namespace Confluent.Kafka.Serialization
             this.encoding = encoding;
         }
 
-        /// <summary>
-        ///     Deserializes a string value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     The data to deserialize.
-        /// </param>
-        /// <returns>
-        ///     <paramref name="data" /> deserialized to a string (or null if data is null).
-        /// </returns>
-        public string Deserialize(byte[] data)
+        private string Deserialize(byte[] data)
         {
             if (data == null)
             {
@@ -55,12 +48,31 @@ namespace Confluent.Kafka.Serialization
             return encoding.GetString(data);
         }
 
-        string IDeserializer<string>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     Deserializes a string value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     The data to deserialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     <paramref name="data" /> deserialized to a string (or null if data is null).
+        /// </returns>
+        public string Deserialize(string topic, byte[] data, bool isKey)
         {
             return Deserialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Text;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -37,16 +39,7 @@ namespace Confluent.Kafka.Serialization
             this.encoding = encoding;
         }
 
-        /// <summary>
-        ///     Encodes a string value in a byte array.
-        /// </summary>
-        /// <param name="val">
-        ///     The string value to serialize.
-        /// </param>
-        /// <returns>
-        ///     <paramref name="val" /> encoded in a byte array (or null if <paramref name="val" /> is null).
-        /// </returns>
-        public byte[] Serialize(string val)
+        private byte[] Serialize(string val)
         {
             if (val == null)
             {
@@ -55,12 +48,31 @@ namespace Confluent.Kafka.Serialization
             return encoding.GetBytes(val);
         }
 
-        byte[] ISerializer<string>.Serialize(string topic, string data)
+        /// <summary>
+        ///     Encodes a string value in a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     The string value to serialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     <paramref name="data" /> encoded in a byte array (or null if <paramref name="data" /> is null).
+        /// </returns>
+        public byte[] Serialize(string topic, string data, bool isKey)
         {
             return Serialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using System.Text;
 
 namespace Confluent.Kafka.Serialization
@@ -52,6 +53,11 @@ namespace Confluent.Kafka.Serialization
                 return null;
             }
             return encoding.GetBytes(val);
+        }
+
+        byte[] ISerializer<string>.Serialize(string topic, string data)
+        {
+            return Serialize(data);
         }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -59,5 +59,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Serialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/IntSerde.cs
+++ b/test/Confluent.Kafka.UnitTests/IntSerde.cs
@@ -75,6 +75,32 @@ namespace Confluent.Kafka.Tests
                 Assert.Equal(theInt, reconstructed);
             }
         }
-    }
 
+        [Fact]
+        public void ExplicitSerializationWorks()
+        {
+            foreach(string topic in new[] {null, "", "topic"})
+            {
+                var serializer = new IntSerializer();
+                var bytesImplicit = serializer.Serialize(42);
+                var bytesExplicit = ((ISerializer<int>)serializer).Serialize(topic, 42);
+
+                Assert.Equal(bytesImplicit, bytesExplicit);
+            }
+        }
+
+        [Fact]
+        public void ExplicitDeserializationWorks()
+        {
+            var byte42 = new IntSerializer().Serialize(42);
+
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var deserializer = new IntDeserializer();
+                var deconstructExplicit = ((IDeserializer<int>)deserializer).Deserialize(topic, byte42);
+
+                Assert.Equal(42, deconstructExplicit);
+            }
+        }
+    }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -51,6 +51,33 @@ namespace Confluent.Kafka.UnitTests
             Assert.ThrowsAny<ArgumentException>(() => new LongDeserializer().Deserialize(new byte[9]));
         }
 
+        [Fact]
+        public void ExplicitSerializationWork()
+        {
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var serializer = new LongSerializer();
+                var bytesImplicit = serializer.Serialize(42);
+                var bytesExplicit = ((ISerializer<long>)serializer).Serialize(topic, 42);
+
+                Assert.Equal(bytesImplicit, bytesExplicit);
+            }
+        }
+
+        [Fact]
+        public void ExplicitDeserializationWorks()
+        {
+            var byte42 = new LongSerializer().Serialize(42);
+
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var deserializer = new LongDeserializer();
+                var deconstructExplicit = ((IDeserializer<long>)deserializer).Deserialize(topic, byte42);
+
+                Assert.Equal(42, deconstructExplicit);
+            }
+        }
+
         public static IEnumerable<object[]> TestData()
         {
             long[] testData = new long[]

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -33,5 +33,33 @@ namespace Confluent.Kafka.Serialization.Tests
             // TODO: check some serialize / deserialize operations that are not expected to work, including some
             //       cases where Deserialize can be expected to throw an exception.
         }
+
+
+        [Fact]
+        public void ExplicitSerializationWork()
+        {
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var serializer = new StringSerializer(Encoding.UTF8);
+                var bytesImplicit = serializer.Serialize("42");
+                var bytesExplicit = ((ISerializer<string>)serializer).Serialize(topic, "42");
+
+                Assert.Equal(bytesImplicit, bytesExplicit);
+            }
+        }
+
+        [Fact]
+        public void ExplicitDeserializationWorks()
+        {
+            var byte42 = new StringSerializer(Encoding.UTF8).Serialize("42");
+
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var deserializer = new StringDeserializer(Encoding.UTF8);
+                var deconstructExplicit = ((IDeserializer<string>)deserializer).Deserialize(topic, byte42);
+
+                Assert.Equal("42", deconstructExplicit);
+            }
+        }
     }
 }


### PR DESCRIPTION
this is a continuation of @treziac 's #129. 

I think I finally have a definite opinion on changes that should be made to (de)serializers for schema registry support (a new idea).

1. configuration works differently to java. the idea is a (de)serializer can take the configuration dict in their constructors, and the constructor of Producer/Consumer then ignores any properties used by the serializers. I also added capability for key and value serializers to be configured separately. we can update the string, int and long serializers to also optionally be configured from the main config dict. we can do the same architectural pattern for custom partitioners (allow them to be configured). 
2. no `IDisposable` - I don't see when this would be necessary. Only suggested it because it's there in java - what am i missing? we can have this if needed, but this raises questions of ownership - it's most convenient if the `Producer` and `Consumer` take ownership of the (de)serializers, and this is not without precedent in dotnet (see StreamReader), but it's a pattern that can cause confusion (in general, though probably not in our case) and best avoided. 
3. actual serializers and custom partitioner classes are not going in the configuration dict - they will be only arguments to the constructor. they can however be parameterized by values from the config. I think this is an optimal balance.
4. no explicit implementation of interfaces (for reasons noted in #129).

to use: 

```
using (var producer = new Producer<string, string>(config, new StringSerializer(config), new AvroSerializer(config)))
{
}
```

(the old way of configuring string serializer will remain as well).

note: WIP tests not updated, just putting the code changes out for comment. 
