### PR TITLE
AppVeyor pre-release nuget feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ client. Thanks Andreas!
 
 Reference the [Confluent.Kafka NuGet package](https://www.nuget.org/packages/Confluent.Kafka/) (version 0.11.0).
 
-To install confluent-kafka-dotnet from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
+To install confluent-kafka-dotnet from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager 
+UI, or run the following command in the Package Manager Console:
 
 ```
 Install-Package Confluent.Kafka -Version 0.11.0
@@ -50,6 +51,14 @@ To reference in a dotnet core project, explicitly add a package reference to you
   ...
 </ItemGroup>
 ```
+
+Pre-release nuget packages are available from the following nuget package source:
+[https://ci.appveyor.com/nuget/confluent-kafka-dotnet](https://ci.appveyor.com/nuget/confluent-kafka-dotnet). 
+
+The version suffix of these nuget packages matches the appveyor build number. You can see which commit a 
+particular build number corresponds to by looking at the 
+[AppVeyor build history](https://ci.appveyor.com/project/ConfluentClientEngineering/confluent-kafka-dotnet/history)
+
 
 ## Examples
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,10 +46,3 @@ deploy:
     folder: dotnet
     artifact: docs
     set_public: true
-
-#deploy:
-#  provider: NuGet
-#  api_key:
-#    secure: qbl3uvq1riFSNeRw6/MHnaDbJ0Ft9evEcz3nQp061pKEhXn0ex4eI56dwUOO2fWF
-#  skip_symbols: true
-#  artifact: /.*\.nupkg/


### PR DESCRIPTION
appveyor exposes pre-release nuget packages, so let's just point people to that and not bother uploading pre-release versions to nuget.org.

for now, leaving the task of uploading release versions to nuget.org as a manual process.
