### PR TITLE
byte[], float and double serdes

### DIFF
--- a/src/Confluent.Kafka/Serialization/ByteArrayDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/ByteArrayDeserializer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     A deserializer for System.Byte[] values. 
+    /// </summary>
+    public class ByteArrayDeserializer : IDeserializer<byte[]>
+    {
+        /// <summary>
+        ///     Deserializes a System.Byte[] value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized System.Byte[] value
+        /// </param>
+        /// <returns>
+        ///     The deserialized System.Byte[] value.
+        /// </returns>
+        public byte[] Deserialize(byte[] data)
+        {
+            return data;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Serialization/ByteArrayDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/ByteArrayDeserializer.cs
@@ -14,25 +14,35 @@
 //
 // Refer to LICENSE for more information.
 
+using System.Collections.Generic;
+
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
-    ///     A deserializer for System.Byte[] values. 
+    ///     A deserializer for System.Byte[] values. This deserializer simply passes through the provided System.Byte[] value.
     /// </summary>
     public class ByteArrayDeserializer : IDeserializer<byte[]>
     {
         /// <summary>
-        ///     Deserializes a System.Byte[] value from a byte array.
+        ///     Deserializes a System.Byte[] value (or null) from a byte array.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
         /// <param name="data">
-        ///     A byte array containing the serialized System.Byte[] value
+        ///     A byte array containing the serialized System.Byte[] value (or null).
         /// </param>
         /// <returns>
         ///     The deserialized System.Byte[] value.
         /// </returns>
-        public byte[] Deserialize(byte[] data)
+        public byte[] Deserialize(string topic, byte[] data)
         {
             return data;
         }
+
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/ByteArraySerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ByteArraySerializer.cs
@@ -14,25 +14,35 @@
 //
 // Refer to LICENSE for more information.
 
+using System.Collections.Generic;
+
+
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
-    ///     System.Byte[] serializer. serialized data is original data.
+    ///     System.Byte[] serializer. This serializer simply passes through the provided System.Byte[] value.
     /// </summary>
     public class ByteArraySerializer : ISerializer<byte[]>
     {
         /// <summary>
-        ///     Serializes the specified System.Byte[] value to a byte array. Byte order is original order.
+        ///     Serializes the specified System.Byte[] value (or null) to a byte array. Byte order is original order. 
         /// </summary>
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this serializer).
+        /// </param>
         /// <param name="data">
-        ///     The System.Byte[] value to serialize.
+        ///     The System.Byte[] value to serialize (or null).
         /// </param>
         /// <returns>
         ///     The System.Byte[] value <paramref name="data" /> encoded as a byte array. 
         /// </returns>
-        public byte[] Serialize(byte[] data)
+        public byte[] Serialize(string topic, byte[] data)
         {
             return data;
         }
+
+        /// <include file='../include_docs.xml' path='API/Member[@name="ISerializer_Configure"]/*' />
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
     }
 }

--- a/src/Confluent.Kafka/Serialization/ByteArraySerializer.cs
+++ b/src/Confluent.Kafka/Serialization/ByteArraySerializer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     System.Byte[] serializer. serialized data is original data.
+    /// </summary>
+    public class ByteArraySerializer : ISerializer<byte[]>
+    {
+        /// <summary>
+        ///     Serializes the specified System.Byte[] value to a byte array. Byte order is original order.
+        /// </summary>
+        /// <param name="data">
+        ///     The System.Byte[] value to serialize.
+        /// </param>
+        /// <returns>
+        ///     The System.Byte[] value <paramref name="data" /> encoded as a byte array. 
+        /// </returns>
+        public byte[] Serialize(byte[] data)
+        {
+            return data;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Serialization/DoubleDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/DoubleDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2017 Confluent Inc.
+// Copyright 2016-2017 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,32 +21,32 @@ using System.Collections.Generic;
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
-    ///     A deserializer for big endian encoded (network byte ordered) System.Single values.
+    ///     A deserializer for big endian encoded (network byte ordered) System.Double values.
     /// </summary>
-    public class FloatDeserializer : IDeserializer<float>
+    public class DoubleDeserializer : IDeserializer<double>
     {
         /// <summary>
-        ///     Deserializes a big endian encoded (network byte ordered) System.Single value from a byte array.
+        ///     Deserializes a big endian encoded (network byte ordered) System.Double value from a byte array.
         /// </summary>
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this deserializer).
         /// </param>
         /// <param name="data">
-        ///     A byte array containing the serialized System.Single value (big endian encoding).
+        ///     A byte array containing the serialized System.Double value (big endian encoding).
         /// </param>
         /// <returns>
-        ///     The deserialized System.Single value.
+        ///     The deserialized System.Double value.
         /// </returns>
-        public float Deserialize(string topic, byte[] data)
+        public double Deserialize(string topic, byte[] data)
         {
             if (data == null)
             {
                 throw new ArgumentNullException($"Arg {nameof(data)} is null");
             }
 
-            if (data.Length != 4)
+            if (data.Length != 8)
             {
-                throw new ArgumentException($"Size of {nameof(data)} received by {nameof(FloatDeserializer)} is not 4");
+                throw new ArgumentException($"Size of {nameof(data)} received by {nameof(DoubleDeserializer)} is not 8");
             }
 
             // network byte order -> big endian -> most significant byte in the smallest address.
@@ -54,8 +54,12 @@ namespace Confluent.Kafka.Serialization
             {
                 unsafe
                 {
-                    float result = default(float);
+                    double result = default(double);
                     byte* p = (byte*)(&result);
+                    *p++ = data[7];
+                    *p++ = data[6];
+                    *p++ = data[5];
+                    *p++ = data[4];
                     *p++ = data[3];
                     *p++ = data[2];
                     *p++ = data[1];
@@ -65,7 +69,7 @@ namespace Confluent.Kafka.Serialization
             }
             else
             {
-                return BitConverter.ToSingle(data, 0);
+                return BitConverter.ToDouble(data, 0);
             }
         }
 

--- a/src/Confluent.Kafka/Serialization/DoubleSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/DoubleSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2017 Confluent Inc.
+// Copyright 2016-2017 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,30 +21,34 @@ using System.Collections.Generic;
 namespace Confluent.Kafka.Serialization
 {
     /// <summary>
-    ///     System.Single serializer. Byte order of serialized data is big endian (network byte order).
+    ///     System.Double serializer. Byte order of serialized data is big endian (network byte order).
     /// </summary>
-    public class FloatSerializer : ISerializer<float>
+    public class DoubleSerializer : ISerializer<double>
     {
         /// <summary>
-        ///     Serializes the specified System.Single value to a byte array of length 4. Byte order is big endian (network byte order).
+        ///     Serializes the specified System.Double value to a byte array of length 8. Byte order is big endian (network byte order).
         /// </summary>
         /// <param name="topic">
         ///     The topic associated with the data (ignored by this serializer).
         /// </param>
         /// <param name="data">
-        ///     The System.Single value to serialize.
+        ///     The System.Double value to serialize.
         /// </param>
         /// <returns>
-        ///     The System.Single value <paramref name="data" /> encoded as a byte array of length 4 (network byte order).
+        ///     The System.Double value <paramref name="data" /> encoded as a byte array of length 4 (network byte order).
         /// </returns>
-        public byte[] Serialize(string topic, float data)
+        public byte[] Serialize(string topic, double data)
         {
             if (BitConverter.IsLittleEndian)
             {
                 unsafe
                 {
-                    byte[] result = new byte[4];
+                    byte[] result = new byte[8];
                     byte* p = (byte*)(&data);
+                    result[7] = *p++;
+                    result[6] = *p++;
+                    result[5] = *p++;
+                    result[4] = *p++;
                     result[3] = *p++;
                     result[2] = *p++;
                     result[1] = *p++;

--- a/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatDeserializer.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     A deserializer for big endian encoded (network byte ordered) System.Single values.
+    /// </summary>
+    public class FloatDeserializer : IDeserializer<float>
+    {
+        /// <summary>
+        ///     Deserializes a big endian encoded (network byte ordered) System.Single value from a byte array.
+        /// </summary>
+        /// <param name="data">
+        ///     A byte array containing the serialized System.Single value (big endian encoding)
+        /// </param>
+        /// <returns>
+        ///     The deserialized System.Single value.
+        /// </returns>
+        public float Deserialize(byte[] data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException($"Arg {nameof(data)} is null");
+            }
+
+            if (data.Length != 4)
+            {
+                throw new ArgumentException($"Size of {nameof(data)} received by {nameof(FloatDeserializer)} is not 4");
+            }
+
+            // network byte order -> big endian -> most significant byte in the smallest address.
+            if (BitConverter.IsLittleEndian)
+            {
+                unsafe
+                {
+                    float result = default(float);
+                    byte* p = (byte*)(&result);
+                    *p++ = data[3];
+                    *p++ = data[2];
+                    *p++ = data[1];
+                    *p++ = data[0];
+                    return result;
+                }
+            }
+            else
+            {
+                return BitConverter.ToSingle(data, 0);
+            }
+        }
+    }
+}

--- a/src/Confluent.Kafka/Serialization/FloatSerializer.cs
+++ b/src/Confluent.Kafka/Serialization/FloatSerializer.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     System.Single serializer. Byte order of serialized data is big endian (network byte order).
+    /// </summary>
+    public class FloatSerializer : ISerializer<float>
+    {
+        /// <summary>
+        ///     Serializes the specified System.Single value to a byte array of length 4. Byte order is big endian (network byte order).
+        /// </summary>
+        /// <param name="data">
+        ///     The System.Single value to serialize.
+        /// </param>
+        /// <returns>
+        ///     The System.Single value <paramref name="data" /> encoded as a byte array of length 4 (network byte order).
+        /// </returns>
+        public byte[] Serialize(float data)
+        {
+            if (BitConverter.IsLittleEndian)
+            {
+                unsafe
+                {
+                    byte[] result = new byte[4];
+                    byte* p = (byte*)(&data);
+                    result[3] = *p++;
+                    result[2] = *p++;
+                    result[1] = *p++;
+                    result[0] = *p++;
+                    return result;
+                }
+            }
+            else
+            {
+                return BitConverter.GetBytes(data);
+            }
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/BrokerMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/BrokerMetadata.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class BrokerMetadataTest
     {

--- a/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
+++ b/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class CommittedOffetsTest
     {

--- a/test/Confluent.Kafka.UnitTests/Consumer.cs
+++ b/test/Confluent.Kafka.UnitTests/Consumer.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using Confluent.Kafka.Serialization;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class ConsumerTests
     {

--- a/test/Confluent.Kafka.UnitTests/Error.cs
+++ b/test/Confluent.Kafka.UnitTests/Error.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class ErrorTests
     {

--- a/test/Confluent.Kafka.UnitTests/GroupInfo.cs
+++ b/test/Confluent.Kafka.UnitTests/GroupInfo.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class GroupInfoTests
     {

--- a/test/Confluent.Kafka.UnitTests/GroupMemberInfo.cs
+++ b/test/Confluent.Kafka.UnitTests/GroupMemberInfo.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class GroupMemberInfoTests
     {

--- a/test/Confluent.Kafka.UnitTests/InvalidHandle.cs
+++ b/test/Confluent.Kafka.UnitTests/InvalidHandle.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class InvalidHandleTest
     {

--- a/test/Confluent.Kafka.UnitTests/LogMessage.cs
+++ b/test/Confluent.Kafka.UnitTests/LogMessage.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class LogMessageTests
     {

--- a/test/Confluent.Kafka.UnitTests/Message.cs
+++ b/test/Confluent.Kafka.UnitTests/Message.cs
@@ -18,7 +18,7 @@ using System;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class MessageTests
     {

--- a/test/Confluent.Kafka.UnitTests/Metadata.cs
+++ b/test/Confluent.Kafka.UnitTests/Metadata.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class MetadataTests
     {

--- a/test/Confluent.Kafka.UnitTests/Offset.cs
+++ b/test/Confluent.Kafka.UnitTests/Offset.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class OffsetTests
     {

--- a/test/Confluent.Kafka.UnitTests/PartitionMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/PartitionMetadata.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class PartitionMetadataTests
     {

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -1,6 +1,7 @@
 ﻿using Confluent.Kafka.Serialization;
 using Xunit;
 
+
 namespace Confluent.Kafka.UnitTests.Serialization
 {
     public class ByteArrayTests
@@ -13,12 +14,6 @@ namespace Confluent.Kafka.UnitTests.Serialization
         public void CanReconstruct(byte[] values)
         {
             Assert.Equal(values, new ByteArrayDeserializer().Deserialize(null, new ByteArraySerializer().Serialize(null, values)));
-        }
-
-        [Fact]
-        public void DeserizerNull()
-        {
-            Assert.Null(new ByteArrayDeserializer().Deserialize(null, null));
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -12,13 +12,13 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [InlineData(new byte[] { 1, 2, 3, 4, 5 })]
         public void CanReconstruct(byte[] values)
         {
-            Assert.Equal(values, new ByteArrayDeserializer().Deserialize(new ByteArraySerializer().Serialize(values)));
+            Assert.Equal(values, new ByteArrayDeserializer().Deserialize(null, new ByteArraySerializer().Serialize(null, values)));
         }
 
         [Fact]
         public void DeserizerNull()
         {
-            Assert.Null(new ByteArrayDeserializer().Deserialize(null));
+            Assert.Null(new ByteArrayDeserializer().Deserialize(null, null));
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -1,0 +1,24 @@
+﻿using Confluent.Kafka.Serialization;
+using Xunit;
+
+namespace Confluent.Kafka.UnitTests.Serialization
+{
+    public class ByteArrayTests
+    {
+        [Theory]
+        [InlineData(default(byte[]))]
+        [InlineData(new byte[0])]
+        [InlineData(new byte[] { 1 })]
+        [InlineData(new byte[] { 1, 2, 3, 4, 5 })]
+        public void CanReconstruct(byte[] values)
+        {
+            Assert.Equal(values, new ByteArrayDeserializer().Deserialize(new ByteArraySerializer().Serialize(values)));
+        }
+
+        [Fact]
+        public void DeserizerNull()
+        {
+            Assert.Null(new ByteArrayDeserializer().Deserialize(null));
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
@@ -27,31 +27,31 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [MemberData(nameof(TestData))]
         public void CanReconstruct(double value)
         {
-            Assert.Equal(value, new DoubleDeserializer().Deserialize(new DoubleSerializer().Serialize(value)));
+            Assert.Equal(value, new DoubleDeserializer().Deserialize(null, new DoubleSerializer().Serialize(null, value)));
         }
 
         [Fact]
         public void IsBigEndian()
         {
-            var buffer = new byte[] { 23, 0, 0, 0 };
+            var buffer = new byte[] { 23, 0, 0, 0, 0, 0, 0, 0 };
             var value = BitConverter.ToDouble(buffer, 0);
-            var data = new DoubleSerializer().Serialize(value);
-            Assert.Equal(23, data[3]);
+            var data = new DoubleSerializer().Serialize(null, value);
+            Assert.Equal(23, data[7]);
             Assert.Equal(0, data[0]);
         }
 
         [Fact]
         public void DeserializeArgNullThrow()
         {
-            Assert.ThrowsAny<ArgumentNullException>(() => new DoubleDeserializer().Deserialize(null));
+            Assert.ThrowsAny<ArgumentNullException>(() => new DoubleDeserializer().Deserialize(null, null));
         }
 
         [Fact]
         public void DeserializeArgLengthNotEqual4Throw()
         {
-            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(new byte[0]));
-            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(new byte[3]));
-            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(new byte[5]));
+            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(null, new byte[0]));
+            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(null, new byte[7]));
+            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(null, new byte[9]));
         }
 
         public static IEnumerable<object[]> TestData()

--- a/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
@@ -1,0 +1,76 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Confluent.Kafka.Serialization;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Confluent.Kafka.UnitTests.Serialization
+{
+    public class DoubleTests
+    {
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void CanReconstruct(double value)
+        {
+            Assert.Equal(value, new DoubleDeserializer().Deserialize(new DoubleSerializer().Serialize(value)));
+        }
+
+        [Fact]
+        public void IsBigEndian()
+        {
+            var buffer = new byte[] { 23, 0, 0, 0 };
+            var value = BitConverter.ToDouble(buffer, 0);
+            var data = new DoubleSerializer().Serialize(value);
+            Assert.Equal(23, data[3]);
+            Assert.Equal(0, data[0]);
+        }
+
+        [Fact]
+        public void DeserializeArgNullThrow()
+        {
+            Assert.ThrowsAny<ArgumentNullException>(() => new DoubleDeserializer().Deserialize(null));
+        }
+
+        [Fact]
+        public void DeserializeArgLengthNotEqual4Throw()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(new byte[0]));
+            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(new byte[3]));
+            Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(new byte[5]));
+        }
+
+        public static IEnumerable<object[]> TestData()
+        {
+            double[] testData = new double[]
+            {
+                0, 1, -1, 42, -42, 127, 128, 129, -127, -128,
+                -129,254, 255, 256, 257, -254, -255, -256, -257,
+                short.MinValue-1, short.MinValue, short.MinValue+1,
+                short.MaxValue-1, short.MaxValue,short.MaxValue+1,
+                int.MaxValue-1, int.MaxValue, int.MinValue, int.MinValue + 1,
+                double.MaxValue-1,double.MaxValue,double.MinValue,double.MinValue+1,
+                double.NaN,double.PositiveInfinity,double.NegativeInfinity,double.Epsilon,-double.Epsilon
+            };
+
+            foreach (var v in testData)
+            {
+                yield return new object[] { v };
+            }
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
+
 namespace Confluent.Kafka.UnitTests.Serialization
 {
     public class DoubleTests
@@ -47,7 +48,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         }
 
         [Fact]
-        public void DeserializeArgLengthNotEqual4Throw()
+        public void DeserializeArgLengthNotEqual8Throw()
         {
             Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(null, new byte[0]));
             Assert.ThrowsAny<ArgumentException>(() => new DoubleDeserializer().Deserialize(null, new byte[7]));

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Confluent.Kafka.Serialization;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Confluent.Kafka.UnitTests.Serialization
+{
+    public class FloatTests
+    {
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void CanReconstruct(float value)
+        {
+            Assert.Equal(value, new FloatDeserializer().Deserialize(new FloatSerializer().Serialize(value)));
+        }
+
+        [Fact]
+        public void IsBigEndian()
+        {
+            var buffer = new byte[] { 23, 0, 0, 0 };
+            var value = BitConverter.ToSingle(buffer, 0);
+            var data = new FloatSerializer().Serialize(value);
+            Assert.Equal(23, data[3]);
+            Assert.Equal(0, data[0]);
+        }
+
+        [Fact]
+        public void DeserializeArgNullThrow()
+        {
+            Assert.ThrowsAny<ArgumentNullException>(() => new FloatDeserializer().Deserialize(null));
+        }
+
+        [Fact]
+        public void DeserializeArgLengthNotEqual4Throw()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[0]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[3]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[5]));
+        }
+
+        public static IEnumerable<object[]> TestData()
+        {
+            float[] testData = new float[]
+            {
+                0, 1, -1, 42, -42, 127, 128, 129, -127, -128,
+                -129,254, 255, 256, 257, -254, -255, -256, -257,
+                short.MinValue-1, short.MinValue, short.MinValue+1,
+                short.MaxValue-1, short.MaxValue,short.MaxValue+1,
+                int.MaxValue-1, int.MaxValue, int.MinValue, int.MinValue + 1,
+                float.MaxValue-1,float.MaxValue,float.MinValue,float.MinValue+1,
+                float.NaN,float.PositiveInfinity,float.NegativeInfinity,float.Epsilon,-float.Epsilon
+            };
+
+            foreach (var v in testData)
+            {
+                yield return new object[] { v };
+            }
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -27,7 +27,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [MemberData(nameof(TestData))]
         public void CanReconstruct(float value)
         {
-            Assert.Equal(value, new FloatDeserializer().Deserialize(new FloatSerializer().Serialize(value)));
+            Assert.Equal(value, new FloatDeserializer().Deserialize(null, new FloatSerializer().Serialize(null, value)));
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             var buffer = new byte[] { 23, 0, 0, 0 };
             var value = BitConverter.ToSingle(buffer, 0);
-            var data = new FloatSerializer().Serialize(value);
+            var data = new FloatSerializer().Serialize(null, value);
             Assert.Equal(23, data[3]);
             Assert.Equal(0, data[0]);
         }
@@ -43,15 +43,15 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [Fact]
         public void DeserializeArgNullThrow()
         {
-            Assert.ThrowsAny<ArgumentNullException>(() => new FloatDeserializer().Deserialize(null));
+            Assert.ThrowsAny<ArgumentNullException>(() => new FloatDeserializer().Deserialize(null, null));
         }
 
         [Fact]
         public void DeserializeArgLengthNotEqual4Throw()
         {
-            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[0]));
-            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[3]));
-            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(new byte[5]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(null, new byte[0]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(null, new byte[3]));
+            Assert.ThrowsAny<ArgumentException>(() => new FloatDeserializer().Deserialize(null, new byte[5]));
         }
 
         public static IEnumerable<object[]> TestData()

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
+
 namespace Confluent.Kafka.UnitTests.Serialization
 {
     public class FloatTests
@@ -64,7 +65,8 @@ namespace Confluent.Kafka.UnitTests.Serialization
                 short.MaxValue-1, short.MaxValue,short.MaxValue+1,
                 int.MaxValue-1, int.MaxValue, int.MinValue, int.MinValue + 1,
                 float.MaxValue-1,float.MaxValue,float.MinValue,float.MinValue+1,
-                float.NaN,float.PositiveInfinity,float.NegativeInfinity,float.Epsilon,-float.Epsilon
+                float.NaN,float.PositiveInfinity,float.NegativeInfinity,float.Epsilon,-float.Epsilon,
+                0.1f, -0.1f
             };
 
             foreach (var v in testData)

--- a/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
@@ -19,9 +19,9 @@ using Xunit;
 using Confluent.Kafka.Serialization;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests.Serialization
 {
-    public class IntSerdeTests
+    public class IntTests
     {
         private static readonly int[] toTest = new int[]
         {

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -19,7 +19,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace Confluent.Kafka.UnitTests
+namespace Confluent.Kafka.UnitTests.Serialization
 {
     public class LongTests
     {

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -22,7 +22,7 @@ using System.Linq;
 using System;
 
 
-namespace Confluent.Kafka.Serialization.Tests
+namespace Confluent.Kafka.UnitTests.Serialization
 {
     public class StringTests
     {

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -17,7 +17,7 @@
 using Xunit;
 using System.Text;
 using System.Collections.Generic;
-using Confluent.Kafka;
+using Confluent.Kafka.Serialization;
 using System.Linq;
 using System;
 

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -18,7 +18,7 @@ using System;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class TimestampTests
     {

--- a/test/Confluent.Kafka.UnitTests/TopicMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicMetadata.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class TopicMetadataTests
     {

--- a/test/Confluent.Kafka.UnitTests/TopicPartition.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartition.cs
@@ -18,7 +18,7 @@ using Xunit;
 using System.Collections.Generic;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class TopicPartitionTests
     {

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffset.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffset.cs
@@ -18,7 +18,7 @@ using Xunit;
 using System.Collections.Generic;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class TopicPartitionOffsetTests
     {

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
@@ -18,7 +18,7 @@ using Xunit;
 using System.Collections.Generic;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class TopicPartitionOffsetErrorTests
     {

--- a/test/Confluent.Kafka.UnitTests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.UnitTests/WatermarkOffsets.cs
@@ -17,7 +17,7 @@
 using Xunit;
 
 
-namespace Confluent.Kafka.Tests
+namespace Confluent.Kafka.UnitTests
 {
     public class WatermarkOffsetTests
     {


### PR DESCRIPTION
this is a continuation of @wangyanjun 's  #130. Adds `double` serde + updates for new serialization interface.
