### PR TITLE
serialization API rework

### DIFF
--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.Examples.SimpleProducer
             var config = new Dictionary<string, object> 
             { 
                 { "bootstrap.servers", brokerList },
-                { "dotnet.key.string.serializer.encoding", "UTF8" }
+                { "dotnet.string.serializer.encoding.value", "UTF8" }
             };
 
             using (var producer = new Producer<Null, string>(config, null, new StringSerializer()))

--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -31,13 +31,9 @@ namespace Confluent.Kafka.Examples.SimpleProducer
             string brokerList = args[0];
             string topicName = args[1];
 
-            var config = new Dictionary<string, object> 
-            { 
-                { "bootstrap.servers", brokerList },
-                { "dotnet.string.serializer.encoding.value", "UTF8" }
-            };
+            var config = new Dictionary<string, object> { { "bootstrap.servers", brokerList } };
 
-            using (var producer = new Producer<Null, string>(config, null, new StringSerializer()))
+            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(Encoding.UTF8)))
             {
                 Console.WriteLine($"{producer.Name} producing on {topicName}. q to exit.");
 

--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -31,9 +31,13 @@ namespace Confluent.Kafka.Examples.SimpleProducer
             string brokerList = args[0];
             string topicName = args[1];
 
-            var config = new Dictionary<string, object> { { "bootstrap.servers", brokerList } };
+            var config = new Dictionary<string, object> 
+            { 
+                { "bootstrap.servers", brokerList },
+                { "string.serializer.encoding.key", "UTF8" }
+            };
 
-            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(Encoding.UTF8)))
+            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(config)))
             {
                 Console.WriteLine($"{producer.Name} producing on {topicName}. q to exit.");
 

--- a/examples/SimpleProducer/Program.cs
+++ b/examples/SimpleProducer/Program.cs
@@ -34,10 +34,10 @@ namespace Confluent.Kafka.Examples.SimpleProducer
             var config = new Dictionary<string, object> 
             { 
                 { "bootstrap.servers", brokerList },
-                { "string.serializer.encoding.key", "UTF8" }
+                { "dotnet.key.string.serializer.encoding", "UTF8" }
             };
 
-            using (var producer = new Producer<Null, string>(config, null, new StringSerializer(config)))
+            using (var producer = new Producer<Null, string>(config, null, new StringSerializer()))
             {
                 Console.WriteLine($"{producer.Name} producing on {topicName}. q to exit.");
 

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -90,8 +90,8 @@ namespace Confluent.Kafka
 
             consumer = new Consumer(
                 config.Where(item => 
-                    adjustedConfig1.Count(ci => ci.Key == item.Key) > 0 &&
-                    adjustedConfig2.Count(ci => ci.Key == item.Key) > 0
+                    adjustedConfig1.Any(ci => ci.Key == item.Key) &&
+                    adjustedConfig2.Any(ci => ci.Key == item.Key)
                 )
             );
 

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -65,8 +65,6 @@ namespace Confluent.Kafka
             KeyDeserializer = keyDeserializer;
             ValueDeserializer = valueDeserializer;
 
-            // TODO: allow deserializers to be set in the producer config IEnumerable<KeyValuePair<string, object>>.
-
             if (KeyDeserializer == null)
             {
                 if (typeof(TKey) != typeof(Null))
@@ -87,7 +85,12 @@ namespace Confluent.Kafka
                 ValueDeserializer = (IDeserializer<TValue>)new NullDeserializer();
             }
 
-            consumer = new Consumer(config);
+            consumer = new Consumer(
+                config.Where(item => 
+                    !keyDeserializer.Configuration.Select(c => c.Key).Contains(item.Key) &&
+                    !valueDeserializer.Configuration.Select(c => c.Key).Contains(item.Key)
+                )
+            );
 
             consumer.OnConsumeError += (sender, msg) 
                 => OnConsumeError?.Invoke(this, msg);

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -85,15 +85,15 @@ namespace Confluent.Kafka
                 ValueDeserializer = (IDeserializer<TValue>)new NullDeserializer();
             }
 
-            var adjustedConfig1 = KeyDeserializer.Configure(config, true);
-            var adjustedConfig2 = ValueDeserializer.Configure(config, false);
+            var configWithoutKeyDeserializerProperties = KeyDeserializer.Configure(config, true);
+            var configWithoutValueDeserializerProperties = ValueDeserializer.Configure(config, false);
 
-            consumer = new Consumer(
-                config.Where(item => 
-                    adjustedConfig1.Any(ci => ci.Key == item.Key) &&
-                    adjustedConfig2.Any(ci => ci.Key == item.Key)
-                )
+            var configWithoutDeserializerProperties = config.Where(item => 
+                configWithoutKeyDeserializerProperties.Any(ci => ci.Key == item.Key) &&
+                configWithoutValueDeserializerProperties.Any(ci => ci.Key == item.Key)
             );
+
+            consumer = new Consumer(configWithoutDeserializerProperties);
 
             consumer.OnConsumeError += (sender, msg) 
                 => OnConsumeError?.Invoke(this, msg);

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -85,10 +85,13 @@ namespace Confluent.Kafka
                 ValueDeserializer = (IDeserializer<TValue>)new NullDeserializer();
             }
 
+            var adjustedConfig1 = KeyDeserializer.Configure(config, true);
+            var adjustedConfig2 = ValueDeserializer.Configure(config, false);
+
             consumer = new Consumer(
                 config.Where(item => 
-                    !keyDeserializer.Configuration.Select(c => c.Key).Contains(item.Key) &&
-                    !valueDeserializer.Configuration.Select(c => c.Key).Contains(item.Key)
+                    adjustedConfig1.Count(ci => ci.Key == item.Key) > 0 &&
+                    adjustedConfig2.Count(ci => ci.Key == item.Key) > 0
                 )
             );
 

--- a/src/Confluent.Kafka/Internal/Extensions/String.cs
+++ b/src/Confluent.Kafka/Internal/Extensions/String.cs
@@ -23,9 +23,9 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Extension methods for the <see cref="String"/> class.
     /// </summary>
-    public static class StringExtensions
+    internal static class StringExtensions
     {
-        internal static Encoding AsEncoding(this string encodingName) 
+        internal static Encoding ToEncoding(this string encodingName) 
         {
             switch (encodingName)
             {
@@ -39,7 +39,7 @@ namespace Confluent.Kafka
                     return Encoding.ASCII;
                 case "Unicode":
                     return Encoding.Unicode;
-                case "BigEndignUnicode":
+                case "BigEndianUnicode":
                     return Encoding.BigEndianUnicode;
                 default:
                     throw new ArgumentException("unknown string encoding: " + encodingName);

--- a/src/Confluent.Kafka/Internal/Extensions/String.cs
+++ b/src/Confluent.Kafka/Internal/Extensions/String.cs
@@ -27,20 +27,17 @@ namespace Confluent.Kafka
     {
         internal static Encoding ToEncoding(this string encodingName) 
         {
-            switch (encodingName)
+            switch (encodingName.ToLower())
             {
-                case "UTF8":
+                // these names match up with static properties of the Encoding class
+                case "utf8":
                     return Encoding.UTF8;
-                case "UTF7":
+                case "utf7":
                     return Encoding.UTF7;
-                case "UTF32":
+                case "utf32":
                     return Encoding.UTF32;
-                case "ASCII":
+                case "ascii":
                     return Encoding.ASCII;
-                case "Unicode":
-                    return Encoding.Unicode;
-                case "BigEndianUnicode":
-                    return Encoding.BigEndianUnicode;
                 default:
                     return Encoding.GetEncoding(encodingName);
             }

--- a/src/Confluent.Kafka/Internal/Extensions/String.cs
+++ b/src/Confluent.Kafka/Internal/Extensions/String.cs
@@ -42,7 +42,7 @@ namespace Confluent.Kafka
                 case "BigEndianUnicode":
                     return Encoding.BigEndianUnicode;
                 default:
-                    throw new ArgumentException("unknown string encoding: " + encodingName);
+                    return Encoding.GetEncoding(encodingName);
             }
         }
     }

--- a/src/Confluent.Kafka/Internal/Extensions/String.cs
+++ b/src/Confluent.Kafka/Internal/Extensions/String.cs
@@ -1,0 +1,49 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Text;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Extension methods for the <see cref="String"/> class.
+    /// </summary>
+    public static class StringExtensions
+    {
+        internal static Encoding AsEncoding(this string encodingName) 
+        {
+            switch (encodingName)
+            {
+                case "UTF8":
+                    return Encoding.UTF8;
+                case "UTF7":
+                    return Encoding.UTF7;
+                case "UTF32":
+                    return Encoding.UTF32;
+                case "ASCII":
+                    return Encoding.ASCII;
+                case "Unicode":
+                    return Encoding.Unicode;
+                case "BigEndignUnicode":
+                    return Encoding.BigEndianUnicode;
+                default:
+                    throw new ArgumentException("unknown string encoding: " + encodingName);
+            }
+        }
+    }
+}

--- a/src/Confluent.Kafka/Internal/Extensions/TimeSpan.cs
+++ b/src/Confluent.Kafka/Internal/Extensions/TimeSpan.cs
@@ -22,7 +22,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Extension methods for the <see cref="TimeSpan"/> class.
     /// </summary>
-    public static class TimeSpanExtensions
+    internal static class TimeSpanExtensions
     {
         /// <summary>
         ///     Converts the TimeSpan value <paramref name="timespan" /> to an integer number of milliseconds.

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -855,8 +855,8 @@ namespace Confluent.Kafka
         private Task<Message<TKey, TValue>> Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull)
         {
             var handler = new TypedTaskDeliveryHandlerShim(key, val);
-            var keyBytes = KeySerializer?.Serialize(key);
-            var valBytes = ValueSerializer?.Serialize(val);
+            var keyBytes = KeySerializer?.Serialize(topic, key);
+            var valBytes = ValueSerializer?.Serialize(topic, val);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
             return handler.Task;
         }
@@ -908,8 +908,8 @@ namespace Confluent.Kafka
         private void Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull, IDeliveryHandler<TKey, TValue> deliveryHandler)
         {
             var handler = new TypedDeliveryHandlerShim(key, val, deliveryHandler);
-            var keyBytes = KeySerializer?.Serialize(key);
-            var valBytes = ValueSerializer?.Serialize(val);
+            var keyBytes = KeySerializer?.Serialize(topic, key);
+            var valBytes = ValueSerializer?.Serialize(topic, val);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
         }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -965,14 +965,16 @@ namespace Confluent.Kafka
             ISerializer<TValue> valueSerializer,
             bool manualPoll, bool disableDeliveryReports)
         {
-            var adjustedConfig1 = keySerializer.Configure(config, true);
-            var adjustedConfig2 = valueSerializer.Configure(config, false);
+            var configWithoutKeySerializerProperties = KeySerializer.Configure(config, true);
+            var configWithoutValueSerializerProperties = ValueSerializer.Configure(config, false);
+
+            var configWithoutSerializerProperties = config.Where(item => 
+                configWithoutKeySerializerProperties.Any(ci => ci.Key == item.Key) &&
+                configWithoutValueSerializerProperties.Any(ci => ci.Key == item.Key)
+            );
 
             producer = new Producer(
-                config.Where(item => 
-                    adjustedConfig1.Any(ci => ci.Key == item.Key) &&
-                    adjustedConfig2.Any(ci => ci.Key == item.Key)
-                ), 
+                configWithoutSerializerProperties, 
                 manualPoll, 
                 disableDeliveryReports
             );

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -803,8 +803,6 @@ namespace Confluent.Kafka
             KeySerializer = keySerializer;
             ValueSerializer = valueSerializer;
 
-            // TODO: allow serializers to be set in the producer config IEnumerable<KeyValuePair<string, object>>.
-
             if (KeySerializer == null)
             {
                 if (typeof(TKey) != typeof(Null))
@@ -855,8 +853,8 @@ namespace Confluent.Kafka
         private Task<Message<TKey, TValue>> Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull)
         {
             var handler = new TypedTaskDeliveryHandlerShim(key, val);
-            var keyBytes = KeySerializer?.Serialize(topic, key);
-            var valBytes = ValueSerializer?.Serialize(topic, val);
+            var keyBytes = KeySerializer?.Serialize(topic, key, true);
+            var valBytes = ValueSerializer?.Serialize(topic, val, false);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
             return handler.Task;
         }
@@ -908,8 +906,8 @@ namespace Confluent.Kafka
         private void Produce(string topic, TKey key, TValue val, DateTime? timestamp, int partition, bool blockIfQueueFull, IDeliveryHandler<TKey, TValue> deliveryHandler)
         {
             var handler = new TypedDeliveryHandlerShim(key, val, deliveryHandler);
-            var keyBytes = KeySerializer?.Serialize(topic, key);
-            var valBytes = ValueSerializer?.Serialize(topic, val);
+            var keyBytes = KeySerializer?.Serialize(topic, key, true);
+            var valBytes = ValueSerializer?.Serialize(topic, val, false);
             producer.Produce(topic, valBytes, 0, valBytes == null ? 0 : valBytes.Length, keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, timestamp, partition, blockIfQueueFull, handler);
         }
 
@@ -967,7 +965,15 @@ namespace Confluent.Kafka
             ISerializer<TValue> valueSerializer,
             bool manualPoll, bool disableDeliveryReports)
         {
-            producer = new Producer(config, manualPoll, disableDeliveryReports);
+            producer = new Producer(
+                config.Where(item => 
+                    !keySerializer.Configuration.Select(ci => ci.Key).Contains(item.Key) &&
+                    !valueSerializer.Configuration.Select(ci => ci.Key).Contains(item.Key)
+                ), 
+                manualPoll, 
+                disableDeliveryReports
+            );
+
             serializingProducer = producer.GetSerializingProducer(keySerializer, valueSerializer);
         }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -970,8 +970,8 @@ namespace Confluent.Kafka
 
             producer = new Producer(
                 config.Where(item => 
-                    adjustedConfig1.Count(ci => ci.Key == item.Key) > 0 &&
-                    adjustedConfig2.Count(ci => ci.Key == item.Key) > 0
+                    adjustedConfig1.Any(ci => ci.Key == item.Key) &&
+                    adjustedConfig2.Any(ci => ci.Key == item.Key)
                 ), 
                 manualPoll, 
                 disableDeliveryReports

--- a/src/Confluent.Kafka/Serialization/Extensions/Message.cs
+++ b/src/Confluent.Kafka/Serialization/Extensions/Message.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                key = keyDeserializer.Deserialize(message.Key);
+                key = keyDeserializer.Deserialize(message.Topic, message.Key);
             }
             catch (Exception ex)
             {
@@ -55,7 +55,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                val = valueDeserializer.Deserialize(message.Value);
+                val = valueDeserializer.Deserialize(message.Topic, message.Value);
             }
             catch (Exception ex)
             {

--- a/src/Confluent.Kafka/Serialization/Extensions/Message.cs
+++ b/src/Confluent.Kafka/Serialization/Extensions/Message.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                key = keyDeserializer.Deserialize(message.Topic, message.Key, true);
+                key = keyDeserializer.Deserialize(message.Topic, message.Key);
             }
             catch (Exception ex)
             {
@@ -55,7 +55,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                val = valueDeserializer.Deserialize(message.Topic, message.Value, false);
+                val = valueDeserializer.Deserialize(message.Topic, message.Value);
             }
             catch (Exception ex)
             {

--- a/src/Confluent.Kafka/Serialization/Extensions/Message.cs
+++ b/src/Confluent.Kafka/Serialization/Extensions/Message.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                key = keyDeserializer.Deserialize(message.Topic, message.Key);
+                key = keyDeserializer.Deserialize(message.Topic, message.Key, true);
             }
             catch (Exception ex)
             {
@@ -55,7 +55,7 @@ namespace Confluent.Kafka.Serialization
 
             try
             {
-                val = valueDeserializer.Deserialize(message.Topic, message.Value);
+                val = valueDeserializer.Deserialize(message.Topic, message.Value, false);
             }
             catch (Exception ex)
             {

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -22,7 +24,7 @@ namespace Confluent.Kafka.Serialization
     ///     Implement this interface to define a deserializer 
     ///     for a particular type T.
     /// </summary>
-    public interface IDeserializer<T> : IDisposable
+    public interface IDeserializer<T>
     {
         /// <summary>
         ///     Deserialize a byte array to an instance of
@@ -35,9 +37,18 @@ namespace Confluent.Kafka.Serialization
         ///     The serialized representation of an instance
         ///     of type T to deserialize.
         /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
         /// <returns>
         ///     The deserialized value.
         /// </returns>
-        T Deserialize(string topic, byte[] data);
+        T Deserialize(string topic, byte[] data, bool isKey);
+
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, object>> Configuration { get; }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -42,19 +42,7 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         T Deserialize(string topic, byte[] data);
 
-        /// <summary>
-        ///     Configure the deserializer using relevant configuration parameter(s) in <paramref name="config" /> (if present).
-        /// </summary>
-        /// <param name="config">
-        ///     A collection containing configuration parameter(s) relevant to this deserializer.
-        /// </param>
-        /// <param name="isKey">
-        ///     true: if this deserializer instance is used to serialize keys,
-        ///     false: if this deserializer instance is used to serialize values.
-        /// </param>
-        /// <returns>
-        ///     A configuration collection with configuration parameter(s) relevant to this deseriaizer removed.
-        /// </returns>
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
         IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey);
     }
 }

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -26,6 +26,9 @@ namespace Confluent.Kafka.Serialization
         ///     Deserialize a byte array to an instance of
         ///     type T.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic associated wih the data.
