### PR TITLE
added badge for slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Confluent's .NET Client for Apache Kafka<sup>TM</sup>
 
 [![Travis Build Status](https://travis-ci.org/confluentinc/confluent-kafka-dotnet.svg?branch=master)](https://travis-ci.org/confluentinc/confluent-kafka-dotnet)
 [![Build status](https://ci.appveyor.com/api/projects/status/kux83eykufuv16cn/branch/master?svg=true)](https://ci.appveyor.com/project/ConfluentClientEngineering/confluent-kafka-dotnet/branch/master)
+[![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-7A5979.svg)](https://confluentcommunity.slack.com/messages/clients)
 
 **confluent-kafka-dotnet** is Confluent's .NET client for [Apache Kafka](http://kafka.apache.org/) and the
 [Confluent Platform](https://www.confluent.io/product/).


### PR DESCRIPTION
added a badge that links to the clients confluent community slack channel. 
should do this for the other clients too.
