### PR TITLE
WIP : Delete topics

### DIFF
--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -1,0 +1,374 @@
+// Copyright 2016-2017 Confluent Inc., 2015-2016 Andreas Heider
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Confluent.Kafka.Impl;
+using Confluent.Kafka.Internal;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Implements a high-level Apache Kafka producer (without serialization).
+    /// </summary>
+    public class AdminClient : IDisposable, IAdmin
+    {
+        private bool manualPoll;
+        private bool disableDeliveryReports;
+        
+        private SafeKafkaHandle kafkaHandle;
+
+        private Task callbackTask;
+        private CancellationTokenSource callbackCts;
+
+        private const int POLL_TIMEOUT_MS = 100;
+        private Task StartPollTask(CancellationToken ct)
+            => Task.Factory.StartNew(() =>
+                {
+                    while (!ct.IsCancellationRequested)
+                    {
+                        kafkaHandle.Poll((IntPtr)POLL_TIMEOUT_MS);
+                    }
+                }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+        private LibRdKafka.ErrorDelegate errorDelegate;
+        private void ErrorCallback(IntPtr rk, ErrorCode err, string reason, IntPtr opaque)
+        {
+            OnError?.Invoke(this, new Error(err, reason));
+        }
+
+        private LibRdKafka.StatsDelegate statsDelegate;
+        private int StatsCallback(IntPtr rk, IntPtr json, UIntPtr json_len, IntPtr opaque)
+        {
+            OnStatistics?.Invoke(this, Util.Marshal.PtrToStringUTF8(json));
+            return 0; // instruct librdkafka to immediately free the json ptr.
+        }
+
+        private LibRdKafka.LogDelegate logDelegate;
+        private void LogCallback(IntPtr rk, int level, string fac, string buf)
+        {
+            var name = Util.Marshal.PtrToStringUTF8(LibRdKafka.name(rk));
+
+            if (OnLog == null)
+            {
+                // Log to stderr by default if no logger is specified.
+                Loggers.ConsoleLogger(this, new LogMessage(name, level, fac, buf));
+                return;
+            }
+
+            OnLog.Invoke(this, new LogMessage(name, level, fac, buf));
+        }
+
+        /// <summary>
+        ///     Initializes a new Producer instance.
+        /// </summary>
+        /// <param name="config">
+        ///     librdkafka configuration parameters (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+        ///     Topic configuration parameters are specified via the "default.topic.config" sub-dictionary config parameter.
+        /// </param>
+        /// <param name="manualPoll">
+        ///     If true, does not start a dedicated polling thread to trigger events or receive delivery reports -
+        ///     you must call the Poll method periodically instead. Typically you should set this parameter to false.
+        /// </param>
+        public AdminClient(IEnumerable<KeyValuePair<string, object>> config, bool manualPoll)
+        {
+            this.manualPoll = manualPoll;
+
+            var configHandle = SafeConfigHandle.Create();
+            config
+                .Where(prop => prop.Key != "default.topic.config")
+                .ToList()
+                .ForEach((kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); });
+
+            IntPtr configPtr = configHandle.DangerousGetHandle();
+            
+            // Explicitly keep references to delegates so they are not reclaimed by the GC.
+            errorDelegate = ErrorCallback;
+            logDelegate = LogCallback;
+            statsDelegate = StatsCallback;
+
+            // TODO: provide some mechanism whereby calls to the error and log callbacks are cached until
+            //       such time as event handlers have had a chance to be registered.
+            LibRdKafka.conf_set_error_cb(configPtr, errorDelegate);
+            LibRdKafka.conf_set_log_cb(configPtr, logDelegate);
+            LibRdKafka.conf_set_stats_cb(configPtr, statsDelegate);
+
+            this.kafkaHandle = SafeKafkaHandle.Create(RdKafkaType.Producer, configPtr);
+            configHandle.SetHandleAsInvalid(); // config object is no longer useable.
+
+            if (!manualPoll)
+            {
+                callbackCts = new CancellationTokenSource();
+                callbackTask = StartPollTask(callbackCts.Token);
+            }
+        }
+
+        /// <summary>
+        ///     Initializes a new Producer instance.
+        /// </summary>
+        /// <param name="config">
+        ///     librdkafka configuration parameters (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+        ///     Topic configuration parameters are specified via the "default.topic.config" sub-dictionary config parameter.
+        /// </param>
+        public AdminClient(IEnumerable<KeyValuePair<string, object>> config)
+            : this(config, false) {}
+
+
+        /// <summary>
+        ///     Poll for callback events. You will not typically need
+        ///     to call this method. Only call on producer instances 
+        ///     where background polling is not enabled.
+        /// </summary>
+        /// <param name="millisecondsTimeout">
+        ///     The maximum period of time to block (in milliseconds) if no
+        ///     callback events are waiting or -1 to block indefinitely. 
+        ///     You should typically use a relatively short timout period 
+        ///     because this operation cannot be cancelled.
+        /// </param>
+        /// <returns>
+        ///     Returns the number of events served.
+        /// </returns>
+        public int Poll(int millisecondsTimeout)
+        {
+            if (!manualPoll)
+            {
+                throw new InvalidOperationException("Poll method called when manualPoll not enabled.");
+            }
+            return kafkaHandle.Poll((IntPtr)millisecondsTimeout);
+        }
+
+        /// <summary>
+        ///     Poll for callback events. You will not typically need
+        ///     to call this method. Only call on producer instances 
+        ///     where background polling is not enabled.
+        /// </summary>
+        /// <param name="timeout">
+        ///     The maximum period of time to block if no callback events
+        ///     are waiting. You should typically use a relatively short 
+        ///     timout period because this operation cannot be cancelled.
+        /// </param>
+        /// <returns>
+        ///     Returns the number of events served.
+        /// </returns>
+        public int Poll(TimeSpan timeout)
+            => Poll(timeout.TotalMillisecondsAsInt());
+        
+        /// <summary>
+        ///     Raised on critical errors, e.g. connection failures or all 
+        ///     brokers down. Note that the client will try to automatically 
+        ///     recover from errors - these errors should be seen as 
+        ///     informational rather than catastrophic
+        /// </summary>
+        /// <remarks>
+        ///     Called on the Producer poll thread.
+        /// </remarks>
+        public event EventHandler<Error> OnError;
+
+        /// <summary>
+        ///     Raised on librdkafka statistics events. JSON formatted
+        ///     string as defined here: https://github.com/edenhill/librdkafka/wiki/Statistics
+        /// </summary>
+        /// <remarks>
+        ///     You can enable statistics and set the statistics interval
+        ///     using the statistics.interval.ms configuration parameter
+        ///     (disabled by default).
+        ///
+        ///     Called on the Producer poll thread.
+        /// </remarks>
+        public event EventHandler<string> OnStatistics;
+
+        /// <summary>
+        ///     Raised when there is information that should be logged.
+        /// </summary>
+        /// <remarks>
+        ///     By default not many log messages are generated.
+        /// 
+        ///     You can specify one or more debug contexts using the 'debug'
+        ///     configuration property and a log level using the 'log_level'
+        ///     configuration property to enable more verbose logging,
+        ///     however you shouldn't typically need to do this.
+        ///
+        ///     Warning: Log handlers are called spontaneously from internal librdkafka 
+        ///     threads and the application must not call any Confluent.Kafka APIs from 
+        ///     within a log handler or perform any prolonged operations.
+        /// </remarks>
+        public event EventHandler<LogMessage> OnLog;
+        
+        /// <summary>
+        ///     Gets the name of this producer instance.
+        ///     Contains (but is not equal to) the client.id configuration parameter.
+        /// </summary>
+        /// <remarks>
+        ///     This name will be unique across all producer instances
+        ///     in a given application which allows log messages to be
+        ///     associated with the corresponding instance.
+        /// </remarks>
+        public string Name
+            => kafkaHandle.Name;
+        
+        /// <summary>
+        ///     Releases all resources used by this AdminClient.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!this.manualPoll)
+            {
+                // Note: It's necessary to wait on callbackTask before disposing kafkaHandle.
+                // TODO: If called in a finalizer, can callbackTask be potentially null?
+                callbackCts.Cancel();
+                callbackTask.Wait();
+            }
+            kafkaHandle.Dispose();
+        }
+
+        /// <summary>
+        ///     Get information pertaining to all groups in the Kafka cluster (blocking)
+        ///
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        /// <param name="timeout">
+        ///     The maximum period of time the call may block.
+        /// </param>
+        public List<GroupInfo> ListGroups(TimeSpan timeout)
+            => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
+
+
+        /// <summary>
+        ///     Get information pertaining to a particular group in the
+        ///     Kafka cluster (blocking).
+        ///
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        /// <param name="group">
+        ///     The group of interest.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time the call may block.
+        /// </param>
+        /// <returns>
+        ///     Returns information pertaining to the specified group
+        ///     or null if this group does not exist.
+        /// </returns>
+        public GroupInfo ListGroup(string group, TimeSpan timeout)
+            => kafkaHandle.ListGroup(group, timeout.TotalMillisecondsAsInt());
+
+        /// <summary>
+        ///     Get information pertaining to a particular group in the
+        ///     Kafka cluster (blocks, potentially indefinitely).
+        ///
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        /// <param name="group">
+        ///     The group of interest.
+        /// </param>
+        /// <returns>
+        ///     Returns information pertaining to the specified group
+        ///     or null if this group does not exist.
+        /// </returns>
+        public GroupInfo ListGroup(string group)
+            => kafkaHandle.ListGroup(group, -1);
+
+
+        /// <summary>
+        ///     Query the Kafka cluster for low (oldest/beginning) and high (newest/end)
+        ///     offsets for the specified topic/partition (blocking).
+        ///
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        /// <param name="topicPartition">
+        ///     The topic/partition of interest.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time the call may block.
+        /// </param>
+        /// <returns>
+        ///     The requested WatermarkOffsets.
+        /// </returns>
+        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
+            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
+
+        /// <summary>
+        ///     Query the Kafka cluster for low (oldest/beginning) and high (newest/end)
+        ///     offsets for the specified topic/partition (blocks, potentially indefinitely).
+        ///
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        /// <param name="topicPartition">
+        ///     The topic/partition of interest.
+        /// </param>
+        /// <returns>
+        ///     The requested WatermarkOffsets.
+        /// </returns>
+        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition)
+            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, -1);
+
+        private Metadata GetMetadata(bool allTopics, int millisecondsTimeout)
+            => kafkaHandle.GetMetadata(allTopics, null, millisecondsTimeout);
+
+        /// <summary>
+        ///     Query the cluster for metadata (blocking).
+        ///
+        ///     - allTopics = true - request all topics from cluster
+        ///     - allTopics = false, - request only locally known topics.
+        ///
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        public Metadata GetMetadata(bool allTopics, TimeSpan timeout)
+            => kafkaHandle.GetMetadata(allTopics, null, timeout.TotalMillisecondsAsInt());
+
+        //TODO add Getmetadata for single topic
+
+        /// <summary>
+        ///     Refer to <see cref="GetMetadata(bool,TimeSpan)" />
+        ///     
+        ///     [UNSTABLE-API] - The API associated with this functionality is subject to change.
+        /// </summary>
+        public Metadata GetMetadata()
+            => GetMetadata(true, -1);
+
+        /// <summary>
+        ///     Adds one or more brokers to the Producer's list of initial
+        ///     bootstrap brokers. 
+        ///
+        ///     Note: Additional brokers are discovered automatically as 
+        ///     soon as the Producer connects to any broker by querying the 
+        ///     broker metadata. Calling this method is only required in 
+        ///     some scenarios where the address of all brokers in the 
+        ///     cluster changes.
+        /// </summary>
+        /// <param name="brokers">
+        ///     Coma-separated list of brokers in the same format as 
+        ///     the bootstrap.server configuration parameter.
+        /// </param>
+        /// <remarks>
+        ///     There is currently no API to remove existing configured, 
+        ///     added or learnt brokers.
+        /// </remarks>
+        /// <returns>
+        ///     The number of brokers added. This value includes brokers
+        ///     that may have been specified a second time.
+        /// </returns>
+        public int AddBrokers(string brokers)
+            => kafkaHandle.AddBrokers(brokers);
+        
+        public List<TopicError> DeleteTopics(IEnumerable<string> topics, TimeSpan timeout, bool waitForDeletion)
+            => kafkaHandle.AdminDeleteTopics(topics, timeout.TotalMillisecondsAsInt(), waitForDeletion);
+    }
+}