+        /// </param>
         /// <param name="data">
         ///     The serialized representation of an instance
         ///     of type T to deserialize.
@@ -33,6 +36,6 @@ namespace Confluent.Kafka.Serialization
         /// <returns>
         ///     The deserialized value.
         /// </returns>
-        T Deserialize(byte[] data);
+        T Deserialize(string topic, byte[] data);
     }
 }

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -37,18 +37,24 @@ namespace Confluent.Kafka.Serialization
         ///     The serialized representation of an instance
         ///     of type T to deserialize.
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     The deserialized value.
         /// </returns>
-        T Deserialize(string topic, byte[] data, bool isKey);
+        T Deserialize(string topic, byte[] data);
 
         /// <summary>
-        ///     Configuration properties used by the deserializer.
+        ///     Configure the deserializer using relevant configuration parameter(s) in <paramref name="config" /> (if present).
         /// </summary>
-        IEnumerable<KeyValuePair<string, object>> Configuration { get; }
+        /// <param name="config">
+        ///     A collection containing configuration parameter(s) relevant to this deserializer.
+        /// </param>
+        /// <param name="isKey">
+        ///     true: if this deserializer instance is used to serialize keys,
+        ///     false: if this deserializer instance is used to serialize values.
+        /// </param>
+        /// <returns>
+        ///     A configuration collection with configuration parameter(s) relevant to this deseriaizer removed.
+        /// </returns>
+        IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey);
     }
 }

