### PR TITLE
removed librdkafka.redist dependency. added note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ client. Thanks Andreas!
 Reference the [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) and 
 [librdkafka.redist](https://www.nuget.org/packages/librdkafka.redist/) NuGet packages (version 0.11.1).
 
-**Important Note:** The librdkafka.redist package dependency is no longer transitive. You must now reference the 
+**Important Note:** The librdkafka.redist package dependency is no longer implicit. You must now reference the 
 librdkafka.redist package explicitly in addition to the Confluent.Kafka package. In the future we plan to provide
 a variety of different librdkafka nuget packages suitable for use on specific platforms. We will also continue to 
 distribute the general purpose librdkafka.redist package and this will continue to work seamlessly on the most 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,20 @@ client. Thanks Andreas!
 
 ## Usage
 
-Reference the [Confluent.Kafka NuGet package](https://www.nuget.org/packages/Confluent.Kafka/) (version 0.11.1).
+Reference the [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) and 
+[librdkafka.redist](https://www.nuget.org/packages/librdkafka.redist/) NuGet packages (version 0.11.1).
 
-To install confluent-kafka-dotnet from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
+**Important Note:** The librdkafka.redist package dependency is no longer transitive. You must now reference the 
+librdkafka.redist package explicitly in addition to the Confluent.Kafka package. In the future we plan to provide
+a variety of different librdkafka nuget packages suitable for use on specific platforms. We will also continue to 
+distribute the general purpose librdkafka.redist package and this will continue to work seamlessly on the most 
+common platforms.
+
+To install confluent-kafka-dotnet from within Visual Studio, search for Confluent.Kafka and librdkafka.redist in the 
+NuGet Package Manager UI, or run the following command in the Package Manager Console:
 
 ```
+Install-Package librdkafka.redist -Version 0.11.1
 Install-Package Confluent.Kafka -Version 0.11.1
 ```
 
@@ -42,6 +51,7 @@ To reference in a dotnet core project, explicitly add a package reference to you
 ```
 <ItemGroup>
   ...
+  <PackageReference Include="librdkafka.redist" Version="0.11.1" />
   <PackageReference Include="Confluent.Kafka" Version="0.11.1" />
   ...
 </ItemGroup>

--- a/examples/AdvancedConsumer/AdvancedConsumer.csproj
+++ b/examples/AdvancedConsumer/AdvancedConsumer.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+  
 </Project>

--- a/examples/AdvancedProducer/AdvancedProducer.csproj
+++ b/examples/AdvancedProducer/AdvancedProducer.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+  
 </Project>

--- a/examples/FSharp/FSharp.fsproj
+++ b/examples/FSharp/FSharp.fsproj
@@ -13,8 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>

--- a/examples/Misc/Misc.csproj
+++ b/examples/Misc/Misc.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+  
 </Project>

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+  
 </Project>

--- a/examples/SimpleConsumer/SimpleConsumer.csproj
+++ b/examples/SimpleConsumer/SimpleConsumer.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+  
 </Project>

--- a/examples/SimpleProducer/SimpleProducer.csproj
+++ b/examples/SimpleProducer/SimpleProducer.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -18,10 +18,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Console" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />

--- a/test/Confluent.Kafka.Benchmark/Confluent.Kafka.Benchmark.csproj
+++ b/test/Confluent.Kafka.Benchmark/Confluent.Kafka.Benchmark.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
+  </ItemGroup>
+
 </Project>

--- a/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
+++ b/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/Confluent.Kafka.StrongName.UnitTests/Confluent.Kafka.StrongName.UnitTests.csproj
+++ b/test/Confluent.Kafka.StrongName.UnitTests/Confluent.Kafka.StrongName.UnitTests.csproj
@@ -25,9 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="librdkafka.redist" Version="0.11.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+++ b/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/Confluent.Kafka.VerifiableClient/Confluent.Kafka.VerifiableClient.csproj
+++ b/test/Confluent.Kafka.VerifiableClient/Confluent.Kafka.VerifiableClient.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="librdkafka.redist" Version="0.11.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@edenhill - as discussed. unfortunately this will fail with a non-descriptive exception if people don't reference librdkafka.redist. I don't think it's easy to give a better warning until the SSL dependency related changes go in. I'll test again on all platforms before tagging and deploying to nuget.
