### PR TITLE
Handle null object case in equality operator overrides.

### DIFF
--- a/src/Confluent.Kafka/Error.cs
+++ b/src/Confluent.Kafka/Error.cs
@@ -161,7 +161,14 @@ namespace Confluent.Kafka
         ///     true if Error values a and b are equal. false otherwise.
         /// </returns>
         public static bool operator ==(Error a, Error b)
-            => a.Equals(b);
+        {
+            if (object.ReferenceEquals(a, null))
+            {
+                return object.ReferenceEquals(b, null);
+            }
+
+            return a.Equals(b);
+        }
 
         /// <summary>
         ///     Tests whether Error value a is not equal to Error value b.

--- a/src/Confluent.Kafka/TopicPartition.cs
+++ b/src/Confluent.Kafka/TopicPartition.cs
@@ -91,7 +91,14 @@ namespace Confluent.Kafka
         ///     true if TopicPartition instances a and b are equal. false otherwise.
         /// </returns>
         public static bool operator ==(TopicPartition a, TopicPartition b)
-            => a.Equals(b);
+        {
+            if (object.ReferenceEquals(a, null))
+            {
+                return object.ReferenceEquals(b, null);
+            }
+
+            return a.Equals(b);
+        }
 
         /// <summary>
         ///     Tests whether TopicPartition instance a is not equal to TopicPartition instance b.

--- a/src/Confluent.Kafka/TopicPartitionOffset.cs
+++ b/src/Confluent.Kafka/TopicPartitionOffset.cs
@@ -118,7 +118,14 @@ namespace Confluent.Kafka
         ///     true if TopicPartitionOffset instances a and b are equal. false otherwise.
         /// </returns>
         public static bool operator ==(TopicPartitionOffset a, TopicPartitionOffset b)
-            => a.Equals(b);
+        {
+            if (object.ReferenceEquals(a, null))
+            {
+                return object.ReferenceEquals(b, null);
+            }
+
+            return a.Equals(b);
+        }
 
         /// <summary>
         ///     Tests whether TopicPartitionOffset instance a is not equal to TopicPartitionOffset instance b.

--- a/src/Confluent.Kafka/TopicPartitionOffsetError.cs
+++ b/src/Confluent.Kafka/TopicPartitionOffsetError.cs
@@ -148,7 +148,14 @@ namespace Confluent.Kafka
         ///     true if TopicPartitionOffsetError instances a and b are equal. false otherwise.
         /// </returns>
         public static bool operator ==(TopicPartitionOffsetError a, TopicPartitionOffsetError b)
-            => a.Equals(b);
+        {
+            if (object.ReferenceEquals(a, null))
+            {
+                return object.ReferenceEquals(b, null);
+            }
+
+            return a.Equals(b);
+        }
 
         /// <summary>
         ///     Tests whether TopicPartitionOffsetError instance a is not equal to TopicPartitionOffsetError instance b.

--- a/test/Confluent.Kafka.UnitTests/Error.cs
+++ b/test/Confluent.Kafka.UnitTests/Error.cs
@@ -59,6 +59,27 @@ namespace Confluent.Kafka.Tests
         }
 
         [Fact]
+        public void NullEquality()
+        {
+            var e1 = new Error(ErrorCode.Local_AllBrokersDown);
+            Error e2 = null;
+            Error e3 = null;
+
+            Assert.NotEqual(e1, e2);
+            Assert.False(e1.Equals(e2));
+            Assert.False(e1 == e2);
+            Assert.True(e1 != e2);
+
+            Assert.NotEqual(e2, e1);
+            Assert.False(e2 == e1);
+            Assert.True(e2 != e1);
+
+            Assert.Equal(e2, e3);
+            Assert.True(e2 == e3);
+            Assert.False(e2 != e3);
+        }
+
+        [Fact]
         public void HasError()
         {
             var e1 = new Error(ErrorCode.NoError);

--- a/test/Confluent.Kafka.UnitTests/TopicPartition.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartition.cs
@@ -55,6 +55,27 @@ namespace Confluent.Kafka.Tests
         }
 
         [Fact]
+        public void NullEquality()
+        {
+            var tp1 = new TopicPartition("a", 31);
+            TopicPartition tp2 = null;
+            TopicPartition tp3 = null;
+
+            Assert.NotEqual(tp1, tp2);
+            Assert.False(tp1.Equals(tp2));
+            Assert.False(tp1 == tp2);
+            Assert.True(tp1 != tp2);
+
+            Assert.NotEqual(tp2, tp1);
+            Assert.False(tp2 == tp1);
+            Assert.True(tp2 != tp1);
+
+            Assert.Equal(tp2, tp3);
+            Assert.True(tp2 == tp3);
+            Assert.False(tp2 != tp3);
+        }
+
+        [Fact]
         public void ToStringTest()
         {
             var tp = new TopicPartition("mytopic", 42);

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffset.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffset.cs
@@ -57,6 +57,27 @@ namespace Confluent.Kafka.Tests
         }
 
         [Fact]
+        public void NullEquality()
+        {
+            var tpo1 = new TopicPartitionOffset("a", 31, 55);
+            TopicPartitionOffset tpo2 = null;
+            TopicPartitionOffset tpo3 = null;
+
+            Assert.NotEqual(tpo1, tpo2);
+            Assert.False(tpo1.Equals(tpo2));
+            Assert.False(tpo1 == tpo2);
+            Assert.True(tpo1 != tpo2);
+
+            Assert.NotEqual(tpo2, tpo1);
+            Assert.False(tpo2 == tpo1);
+            Assert.True(tpo2 != tpo1);
+
+            Assert.Equal(tpo2, tpo3);
+            Assert.True(tpo2 == tpo3);
+            Assert.False(tpo2 != tpo3);
+        }
+
+        [Fact]
         public void ToStringTest()
         {
             var tpo = new TopicPartitionOffset("mytopic", 42, 107);

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
@@ -60,6 +60,27 @@ namespace Confluent.Kafka.Tests
         }
 
         [Fact]
+        public void NullEquality()
+        {
+            var tpoe1 = new TopicPartitionOffsetError("a", 31, 55, ErrorCode.NoError);
+            TopicPartitionOffsetError tpoe2 = null;
+            TopicPartitionOffsetError tpoe3 = null;
+
+            Assert.NotEqual(tpoe1, tpoe2);
+            Assert.False(tpoe1.Equals(tpoe2));
+            Assert.False(tpoe1 == tpoe2);
+            Assert.True(tpoe1 != tpoe2);
+
+            Assert.NotEqual(tpoe2, tpoe1);
+            Assert.False(tpoe2 == tpoe1);
+            Assert.True(tpoe2 != tpoe1);
+
+            Assert.Equal(tpoe2, tpoe3);
+            Assert.True(tpoe2 == tpoe3);
+            Assert.False(tpoe2 != tpoe3);
+        }
+
+        [Fact]
         public void ToStringTest()
         {
             var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.Local_BadMsg);


### PR DESCRIPTION
Prevent NullReferenceException when doing == or != comparisons when Kafka object is null.