--- a/src/Confluent.Kafka/Serialization/IDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IDeserializer.cs
@@ -14,13 +14,15 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
     ///     Implement this interface to define a deserializer 
     ///     for a particular type T.
     /// </summary>
-    public interface IDeserializer<T>
+    public interface IDeserializer<T> : IDisposable
     {
         /// <summary>
         ///     Deserialize a byte array to an instance of

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -35,18 +35,24 @@ namespace Confluent.Kafka.Serialization
         /// <param name="data">
         ///     The object to serialize.
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     <paramref name="data" /> serialized as a byte array.
         /// </returns>
-        byte[] Serialize(string topic, T data, bool isKey);
+        byte[] Serialize(string topic, T data);
 
         /// <summary>
-        ///     Configuration properties used by the serializer.
+        ///     Configure the serializer using relevant configuration parameter(s) in <paramref name="config" /> (if present)
         /// </summary>
-        IEnumerable<KeyValuePair<string, object>> Configuration { get; }
+        /// <param name="config">
+        ///     A collection containing configuration parameter(s) relevant to this serializer.
+        /// </param>
+        /// <param name="isKey">
+        ///     true: if this serializer instance is used to serialize keys,
+        ///     false: if this serializer instance is used to serialize values.
+        /// </param>
+        /// <returns>
+        ///     A configuration collection with configuration parameter(s) relevant to this seriaizer removed.
+        /// </returns>
+        IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey);
     }
 }

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -22,7 +24,7 @@ namespace Confluent.Kafka.Serialization
     ///     Implement this interface to define a serializer 
     ///     for a particular type T.
     /// </summary>
-    public interface ISerializer<T> : IDisposable
+    public interface ISerializer<T>
     {
         /// <summary>
         ///     Serialize an instance of type T to a byte array.
@@ -33,9 +35,18 @@ namespace Confluent.Kafka.Serialization
         /// <param name="data">
         ///     The object to serialize.
         /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
         /// <returns>
         ///     <paramref name="data" /> serialized as a byte array.
         /// </returns>
-        byte[] Serialize(string topic, T data);
+        byte[] Serialize(string topic, T data, bool isKey);
+
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, object>> Configuration { get; }
     }
 }

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -40,19 +40,7 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         byte[] Serialize(string topic, T data);
 
-        /// <summary>
-        ///     Configure the serializer using relevant configuration parameter(s) in <paramref name="config" /> (if present)
-        /// </summary>
-        /// <param name="config">
-        ///     A collection containing configuration parameter(s) relevant to this serializer.
-        /// </param>
-        /// <param name="isKey">
-        ///     true: if this serializer instance is used to serialize keys,
-        ///     false: if this serializer instance is used to serialize values.
-        /// </param>
-        /// <returns>
-        ///     A configuration collection with configuration parameter(s) relevant to this seriaizer removed.
-        /// </returns>
+        /// <include file='../include_docs.xml' path='API/Member[@name="ISerializer_Configure"]/*' />
         IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey);
     }
 }

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -25,12 +25,15 @@ namespace Confluent.Kafka.Serialization
         /// <summary>
         ///     Serialize an instance of type T to a byte array.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic associated wih the data.
+        /// </param>
         /// <param name="data">
-        ///     The object to serialize
+        ///     The object to serialize.
         /// </param>
         /// <returns>
         ///     <paramref name="data" /> serialized as a byte array.
         /// </returns>
-        byte[] Serialize(T data);
+        byte[] Serialize(string topic, T data);
     }
 }

--- a/src/Confluent.Kafka/Serialization/ISerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ISerializer.cs
@@ -14,13 +14,15 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
     ///     Implement this interface to define a serializer 
     ///     for a particular type T.
     /// </summary>
-    public interface ISerializer<T>
+    public interface ISerializer<T> : IDisposable
     {
         /// <summary>
         ///     Serialize an instance of type T to a byte array.

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -47,6 +47,7 @@ namespace Confluent.Kafka.Serialization
                 (int)data[3];
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
     }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -39,5 +39,10 @@ namespace Confluent.Kafka.Serialization
                 (((int)data[2]) << 8) |
                 (int)data[3];
         }