--- a/src/Confluent.Kafka/IAdmin.cs
+++ b/src/Confluent.Kafka/IAdmin.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2016-2017 Confluent Inc., 2015-2016 Andreas Heider
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Expose administrative commands to interact with broker state and configuration.
+    /// </summary>
+    public interface IAdmin
+    {
+        /// <summary>
+        ///     Delete a set of topics and all its replica.
+        ///     This methold will block fot ar most timeout.
+        /// </summary>
+        /// <param name="topics">
+        ///     The list of topics to delete.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum time the method will block, must be positive or zero.
+        ///     It serves as timeout for controller lookup (try to send request
+        ///     to broker) and remaining time will serve as timeout for request 
+        ///     if <paramref name="waitForDeletion"/> is true.
+        /// </param>
+        /// <param name="waitForDeletion">
+        ///     If false, the method return as soon as broker receive the 
+        ///     request, and <see cref="ErrorCode.NoError"/> denotes topic
+        ///     was marked for deletion.
+        ///
+        ///     If true, the broker will wait for at most remaining timeout for
+        ///     deletion to complete. Return may then be populated with
+        ///     <see cref="ErrorCode.RequestTimedOut"/> if completion did
+        ///     not complete in remaining time (topic will still be marked
+        ///     for deletion)
+        /// </param>
+        /// <returns>
+        ///     A list corresponding to topics asked for deletion with a 
+        ///     corresponding error.
+        ///     
+        ///     Any other error denote the deletetopic request failed for the 
+        ///     given topic (or timed out if <paramref name="waitForDeletion"/> is enable
+        /// </returns>
+        /// <exception cref="KafkaException">
+        ///     Exception indicating the delete topic request encountered an error.
+        ///     This may either denote a fail in sending request to broker,
+        ///     its treatment, or if a common error occured on all topics.
+        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="topics"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is negative.</exception>
+        List<TopicError> DeleteTopics(IEnumerable<string> topics, TimeSpan timeout, bool waitForDeletion);
+    }
+}

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -182,6 +182,7 @@ namespace Confluent.Kafka.Impl
             _event_topic_partition_list = NativeMethods.rd_kafka_event_topic_partition_list;
             _event_destroy = NativeMethods.rd_kafka_event_destroy;
             _queue_poll = NativeMethods.rd_kafka_queue_poll;
