### PR TITLE
Fix integration test on windows and/or distant cluster

### DIFF
--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
@@ -43,8 +43,8 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new Producer(producerConfig))
             {
                 firstProduced = producer.ProduceAsync(topic, Encoding.UTF8.GetBytes("key"), null).Result.TopicPartitionOffset;
-                producer.ProduceAsync(topic, null, Encoding.UTF8.GetBytes("val"));
-                producer.Flush(30);
+                var secondProduced = producer.ProduceAsync(topic, null, Encoding.UTF8.GetBytes("val"));
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             var consumerConfig = new Dictionary<string, object>

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
@@ -43,7 +43,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new Producer(producerConfig))
             {
                 firstProduced = producer.ProduceAsync(topic, Encoding.UTF8.GetBytes("key"), null).Result.TopicPartitionOffset;
-                var secondProduced = producer.ProduceAsync(topic, null, Encoding.UTF8.GetBytes("val"));
+                producer.ProduceAsync(topic, null, Encoding.UTF8.GetBytes("val"));
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -54,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Subscribe(topic);
                 Assert.Equal(consumer.Assignment.Count, 0);
-                consumer.Poll(TimeSpan.FromSeconds(1));
+                consumer.Poll(TimeSpan.FromSeconds(10));
                 Assert.Equal(consumer.Assignment.Count, 1);
                 Assert.Equal(consumer.Assignment[0].Topic, topic);
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = await producer.ProduceAsync(topic, new byte[] {42}, new byte[] {44});
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
-                producer.Flush(30);
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = await producer.ProduceAsync(topic, null, "test string");
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
-                producer.Flush(30);
+                producer.Flush(TimeSpan.FromSeconds(10));
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Tests.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Tests.cs
@@ -19,12 +19,22 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using System.Reflection;
+using System;
 
 namespace Confluent.Kafka.IntegrationTests
 {
     public static partial class Tests
     {
         private static List<object[]> kafkaParameters;
+
+        static Tests()
+        {
+            // Quick fix for https://github.com/Microsoft/vstest/issues/918
+            // Some tests will log using ConsoleLogger which print to standard Err by default, bugged on vstest
+            // If we have error in test, they may hang
+            // Write to standard output solve the issue
+            Console.SetError(Console.Out);
+        }
 
         public static IEnumerable<object[]> KafkaParameters()
         {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Tests.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Tests.cs
@@ -30,9 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             if (kafkaParameters == null)
             {
-                var codeBase = typeof(Tests).GetTypeInfo().Assembly.CodeBase;
-                // TODO: Better way to turn Uri into path?
-                var assemblyPath = codeBase.Substring("file://".Length);
+                var assemblyPath = typeof(Tests).GetTypeInfo().Assembly.Location;
                 var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
                 var jsonPath = Path.Combine(assemblyDirectory, "kafka.parameters.json");
                 dynamic json = JsonConvert.DeserializeObject(File.ReadAllText(jsonPath));


### PR DESCRIPTION
Fix #136 
Fix integration tests on windows (path to file and bug on Console.Error)

Also fix integration tests when testing on distant cluster, where flush/poll need more time to complete properly