+
+        int IDeserializer<int>.Deserialize(string topic, byte[] data)
+        {
+            return Deserialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -44,5 +46,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Deserialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -44,23 +44,16 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this deserializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     The deserialized <see cref="System.Int32"/> value.
         /// </returns>
-        public int Deserialize(string topic, byte[] data, bool isKey)
+        public int Deserialize(string topic, byte[] data)
         {
             return Deserialize(data);
         }
 
-        /// <summary>
-        ///     Configuration properties used by the deserializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
    
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class IntDeserializer : IDeserializer<int>
     {
-        /// <summary>
-        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int32"/> value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     A byte array containing the serialized <see cref="System.Int32"/> value (big endian encoding).
-        /// </param>
-        /// <returns>
-        ///     The deserialized <see cref="System.Int32"/> value.
-        /// </returns>
-        public int Deserialize(byte[] data)
+        private int Deserialize(byte[] data)
         {
             // network byte order -> big endian -> most significant byte in the smallest address.
             return
@@ -42,12 +35,32 @@ namespace Confluent.Kafka.Serialization
                 (int)data[3];
         }
 
-        int IDeserializer<int>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int32"/> value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized <see cref="System.Int32"/> value (big endian encoding).
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The deserialized <see cref="System.Int32"/> value.
+        /// </returns>
+        public int Deserialize(string topic, byte[] data, bool isKey)
         {
             return Deserialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
+   
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntDeserializer.cs
@@ -25,16 +25,6 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class IntDeserializer : IDeserializer<int>
     {
-        private int Deserialize(byte[] data)
-        {
-            // network byte order -> big endian -> most significant byte in the smallest address.
-            return
-                (((int)data[0]) << 24) |
-                (((int)data[1]) << 16) |
-                (((int)data[2]) << 8) |
-                (int)data[3];
-        }
-
         /// <summary>
         ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int32"/> value from a byte array.
         /// </summary>
@@ -49,11 +39,15 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         public int Deserialize(string topic, byte[] data)
         {
-            return Deserialize(data);
+            // network byte order -> big endian -> most significant byte in the smallest address.
+            return
+                (((int)data[0]) << 24) |
+                (((int)data[1]) << 16) |
+                (((int)data[2]) << 8) |
+                (int)data[3];
         }
 
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
-   
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -43,5 +43,10 @@ namespace Confluent.Kafka.Serialization
             result[3] = (byte)val; // & 0xff;
             return result;
         }
+
+        byte[] ISerializer<int>.Serialize(string topic, int data)
+        {
+            return Serialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -43,10 +45,13 @@ namespace Confluent.Kafka.Serialization
             result[3] = (byte)val; // & 0xff;
             return result;
         }
-
+        
         byte[] ISerializer<int>.Serialize(string topic, int data)
         {
             return Serialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -25,20 +25,6 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class IntSerializer : ISerializer<int>
     {
-        private byte[] Serialize(int val)
-        {
-            var result = new byte[4]; // int is always 32 bits on .NET.
-            // network byte order -> big endian -> most significant byte in the smallest address.
-            // Note: At the IL level, the conv.u1 operator is used to cast int to byte which truncates
-            // the high order bits if overflow occurs.
-            // https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.conv_u1.aspx
-            result[0] = (byte)(val >> 24);
-            result[1] = (byte)(val >> 16); // & 0xff;
-            result[2] = (byte)(val >> 8); // & 0xff;
-            result[3] = (byte)val; // & 0xff;
-            return result;
-        }
-        
         /// <summary>
         ///     Serializes the specified <see cref="System.Int32"/> value to a byte array of length 4. Byte order is big endian (network byte order).
         /// </summary>
@@ -53,7 +39,16 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         public byte[] Serialize(string topic, int data)
         {
-            return Serialize(data);
+            var result = new byte[4]; // int is always 32 bits on .NET.
+            // network byte order -> big endian -> most significant byte in the smallest address.
+            // Note: At the IL level, the conv.u1 operator is used to cast int to byte which truncates
+            // the high order bits if overflow occurs.
+            // https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.conv_u1.aspx
+            result[0] = (byte)(data >> 24);
+            result[1] = (byte)(data >> 16); // & 0xff;
+            result[2] = (byte)(data >> 8); // & 0xff;
+            result[3] = (byte)data; // & 0xff;
+            return result;
         }
 
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class IntSerializer : ISerializer<int>
     {
-        /// <summary>
-        ///     Serializes the specified <see cref="System.Int32"/> value to a byte array of length 4. Byte order is big endian (network byte order).
-        /// </summary>
-        /// <param name="val">
-        ///     The <see cref="System.Int32"/> value to serialize.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="System.Int32"/> value <paramref name="val" /> encoded as a byte array of length 8 (network byte order).
-        /// </returns>
-        public byte[] Serialize(int val)
+        private byte[] Serialize(int val)
         {
             var result = new byte[4]; // int is always 32 bits on .NET.
             // network byte order -> big endian -> most significant byte in the smallest address.
@@ -46,12 +39,31 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
         
-        byte[] ISerializer<int>.Serialize(string topic, int data)
+        /// <summary>
+        ///     Serializes the specified <see cref="System.Int32"/> value to a byte array of length 4. Byte order is big endian (network byte order).
+        /// </summary>
+        /// <param name="data">
+        ///     The <see cref="System.Int32"/> value to serialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="System.Int32"/> value <paramref name="data" /> encoded as a byte array of length 8 (network byte order).
+        /// </returns>
+        public byte[] Serialize(string topic, int data, bool isKey)
         {
             return Serialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -48,22 +48,15 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this serializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     The <see cref="System.Int32"/> value <paramref name="data" /> encoded as a byte array of length 8 (network byte order).
         /// </returns>
-        public byte[] Serialize(string topic, int data, bool isKey)
+        public byte[] Serialize(string topic, int data)
         {
             return Serialize(data);
         }
 
-        /// <summary>
-        ///     Configuration properties used by the serializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/IntSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/IntSerializer.cs
@@ -51,6 +51,7 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="ISerializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
     }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -61,6 +61,7 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
     }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -61,5 +61,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Deserialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -56,5 +56,10 @@ namespace Confluent.Kafka.Serialization
                 (data[7]);
             return result;
         }
+        
+        long IDeserializer<long>.Deserialize(string topic, byte[] data)
+        {
+            return Deserialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -25,7 +25,19 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class LongDeserializer : IDeserializer<long>
     {
-        private long Deserialize(byte[] data)
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int64"/> value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized <see cref="System.Int64"/> value (big endian encoding)
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <returns>
+        ///     The deserialized <see cref="System.Int64"/> value.
+        /// </returns>
+        public long Deserialize(string topic, byte[] data)
         {
             if (data == null)
             {
@@ -47,23 +59,6 @@ namespace Confluent.Kafka.Serialization
                 ((long)(data[6])) << 8 |
                 (data[7]);
             return result;
-        }
-        
-        /// <summary>
-        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int64"/> value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     A byte array containing the serialized <see cref="System.Int64"/> value (big endian encoding)
-        /// </param>
-        /// <param name="topic">
-        ///     The topic associated with the data (ignored by this deserializer).
-        /// </param>
-        /// <returns>
-        ///     The deserialized <see cref="System.Int64"/> value.
-        /// </returns>
-        public long Deserialize(string topic, byte[] data)
-        {
-            return Deserialize(data);
         }
 
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -58,22 +58,15 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this deserializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     The deserialized <see cref="System.Int64"/> value.
         /// </returns>
-        public long Deserialize(string topic, byte[] data, bool isKey)
+        public long Deserialize(string topic, byte[] data)
         {
             return Deserialize(data);
         }
 
-        /// <summary>
-        ///     Configuration properties used by the deserializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongDeserializer.cs
@@ -14,8 +14,9 @@
 //
 // Refer to LICENSE for more information.
 
-
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -24,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class LongDeserializer : IDeserializer<long>
     {
-        /// <summary>
-        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int64"/> value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     A byte array containing the serialized <see cref="System.Int64"/> value (big endian encoding)
-        /// </param>
-        /// <returns>
-        ///     The deserialized <see cref="System.Int64"/> value.
-        /// </returns>
-        public long Deserialize(byte[] data)
+        private long Deserialize(byte[] data)
         {
             if (data == null)
             {
@@ -57,12 +49,31 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
         
-        long IDeserializer<long>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) <see cref="System.Int64"/> value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized <see cref="System.Int64"/> value (big endian encoding)
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The deserialized <see cref="System.Int64"/> value.
+        /// </returns>
+        public long Deserialize(string topic, byte[] data, bool isKey)
         {
             return Deserialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class LongSerializer : ISerializer<long>
     {
-        /// <summary>
-        ///     Serializes the specified <see cref="System.Int64"/> value to a byte array of length 8. Byte order is big endian (network byte order).
-        /// </summary>
-        /// <param name="val">
-        ///     The <see cref="System.Int64"/> value to serialize.
-        /// </param>
-        /// <returns>
-        ///     The <see cref="System.Int64"/> value <paramref name="val" /> encoded as a byte array of length 8 (network byte order).
-        /// </returns>
-        public byte[] Serialize(long val)
+        private byte[] Serialize(long val)
         {
             var result = new byte[8];
             result[0] = (byte)(val >> 56);
@@ -46,12 +39,31 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
         
-        byte[] ISerializer<long>.Serialize(string topic, long data)
+        /// <summary>
+        ///     Serializes the specified <see cref="System.Int64"/> value to a byte array of length 8. Byte order is big endian (network byte order).
+        /// </summary>
+        /// <param name="data">
+        ///     The <see cref="System.Int64"/> value to serialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="System.Int64"/> value <paramref name="data" /> encoded as a byte array of length 8 (network byte order).
+        /// </returns>
+        public byte[] Serialize(string topic, long data, bool isKey)
         {
             return Serialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -43,5 +43,10 @@ namespace Confluent.Kafka.Serialization
             result[7] = (byte)val;
             return result;
         }
+        
+        byte[] ISerializer<long>.Serialize(string topic, long data)
+        {
+            return Serialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -48,22 +48,15 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this serializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     The <see cref="System.Int64"/> value <paramref name="data" /> encoded as a byte array of length 8 (network byte order).
         /// </returns>
-        public byte[] Serialize(string topic, long data, bool isKey)
+        public byte[] Serialize(string topic, long data)
         {
             return Serialize(data);
         }
 
-        /// <summary>
-        ///     Configuration properties used by the serializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -25,20 +25,6 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class LongSerializer : ISerializer<long>
     {
-        private byte[] Serialize(long val)
-        {
-            var result = new byte[8];
-            result[0] = (byte)(val >> 56);
-            result[1] = (byte)(val >> 48);
-            result[2] = (byte)(val >> 40);
-            result[3] = (byte)(val >> 32);
-            result[4] = (byte)(val >> 24);
-            result[5] = (byte)(val >> 16);
-            result[6] = (byte)(val >> 8);
-            result[7] = (byte)val;
-            return result;
-        }
-        
         /// <summary>
         ///     Serializes the specified <see cref="System.Int64"/> value to a byte array of length 8. Byte order is big endian (network byte order).
         /// </summary>
@@ -53,7 +39,16 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         public byte[] Serialize(string topic, long data)
         {
-            return Serialize(data);
+            var result = new byte[8];
+            result[0] = (byte)(data >> 56);
+            result[1] = (byte)(data >> 48);
+            result[2] = (byte)(data >> 40);
+            result[3] = (byte)(data >> 32);
+            result[4] = (byte)(data >> 24);
+            result[5] = (byte)(data >> 16);
+            result[6] = (byte)(data >> 8);
+            result[7] = (byte)data;
+            return result;
         }
 
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -48,5 +50,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Serialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/LongSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/LongSerializer.cs
@@ -51,6 +51,7 @@ namespace Confluent.Kafka.Serialization
             return result;
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="ISerializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
     }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -25,16 +25,6 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class NullDeserializer : IDeserializer<Null>
     {
-        private Null Deserialize(byte[] data)
-        {
-            if (data != null)
-            {
-                throw new System.ArgumentException("NullDeserializer may only be used to deserialize data that is null.");
-            }
-
-            return null;
-        }
-
         /// <summary>
         ///     'Deserializes' a null value to a null value.
         /// </summary>
@@ -49,6 +39,11 @@ namespace Confluent.Kafka.Serialization
         /// </returns>
         public Null Deserialize(string topic, byte[] data)
         {
+            if (data != null)
+            {
+                throw new System.ArgumentException("NullDeserializer may only be used to deserialize data that is null.");
+            }
+
             return null;
         }
 

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -44,22 +44,15 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this deserializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     null
         /// </returns>
-        public Null Deserialize(string topic, byte[] data, bool isKey)
+        public Null Deserialize(string topic, byte[] data)
         {
             return null;
         }
 
-        /// <summary>
-        ///     Configuration properties used by the deserializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,16 +25,7 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class NullDeserializer : IDeserializer<Null>
     {
-        /// <summary>
-        ///     'Deserializes' a null value to a null value.
-        /// </summary>
-        /// <param name="data">
-        ///     The data to deserialize (must be null).
-        /// </param>
-        /// <returns>
-        ///     null
-        /// </returns>
-        public Null Deserialize(byte[] data)
+        private Null Deserialize(byte[] data)
         {
             if (data != null)
             {
@@ -42,12 +35,31 @@ namespace Confluent.Kafka.Serialization
             return null;
         }
 
-        Null IDeserializer<Null>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     'Deserializes' a null value to a null value.
+        /// </summary>
+        /// <param name="data">
+        ///     The data to deserialize (must be null).
+        /// </param>        
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     null
+        /// </returns>
+        public Null Deserialize(string topic, byte[] data, bool isKey)
         {
             return null;
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -39,5 +39,10 @@ namespace Confluent.Kafka.Serialization
 
             return null;
         }
+
+        Null IDeserializer<Null>.Deserialize(string topic, byte[] data)
+        {
+            return null;
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -44,5 +46,8 @@ namespace Confluent.Kafka.Serialization
         {
             return null;
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullDeserializer.cs
@@ -47,6 +47,7 @@ namespace Confluent.Kafka.Serialization
             return null;
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
     }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -36,22 +36,15 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this serializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     null
         /// </returns>
-        public byte[] Serialize(string topic, Null data, bool isKey)
+        public byte[] Serialize(string topic, Null data)
         {
             return null;
         }
 
-        /// <summary>
-        ///     Configuration properties used by the serializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
@@ -36,5 +38,8 @@ namespace Confluent.Kafka.Serialization
         {
             return null;
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -31,5 +31,10 @@ namespace Confluent.Kafka.Serialization
         {
             return null;
         }
+
+        byte[] ISerializer<Null>.Serialize(string topic, Null data)
+        {
+            return null;
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -25,11 +25,6 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class NullSerializer : ISerializer<Null>
     {
-        private byte[] Serialize(Null val)
-        {
-            return null;
-        }
-
         /// <param name="data">
         ///     Can only be null (the <see cref="Null"/> class cannot be instantiated).
         /// </param>

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -39,6 +39,7 @@ namespace Confluent.Kafka.Serialization
             return null;
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="ISerializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
             => config;
     }

--- a/src/Confluent.Kafka/Serialization/NullSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/NullSerializer.cs
@@ -15,6 +15,8 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -23,23 +25,33 @@ namespace Confluent.Kafka.Serialization
     /// </summary>
     public class NullSerializer : ISerializer<Null>
     {
-        /// <param name="val">
+        private byte[] Serialize(Null val)
+        {
+            return null;
+        }
+
+        /// <param name="data">
         ///     Can only be null (the <see cref="Null"/> class cannot be instantiated).
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
         /// </param>
         /// <returns>
         ///     null
         /// </returns>
-        public byte[] Serialize(Null val)
+        public byte[] Serialize(string topic, Null data, bool isKey)
         {
             return null;
         }
 
-        byte[] ISerializer<Null>.Serialize(string topic, Null data)
-        {
-            return null;
-        }
-
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -57,22 +57,15 @@ namespace Confluent.Kafka.Serialization
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this deserializer).
         /// </param>
-        /// <param name="isKey">
-        ///     true: deserialization is for a key, 
-        ///     false: deserializing is for a value.
-        /// </param>
         /// <returns>
         ///     <paramref name="data" /> deserialized to a string (or null if data is null).
         /// </returns>
-        public string Deserialize(string topic, byte[] data, bool isKey)
+        public string Deserialize(string topic, byte[] data)
         {
             return Deserialize(data);
         }
 
-        /// <summary>
-        ///     Configuration properties used by the deserializer.
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> Configuration 
-            => new List<KeyValuePair<string, object>>();
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -53,5 +53,10 @@ namespace Confluent.Kafka.Serialization
             }
             return encoding.GetString(data);
         }
+
+        string IDeserializer<string>.Deserialize(string topic, byte[] data)
+        {
+            return Deserialize(data);
+        }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -73,6 +73,7 @@ namespace Confluent.Kafka.Serialization
             return encoding.GetString(data);
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
         {
             var propertyName = isKey ? KeyEncodingConfigParam : ValueEncodingConfigParam;

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -86,7 +86,7 @@ namespace Confluent.Kafka.Serialization
             var propertyName = isKey ? KeyEncodingConfigParam : ValueEncodingConfigParam;
             var keyOrValue = isKey ? "Key" : "Value";
 
-            if (config.Count(ci => ci.Key == propertyName) > 0)
+            if (config.Any(ci => ci.Key == propertyName))
             {
                 if (encoding != null)
                 {
@@ -108,7 +108,7 @@ namespace Confluent.Kafka.Serialization
 
                 encoding = encodingName.ToEncoding();
                 
-                return config.Where(ci => ci.Key != KeyEncodingConfigParam);
+                return config.Where(ci => ci.Key != propertyName);
             }
 
             if (encoding == null)

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -29,15 +29,23 @@ namespace Confluent.Kafka.Serialization
     {
         Encoding encoding;
 
-        private const string KeyEncodingConfigParam = "dotnet.string.deserializer.encoding.key";
-        private const string ValueEncodingConfigParam = "dotnet.string.deserializer.encoding.value";
+        /// <summary>
+        ///     Name of the encoding configuration parameter for the case of key deserialization.
+        /// </summary>
+        public const string KeyEncodingConfigParam = "dotnet.string.deserializer.encoding.key";
+
+        /// <summary>
+        ///     Name of the encoding configuration parameter for the case of value deserialization.
+        /// </summary>
+        public const string ValueEncodingConfigParam = "dotnet.string.deserializer.encoding.value";
 
 
         /// <summary>
         ///     Initializes a new StringDeserializer class instance.
         /// </summary>
         /// <param name="encoding">
-        ///     The encoding to use when deserializing.
+        ///     The encoding to use when deserializing. For available options, refer to:
+        ///     https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
         /// </param>
         public StringDeserializer(Encoding encoding)
         {
@@ -49,8 +57,7 @@ namespace Confluent.Kafka.Serialization
         ///     The encoding encoding to use must be provided via <see cref="Consumer" /> configuration properties.
         /// </summary>
         public StringDeserializer()
-        {
-        }
+        { }
 
         /// <summary>
         ///     Deserializes a string value from a byte array.
@@ -81,24 +88,26 @@ namespace Confluent.Kafka.Serialization
 
             if (config.Count(ci => ci.Key == propertyName) > 0)
             {
-                try
-                {
-                    encoding = config
-                        .Single(ci => ci.Key == propertyName)
-                        .Value
-                        .ToString()
-                        .ToEncoding();
-                }
-                catch
-                {
-                    throw new ArgumentException($"{keyOrValue} StringDeserializer encoding configuration parameter was specified twice.");
-                }
-
                 if (encoding != null)
                 {
                     throw new ArgumentException($"{keyOrValue} StringDeserializer encoding was configured using both constructor and configuration parameter.");
                 }
 
+                string encodingName;
+                try
+                {
+                    encodingName = config
+                        .Single(ci => ci.Key == propertyName)
+                        .Value
+                        .ToString();
+                }
+                catch (Exception e)
+                {
+                    throw new ArgumentException($"{keyOrValue} StringDeserializer encoding configuration parameter was specified twice.", e);
+                }
+
+                encoding = encodingName.ToEncoding();
+                
                 return config.Where(ci => ci.Key != KeyEncodingConfigParam);
             }
 

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using System.Text;
 
 namespace Confluent.Kafka.Serialization
@@ -58,5 +59,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Deserialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Serialization
 
         /// <summary>
         ///     Initializes a new StringDesrializer class instance.
-        ///     The encoding encoding to use must be provided via <see cref="Producer" /> configuration properties.
+        ///     The encoding encoding to use must be provided via <see cref="Consumer" /> configuration properties.
         /// </summary>
         public StringDeserializer()
         {

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -30,12 +30,12 @@ namespace Confluent.Kafka.Serialization
         Encoding encoding;
 
         /// <summary>
-        ///     Name of the encoding configuration parameter for the case of key deserialization.
+        ///     Name of the configuration parameter used to specify the encoding when deserializing keys.
         /// </summary>
         public const string KeyEncodingConfigParam = "dotnet.string.deserializer.encoding.key";
 
         /// <summary>
-        ///     Name of the encoding configuration parameter for the case of value deserialization.
+        ///     Name of the configuration parameter used to specify the encoding when deserializing values.
         /// </summary>
         public const string ValueEncodingConfigParam = "dotnet.string.deserializer.encoding.value";
 
@@ -44,8 +44,7 @@ namespace Confluent.Kafka.Serialization
         ///     Initializes a new StringDeserializer class instance.
         /// </summary>
         /// <param name="encoding">
-        ///     The encoding to use when deserializing. For available options, refer to:
-        ///     https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
+        ///     The encoding to use when deserializing.
         /// </param>
         public StringDeserializer(Encoding encoding)
         {
@@ -53,8 +52,14 @@ namespace Confluent.Kafka.Serialization
         }
 
         /// <summary>
-        ///     Initializes a new StringDesrializer class instance.
-        ///     The encoding encoding to use must be provided via <see cref="Consumer" /> configuration properties.
+        ///     Initializes a new StringDeserializer class instance.
+        ///     The encoding to use must be provided via a <see cref="Consumer" /> 
+        ///     configuration property. When used to deserialize keys, the 
+        ///     relevant property is 'dotnet.string.deserializer.encoding.key'.
+        ///     When used to deserialize values, the relevant property is
+        ///     'dotnet.string.deserializer.encoding.value'. For available encodings, 
+        ///     refer to:
+        ///     https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
         /// </summary>
         public StringDeserializer()
         { }

--- a/src/Confluent.Kafka/Serialization/StringDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringDeserializer.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Text;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -37,16 +39,7 @@ namespace Confluent.Kafka.Serialization
             this.encoding = encoding;
         }
 
-        /// <summary>
-        ///     Deserializes a string value from a byte array.
-        /// </summary>
-        /// <param name="data">
-        ///     The data to deserialize.
-        /// </param>
-        /// <returns>
-        ///     <paramref name="data" /> deserialized to a string (or null if data is null).
-        /// </returns>
-        public string Deserialize(byte[] data)
+        private string Deserialize(byte[] data)
         {
             if (data == null)
             {
@@ -55,12 +48,31 @@ namespace Confluent.Kafka.Serialization
             return encoding.GetString(data);
         }
 
-        string IDeserializer<string>.Deserialize(string topic, byte[] data)
+        /// <summary>
+        ///     Deserializes a string value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     The data to deserialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     <paramref name="data" /> deserialized to a string (or null if data is null).
+        /// </returns>
+        public string Deserialize(string topic, byte[] data, bool isKey)
         {
             return Deserialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the deserializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -75,23 +75,37 @@ namespace Confluent.Kafka.Serialization
 
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
         {
-            var paramName = isKey ? KeyEncodingConfigParam : ValueEncodingConfigParam;
-            var typeName = isKey ? "Key" : "Value";
+            var propertyName = isKey ? KeyEncodingConfigParam : ValueEncodingConfigParam;
+            var keyOrValue = isKey ? "Key" : "Value";
 
-            if (config.Count(ci => ci.Key == paramName) > 0)
+            if (config.Count(ci => ci.Key == propertyName) > 0)
             {
-                var configItem = config.Single(ci => ci.Key == paramName);
-                encoding = configItem.Value.ToString().AsEncoding();
+                try
+                {
+                    encoding = config
+                        .Single(ci => ci.Key == propertyName)
+                        .Value
+                        .ToString()
+                        .ToEncoding();
+                }
+                catch
+                {
+                    throw new ArgumentException($"{keyOrValue} StringSerializer encoding configuration parameter was specified twice.");
+                }
+
                 if (encoding != null)
                 {
-                    throw new ArgumentException($"{typeName} StringSerializer encoding was configured using both constructor and configuration parameter.");
+                    throw new ArgumentException($"{keyOrValue} StringSerializer encoding was configured using both constructor and configuration parameter.");
                 }
+
                 return config.Where(ci => ci.Key != KeyEncodingConfigParam);
             }
+
             if (encoding == null)
             {
-                throw new ArgumentException($"{typeName} StringSerializer encoding was not configured.");
+                throw new ArgumentException($"{keyOrValue} StringSerializer encoding was not configured.");
             }
+
             return config;
         }
 

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Text;
+using System.Collections.Generic;
+
 
 namespace Confluent.Kafka.Serialization
 {
@@ -37,16 +39,7 @@ namespace Confluent.Kafka.Serialization
             this.encoding = encoding;
         }
 
-        /// <summary>
-        ///     Encodes a string value in a byte array.
-        /// </summary>
-        /// <param name="val">
-        ///     The string value to serialize.
-        /// </param>
-        /// <returns>
-        ///     <paramref name="val" /> encoded in a byte array (or null if <paramref name="val" /> is null).
-        /// </returns>
-        public byte[] Serialize(string val)
+        private byte[] Serialize(string val)
         {
             if (val == null)
             {
@@ -55,12 +48,31 @@ namespace Confluent.Kafka.Serialization
             return encoding.GetBytes(val);
         }
 
-        byte[] ISerializer<string>.Serialize(string topic, string data)
+        /// <summary>
+        ///     Encodes a string value in a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     The string value to serialize.
+        /// </param>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
+        /// <param name="isKey">
+        ///     true: deserialization is for a key, 
+        ///     false: deserializing is for a value.
+        /// </param>
+        /// <returns>
+        ///     <paramref name="data" /> encoded in a byte array (or null if <paramref name="data" /> is null).
+        /// </returns>
+        public byte[] Serialize(string topic, string data, bool isKey)
         {
             return Serialize(data);
         }
 
-        void IDisposable.Dispose()
-        { }
+        /// <summary>
+        ///     Configuration properties used by the serializer.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Configuration 
+            => new List<KeyValuePair<string, object>>();
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -73,6 +73,7 @@ namespace Confluent.Kafka.Serialization
             return encoding.GetBytes(data);
         }
 
+        /// <include file='../include_docs.xml' path='API/Member[@name="ISerializer_Configure"]/*' />
         public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
         {
             var propertyName = isKey ? KeyEncodingConfigParam : ValueEncodingConfigParam;

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -29,14 +29,22 @@ namespace Confluent.Kafka.Serialization
     {
         private Encoding encoding;
 
-        private const string KeyEncodingConfigParam = "dotnet.string.serializer.encoding.key";
-        private const string ValueEncodingConfigParam = "dotnet.string.serializer.encoding.value";
+        /// <summary>
+        ///     Name of the encoding configuration parameter for the case of key serialization.
+        /// </summary>
+        public const string KeyEncodingConfigParam = "dotnet.string.serializer.encoding.key";
+
+        /// <summary>
+        ///     Name of the encoding configuration parameter for the case of value serialization.
+        /// </summary>
+        public const string ValueEncodingConfigParam = "dotnet.string.serializer.encoding.value";
 
         /// <summary>
         ///     Initializes a new StringSerializer class instance.
         /// </summary>
         /// <param name="encoding">
-        ///     The encoding to use when serializing.
+        ///     The encoding to use when serializing. For available options, refer to:
+        ///     https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
         /// </param>
         public StringSerializer(Encoding encoding)
         {
@@ -48,8 +56,7 @@ namespace Confluent.Kafka.Serialization
         ///     The encoding encoding to use must be provided via <see cref="Producer" /> configuration properties.
         /// </summary>
         public StringSerializer()
-        {
-        }
+        { }
 
         /// <summary>
         ///     Encodes a string value in a byte array.
@@ -81,23 +88,25 @@ namespace Confluent.Kafka.Serialization
 
             if (config.Count(ci => ci.Key == propertyName) > 0)
             {
-                try
-                {
-                    encoding = config
-                        .Single(ci => ci.Key == propertyName)
-                        .Value
-                        .ToString()
-                        .ToEncoding();
-                }
-                catch
-                {
-                    throw new ArgumentException($"{keyOrValue} StringSerializer encoding configuration parameter was specified twice.");
-                }
-
                 if (encoding != null)
                 {
                     throw new ArgumentException($"{keyOrValue} StringSerializer encoding was configured using both constructor and configuration parameter.");
                 }
+
+                string encodingName;
+                try
+                {
+                    encodingName = config
+                        .Single(ci => ci.Key == propertyName)
+                        .Value
+                        .ToString();
+                }
+                catch (Exception e)
+                {
+                    throw new ArgumentException($"{keyOrValue} StringSerializer encoding configuration parameter was specified twice.", e);
+                }
+                
+                encoding = encodingName.ToEncoding();
 
                 return config.Where(ci => ci.Key != KeyEncodingConfigParam);
             }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -30,12 +30,12 @@ namespace Confluent.Kafka.Serialization
         private Encoding encoding;
 
         /// <summary>
-        ///     Name of the encoding configuration parameter for the case of key serialization.
+        ///     Name of the configuration parameter used to specify the encoding when serializing keys.
         /// </summary>
         public const string KeyEncodingConfigParam = "dotnet.string.serializer.encoding.key";
 
         /// <summary>
-        ///     Name of the encoding configuration parameter for the case of value serialization.
+        ///     Name of the configuration parameter used to specify the encoding when serializing values.
         /// </summary>
         public const string ValueEncodingConfigParam = "dotnet.string.serializer.encoding.value";
 
@@ -43,8 +43,7 @@ namespace Confluent.Kafka.Serialization
         ///     Initializes a new StringSerializer class instance.
         /// </summary>
         /// <param name="encoding">
-        ///     The encoding to use when serializing. For available options, refer to:
-        ///     https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
+        ///     The encoding to use when serializing. 
         /// </param>
         public StringSerializer(Encoding encoding)
         {
@@ -53,7 +52,13 @@ namespace Confluent.Kafka.Serialization
 
         /// <summary>
         ///     Initializes a new StringSerializer class instance.
-        ///     The encoding encoding to use must be provided via <see cref="Producer" /> configuration properties.
+        ///     The encoding to use must be provided via a <see cref="Producer" /> 
+        ///     configuration property. When used to serialize keys, the 
+        ///     relevant property is 'dotnet.string.serializer.encoding.key'.
+        ///     When used to serialize values, the relevant property is
+        ///     'dotnet.string.serializer.encoding.value'. For available encodings, 
+        ///     refer to:
+        ///     https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
         /// </summary>
         public StringSerializer()
         { }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using System.Text;
 
 namespace Confluent.Kafka.Serialization
@@ -52,6 +53,11 @@ namespace Confluent.Kafka.Serialization
                 return null;
             }
             return encoding.GetBytes(val);
+        }
+
+        byte[] ISerializer<string>.Serialize(string topic, string data)
+        {
+            return Serialize(data);
         }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -59,5 +59,8 @@ namespace Confluent.Kafka.Serialization
         {
             return Serialize(data);
         }
+
+        void IDisposable.Dispose()
+        { }
     }
 }

--- a/src/Confluent.Kafka/Serialization/StringSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/StringSerializer.cs
@@ -86,7 +86,7 @@ namespace Confluent.Kafka.Serialization
             var propertyName = isKey ? KeyEncodingConfigParam : ValueEncodingConfigParam;
             var keyOrValue = isKey ? "Key" : "Value";
 
-            if (config.Count(ci => ci.Key == propertyName) > 0)
+            if (config.Any(ci => ci.Key == propertyName))
             {
                 if (encoding != null)
                 {
@@ -108,7 +108,7 @@ namespace Confluent.Kafka.Serialization
                 
                 encoding = encodingName.ToEncoding();
 
-                return config.Where(ci => ci.Key != KeyEncodingConfigParam);
+                return config.Where(ci => ci.Key != propertyName);
             }
 
             if (encoding == null)

--- a/src/Confluent.Kafka/include_docs.xml
+++ b/src/Confluent.Kafka/include_docs.xml
@@ -1,0 +1,35 @@
+<API>  
+
+<Member name="ISerializer_Configure">  
+    <summary>
+        Configure the serializer using relevant configuration parameter(s) in <paramref name="config" /> (if present)
+    </summary>
+    <param name="config">
+        A collection containing configuration parameter(s) relevant to this serializer.
+    </param>
+    <param name="isKey">
+        true: if this serializer instance is used to serialize keys,
+        false: if this serializer instance is used to serialize values.
+    </param>
+    <returns>
+        A configuration collection with configuration parameter(s) relevant to this seriaizer removed.
+    </returns>
+</Member>  
+
+<Member name="IDeserializer_Configure">
+    <summary>
+        Configure the deserializer using relevant configuration parameter(s) in <paramref name="config" /> (if present).
+    </summary>
+    <param name="config">
+        A collection containing configuration parameter(s) relevant to this deserializer.
+    </param>
+    <param name="isKey">
+        true: if this deserializer instance is used to serialize keys,
+        false: if this deserializer instance is used to serialize values.
+    </param>
+    <returns>
+        A configuration collection with configuration parameter(s) relevant to this deseriaizer removed.
+    </returns>
+</Member>
+
+</API>  

--- a/src/Confluent.Kafka/include_docs.xml
+++ b/src/Confluent.Kafka/include_docs.xml
@@ -12,7 +12,7 @@
         false: if this serializer instance is used to serialize values.
     </param>
     <returns>
-        A configuration collection with configuration parameter(s) relevant to this seriaizer removed.
+        A configuration collection with configuration parameter(s) relevant to this serializer removed.
     </returns>
 </Member>  
 
@@ -28,7 +28,7 @@
         false: if this deserializer instance is used to serialize values.
     </param>
     <returns>
-        A configuration collection with configuration parameter(s) relevant to this deseriaizer removed.
+        A configuration collection with configuration parameter(s) relevant to this deserializer removed.
     </returns>
 </Member>
 

--- a/test/Confluent.Kafka.UnitTests/IntSerde.cs
+++ b/test/Confluent.Kafka.UnitTests/IntSerde.cs
@@ -75,6 +75,32 @@ namespace Confluent.Kafka.Tests
                 Assert.Equal(theInt, reconstructed);
             }
         }
-    }
 
+        [Fact]
+        public void ExplicitSerializationWorks()
+        {
+            foreach(string topic in new[] {null, "", "topic"})
+            {
+                var serializer = new IntSerializer();
+                var bytesImplicit = serializer.Serialize(42);
+                var bytesExplicit = ((ISerializer<int>)serializer).Serialize(topic, 42);
+
+                Assert.Equal(bytesImplicit, bytesExplicit);
+            }
+        }
+
+        [Fact]
+        public void ExplicitDeserializationWorks()
+        {
+            var byte42 = new IntSerializer().Serialize(42);
+
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var deserializer = new IntDeserializer();
+                var deconstructExplicit = ((IDeserializer<int>)deserializer).Deserialize(topic, byte42);
+
+                Assert.Equal(42, deconstructExplicit);
+            }
+        }
+    }
 }

--- a/test/Confluent.Kafka.UnitTests/IntSerde.cs
+++ b/test/Confluent.Kafka.UnitTests/IntSerde.cs
@@ -36,7 +36,7 @@ namespace Confluent.Kafka.Tests
         public void IsBigEndian()
         {
             var serializer = new IntSerializer();
-            var bytes = serializer.Serialize(42);
+            var bytes = serializer.Serialize("topic", 42);
             Assert.Equal(bytes.Length, 4);
             // most significant byte in smallest address.
             Assert.Equal(bytes[0], 0);
@@ -52,7 +52,7 @@ namespace Confluent.Kafka.Tests
                 var bytes1 = BitConverter.GetBytes(networkOrder);
 
                 var serializer = new IntSerializer();
-                var bytes2 = serializer.Serialize(theInt);
+                var bytes2 = serializer.Serialize("topic", theInt);
 
                 Assert.Equal(bytes1.Length, bytes2.Length);
 
@@ -71,35 +71,8 @@ namespace Confluent.Kafka.Tests
 
             foreach (int theInt in toTest)
             {
-                var reconstructed = deserializer.Deserialize(serializer.Serialize(theInt));
+                var reconstructed = deserializer.Deserialize("topic", serializer.Serialize("topic", theInt));
                 Assert.Equal(theInt, reconstructed);
-            }
-        }
-
-        [Fact]
-        public void ExplicitSerializationWorks()
-        {
-            foreach(string topic in new[] {null, "", "topic"})
-            {
-                var serializer = new IntSerializer();
-                var bytesImplicit = serializer.Serialize(42);
-                var bytesExplicit = ((ISerializer<int>)serializer).Serialize(topic, 42);
-
-                Assert.Equal(bytesImplicit, bytesExplicit);
-            }
-        }
-
-        [Fact]
-        public void ExplicitDeserializationWorks()
-        {
-            var byte42 = new IntSerializer().Serialize(42);
-
-            foreach (string topic in new[] { null, "", "topic" })
-            {
-                var deserializer = new IntDeserializer();
-                var deconstructExplicit = ((IDeserializer<int>)deserializer).Deserialize(topic, byte42);
-
-                Assert.Equal(42, deconstructExplicit);
             }
         }
     }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -51,6 +51,33 @@ namespace Confluent.Kafka.UnitTests
             Assert.ThrowsAny<ArgumentException>(() => new LongDeserializer().Deserialize(new byte[9]));
         }
 
+        [Fact]
+        public void ExplicitSerializationWork()
+        {
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var serializer = new LongSerializer();
+                var bytesImplicit = serializer.Serialize(42);
+                var bytesExplicit = ((ISerializer<long>)serializer).Serialize(topic, 42);
+
+                Assert.Equal(bytesImplicit, bytesExplicit);
+            }
+        }
+
+        [Fact]
+        public void ExplicitDeserializationWorks()
+        {
+            var byte42 = new LongSerializer().Serialize(42);
+
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var deserializer = new LongDeserializer();
+                var deconstructExplicit = ((IDeserializer<long>)deserializer).Deserialize(topic, byte42);
+
+                Assert.Equal(42, deconstructExplicit);
+            }
+        }
+
         public static IEnumerable<object[]> TestData()
         {
             long[] testData = new long[]

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -27,13 +27,13 @@ namespace Confluent.Kafka.UnitTests
         [MemberData(nameof(TestData))]
         public void CanReconstruct(long value)
         {
-            Assert.Equal(value, new LongDeserializer().Deserialize(new LongSerializer().Serialize(value)));
+            Assert.Equal(value, new LongDeserializer().Deserialize("topic", new LongSerializer().Serialize("topic", value)));
         }
 
         [Fact]
         public void IsBigEndian()
         {
-            var data = new LongSerializer().Serialize(23L);
+            var data = new LongSerializer().Serialize("topic", 23L);
             Assert.Equal(23, data[7]);
             Assert.Equal(0, data[0]);
         }
@@ -41,41 +41,14 @@ namespace Confluent.Kafka.UnitTests
         [Fact]
         public void DeserializeArgNull()
         {
-            Assert.ThrowsAny<ArgumentException>(()=> new LongDeserializer().Deserialize(null));
+            Assert.ThrowsAny<ArgumentException>(()=> new LongDeserializer().Deserialize("topic", null));
         }
 
         [Fact]
         public void DeserializeArgLengthNotEqual8Throw()
         {
-            Assert.ThrowsAny<ArgumentException>(() => new LongDeserializer().Deserialize(new byte[7]));
-            Assert.ThrowsAny<ArgumentException>(() => new LongDeserializer().Deserialize(new byte[9]));
-        }
-
-        [Fact]
-        public void ExplicitSerializationWork()
-        {
-            foreach (string topic in new[] { null, "", "topic" })
-            {
-                var serializer = new LongSerializer();
-                var bytesImplicit = serializer.Serialize(42);
-                var bytesExplicit = ((ISerializer<long>)serializer).Serialize(topic, 42);
-
-                Assert.Equal(bytesImplicit, bytesExplicit);
-            }
-        }
-
-        [Fact]
-        public void ExplicitDeserializationWorks()
-        {
-            var byte42 = new LongSerializer().Serialize(42);
-
-            foreach (string topic in new[] { null, "", "topic" })
-            {
-                var deserializer = new LongDeserializer();
-                var deconstructExplicit = ((IDeserializer<long>)deserializer).Deserialize(topic, byte42);
-
-                Assert.Equal(42, deconstructExplicit);
-            }
+            Assert.ThrowsAny<ArgumentException>(() => new LongDeserializer().Deserialize("topic", new byte[7]));
+            Assert.ThrowsAny<ArgumentException>(() => new LongDeserializer().Deserialize("topic", new byte[9]));
         }
 
         public static IEnumerable<object[]> TestData()

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -16,6 +16,10 @@
 
 using Xunit;
 using System.Text;
+using System.Collections.Generic;
+using Confluent.Kafka;
+using System.Linq;
+using System;
 
 
 namespace Confluent.Kafka.Serialization.Tests
@@ -32,6 +36,94 @@ namespace Confluent.Kafka.Serialization.Tests
 
             // TODO: check some serialize / deserialize operations that are not expected to work, including some
             //       cases where Deserialize can be expected to throw an exception.
+        }
+
+        [Fact]
+        public void DeserializerConstructKeyViaConfig()
+        {
+            string testString = "hello world";
+            var serialized = new StringSerializer(Encoding.UTF8).Serialize("mytopic", testString);
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.deserializer.encoding.key", "utf-8");
+            var deserializer = new StringDeserializer();
+            var newConfig = deserializer.Configure(config, true);
+            Assert.Equal(0, newConfig.Count());
+            Assert.Equal(testString, deserializer.Deserialize("mytopic", serialized));
+        }
+
+        [Fact]
+        public void DeserializerConstructValueViaConfig()
+        {
+            string testString = "hello world";
+            var serialized = new StringSerializer(Encoding.UTF8).Serialize("mytopic", testString);
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.deserializer.encoding.value", "utf-8");
+            var deserializer = new StringDeserializer();
+            var newConfig = deserializer.Configure(config, false);
+            Assert.Equal(0, newConfig.Count());
+            Assert.Equal(testString, deserializer.Deserialize("mytopic", serialized));
+        }
+
+        [Fact]
+        public void SerializerConstructKeyViaConfig()
+        {
+            string testString = "hello world";
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.serializer.encoding.key", "utf-8");
+            var serializer = new StringSerializer();
+            var newConfig = serializer.Configure(config, true);
+            Assert.Equal(0, newConfig.Count());
+            var serialized = serializer.Serialize("mytopic", testString);
+            Assert.Equal(new StringDeserializer(Encoding.UTF8).Deserialize("mytopic", serialized), testString);
+        }
+
+        [Fact]
+        public void SerializerConstructValueViaConfig()
+        {
+            string testString = "hello world";
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.serializer.encoding.value", "utf-8");
+            var serializer = new StringSerializer();
+            var newConfig = serializer.Configure(config, false);
+            Assert.Equal(0, newConfig.Count());
+            var serialized = serializer.Serialize("mytopic", testString);
+            Assert.Equal(new StringDeserializer(Encoding.UTF8).Deserialize("mytopic", serialized), testString);
+        }
+
+        [Fact]
+        public void SerializeDoubleConfigKey()
+        {
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.serializer.encoding.value", "utf-8");
+            try
+            {
+                var serializer = new StringSerializer(Encoding.UTF32);
+                serializer.Configure(config, false);
+            }
+            catch (ArgumentException)
+            {
+                return;
+            }
+
+            Assert.True(false, "Exception expected");
+        }
+
+        [Fact]
+        public void DeserializeDoubleConfigValue()
+        {
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.deserializer.encoding.value", "utf-8");
+            try
+            {
+                var deserializer = new StringDeserializer(Encoding.UTF32);
+                deserializer.Configure(config, false);
+            }
+            catch (ArgumentException)
+            {
+                return;
+            }
+
+            Assert.True(false, "Exception expected");
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -25,41 +25,13 @@ namespace Confluent.Kafka.Serialization.Tests
         [Fact]
         public void SerializeDeserialize()
         {
-            Assert.Equal("hello world", new StringDeserializer(Encoding.UTF8).Deserialize(new StringSerializer(Encoding.UTF8).Serialize("hello world")));
-            Assert.Equal("ឆ្មាត្រូវបានហែលទឹក", new StringDeserializer(Encoding.UTF8).Deserialize(new StringSerializer(Encoding.UTF8).Serialize("ឆ្មាត្រូវបានហែលទឹក")));
-            Assert.Equal("вы не банан", new StringDeserializer(Encoding.UTF8).Deserialize(new StringSerializer(Encoding.UTF8).Serialize("вы не банан")));
-            Assert.Equal(null, new StringDeserializer(Encoding.UTF8).Deserialize(new StringSerializer(Encoding.UTF8).Serialize(null)));
+            Assert.Equal("hello world", new StringDeserializer(Encoding.UTF8).Deserialize("topic", new StringSerializer(Encoding.UTF8).Serialize("topic", "hello world")));
+            Assert.Equal("ឆ្មាត្រូវបានហែលទឹក", new StringDeserializer(Encoding.UTF8).Deserialize("topic", new StringSerializer(Encoding.UTF8).Serialize("topic", "ឆ្មាត្រូវបានហែលទឹក")));
+            Assert.Equal("вы не банан", new StringDeserializer(Encoding.UTF8).Deserialize("topic", new StringSerializer(Encoding.UTF8).Serialize("topic", "вы не банан")));
+            Assert.Equal(null, new StringDeserializer(Encoding.UTF8).Deserialize("topic", new StringSerializer(Encoding.UTF8).Serialize("topic", null)));
 
             // TODO: check some serialize / deserialize operations that are not expected to work, including some
             //       cases where Deserialize can be expected to throw an exception.
-        }
-
-
-        [Fact]
-        public void ExplicitSerializationWork()
-        {
-            foreach (string topic in new[] { null, "", "topic" })
-            {
-                var serializer = new StringSerializer(Encoding.UTF8);
-                var bytesImplicit = serializer.Serialize("42");
-                var bytesExplicit = ((ISerializer<string>)serializer).Serialize(topic, "42");
-
-                Assert.Equal(bytesImplicit, bytesExplicit);
-            }
-        }
-
-        [Fact]
-        public void ExplicitDeserializationWorks()
-        {
-            var byte42 = new StringSerializer(Encoding.UTF8).Serialize("42");
-
-            foreach (string topic in new[] { null, "", "topic" })
-            {
-                var deserializer = new StringDeserializer(Encoding.UTF8);
-                var deconstructExplicit = ((IDeserializer<string>)deserializer).Deserialize(topic, byte42);
-
-                Assert.Equal("42", deconstructExplicit);
-            }
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -33,5 +33,33 @@ namespace Confluent.Kafka.Serialization.Tests
             // TODO: check some serialize / deserialize operations that are not expected to work, including some
             //       cases where Deserialize can be expected to throw an exception.
         }
+
+
+        [Fact]
+        public void ExplicitSerializationWork()
+        {
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var serializer = new StringSerializer(Encoding.UTF8);
+                var bytesImplicit = serializer.Serialize("42");
+                var bytesExplicit = ((ISerializer<string>)serializer).Serialize(topic, "42");
+
+                Assert.Equal(bytesImplicit, bytesExplicit);
+            }
+        }
+
+        [Fact]
+        public void ExplicitDeserializationWorks()
+        {
+            var byte42 = new StringSerializer(Encoding.UTF8).Serialize("42");
+
+            foreach (string topic in new[] { null, "", "topic" })
+            {
+                var deserializer = new StringDeserializer(Encoding.UTF8);
+                var deconstructExplicit = ((IDeserializer<string>)deserializer).Deserialize(topic, byte42);
+
+                Assert.Equal("42", deconstructExplicit);
+            }
+        }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -125,5 +125,74 @@ namespace Confluent.Kafka.Serialization.Tests
 
             Assert.True(false, "Exception expected");
         }
+
+        [Fact]
+        public void DeserializeInvalidConfigValue()
+        {
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.deserializer.encoding.value", "invalid-encoding");
+            try
+            {
+                var deserializer = new StringDeserializer();
+                deserializer.Configure(config, false);
+            }
+            catch (Exception)
+            {
+                return;
+            }
+
+            Assert.True(false, "Exception expected");
+        }
+
+        [Fact]
+        public void SerializeInvalidConfigValue()
+        {
+            var config = new Dictionary<string, object>();
+            config.Add("dotnet.string.serializer.encoding.value", "invalid-encoding");
+            try
+            {
+                var serializer = new StringSerializer();
+                serializer.Configure(config, false);
+            }
+            catch (Exception)
+            {
+                return;
+            }
+
+            Assert.True(false, "Exception expected");
+        }
+
+        [Fact]
+        public void DeserializeNoConfigValue()
+        {
+            try
+            {
+                var deserializer = new StringDeserializer();
+                deserializer.Configure(new Dictionary<string, object>(), false);
+            }
+            catch (Exception)
+            {
+                return;
+            }
+
+            Assert.True(false, "Exception expected");
+        }
+
+        [Fact]
+        public void SerializeNoConfigValue()
+        {
+            try
+            {
+                var serializer = new StringSerializer();
+                serializer.Configure(new Dictionary<string, object>(), false);
+            }
+            catch (Exception)
+            {
+                return;
+            }
+
+            Assert.True(false, "Exception expected");
+        }
+
     }
 }


### PR DESCRIPTION
alternative to #202, following on from #129 

I like this better. Similar to Java, except (de)serializers specified via constructors can be configured using the config passed into the `Producer` or `Consumer`. 