+            _admin_delete_topics = NativeMethods.rd_kafka_admin_delete_topics;
 
             if ((long)version() < minVersion)
             {
@@ -574,6 +575,10 @@ namespace Confluent.Kafka.Impl
         private static Func<IntPtr, IntPtr> _event_topic_partition_list;
         internal static IntPtr event_topic_partition_list(IntPtr rkev)
             => _event_topic_partition_list(rkev);
+        
+        private static Func<IntPtr, IntPtr, IntPtr, ErrorCode> _admin_delete_topics;
+        internal static ErrorCode admin_delete_topics(IntPtr rk, IntPtr topics, IntPtr timeout_ms)
+            => _admin_delete_topics(rk, topics, timeout_ms);
 
 
 
@@ -896,6 +901,9 @@ namespace Confluent.Kafka.Impl
 
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr rd_kafka_event_topic_partition_list(IntPtr rkev);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern ErrorCode rd_kafka_admin_delete_topics(IntPtr rk, IntPtr topics, IntPtr timeout_ms);
         }
 
     }

--- a/src/Confluent.Kafka/TopicError.cs
+++ b/src/Confluent.Kafka/TopicError.cs
@@ -1,0 +1,124 @@
+// Copyright 2016-2017 Confluent Inc., 2015-2016 Andreas Heider
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Represents a Kafka (topic, error) tuple.
+    /// </summary>
+    public class TopicError
+    {
+        /// <summary>
+        ///     Initializes a new TopicError instance.
+        /// </summary>
+        /// <param name="topic">
+        ///     A Kafka topic name.
+        /// </param>
+        /// <param name="error">
+        ///     A Kafka error.
+        /// </param>
+        public TopicError(string topic, Error error)
+        {
+            Topic = topic;
+            Error = error;
+        }
+
+        /// <summary>
+        ///     Gets the Kafka topic name.
+        /// </summary>
+        public string Topic { get; }
+        
+        /// <summary>
+        ///     Gets the Kafka error.
+        /// </summary>
+        public Error Error { get; }
+
+        /// <summary>
+        ///     Tests whether this TopicError instance is equal to the specified object.
+        /// </summary>
+        /// <param name="obj">
+        ///     The object to test.
+        /// </param>
+        /// <returns>
+        ///     true if obj is a TopicError and all properties are equal. false otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is TopicError tp))
+            {
+                return false;
+            }
+            
+            return tp.Topic == Topic && tp.Error == Error;
+        }
+
+        /// <summary>
+        ///     Returns a hash code for this TopicError.
+        /// </summary>
+        /// <returns>
+        ///     An integer that specifies a hash value for this TopicError.
+        /// </returns>
+        public override int GetHashCode()
+            // x by prime number is quick and gives decent distribution.
+            => (Topic.GetHashCode())*251 + Error.GetHashCode();
+
+        /// <summary>
+        ///     Tests whether TopicError instance a is equal to TopicError instance b.
+        /// </summary>
+        /// <param name="a">
+        ///     The first TopicError instance to compare.
+        /// </param>
+        /// <param name="b">
+        ///     The second TopicError instance to compare.
+        /// </param>
+        /// <returns>
+        ///     true if TopicError instances a and b are equal. false otherwise.
+        /// </returns>
+        public static bool operator ==(TopicError a, TopicError b)
+        {
+            if (object.ReferenceEquals(a, null))
+            {
+                return object.ReferenceEquals(b, null);
+            }
+
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        ///     Tests whether TopicError instance a is not equal to TopicError instance b.
+        /// </summary>
+        /// <param name="a">
+        ///     The first TopicError instance to compare.
+        /// </param>
+        /// <param name="b">
+        ///     The second TopicError instance to compare.
+        /// </param>
+        /// <returns>
+        ///     true if TopicError instances a and b are not equal. false otherwise.
+        /// </returns>
+        public static bool operator !=(TopicError a, TopicError b)
+            => !(a == b);
+
+        /// <summary>
+        ///     Returns a string representation of the TopicError object.
+        /// </summary>
+        /// <returns>
+        ///     A string representation of the TopicError object.
+        /// </returns>
+        public override string ToString()
+            => $"{Topic} : {Error}";
+    }
+}


### PR DESCRIPTION
Binding to https://github.com/edenhill/librdkafka/pull/1399

Need to include proper librdkafka dll for it to work

## Admin interface / client
This is more for discussion on how to implement AdminClient : either create a completly different handle (like here in the AdminClient, in which case we will have to deprecate all admin method from producer/consumer to put them in), either only on existing handle (like here on the Producer), either on both, either AdminClient.CreateFrom(producer | consumer). I like it to be able to use admin api from existing handle, so I'm just again the "new AdminClient only"

I made the producer explicitly implement IAdmin more for testing (prevent producer.DeleteTopics usage), not necesseraly a good idea. Idealy we should add the IProducer, ISerializingProducer api, so that we can distinguish producing method from admin method easily (having a IProducer producer = new Producer())

I let some existing common method in AdminClient, will have to decide which one make it to IAdmin api and which one don't.

## Delete topics
The way to treat timeout is more something to discuss on librdkafka PR first than here, but the way exception have to be treated in C# can be reviewed also

