### PR TITLE
added IgnoreDeserializer

### DIFF
--- a/examples/AdvancedConsumer/Program.cs
+++ b/examples/AdvancedConsumer/Program.cs
@@ -63,9 +63,11 @@ namespace Confluent.Kafka.Examples.AdvancedConsumer
                 consumer.OnPartitionEOF += (_, end)
                     => Console.WriteLine($"Reached end of topic {end.Topic} partition {end.Partition}, next message will be at offset {end.Offset}");
 
+                // Raised on critical errors, e.g. connection failures or all brokers down.
                 consumer.OnError += (_, error)
                     => Console.WriteLine($"Error: {error}");
 
+                // Raised on deserialization errors or when a consumed message has an error != NoError.
                 consumer.OnConsumeError += (_, msg)
                     => Console.WriteLine($"Error consuming from topic/partition/offset {msg.Topic}/{msg.Partition}/{msg.Offset}: {msg.Error}");
 

--- a/examples/AdvancedConsumer/Program.cs
+++ b/examples/AdvancedConsumer/Program.cs
@@ -122,7 +122,7 @@ namespace Confluent.Kafka.Examples.AdvancedConsumer
         /// </summary>
         public static void Run_Consume(string brokerList, List<string> topics)
         {
-            using (var consumer = new Consumer<Null, string>(constructConfig(brokerList, false), null, new StringDeserializer(Encoding.UTF8)))
+            using (var consumer = new Consumer<Ignore, string>(constructConfig(brokerList, false), null, new StringDeserializer(Encoding.UTF8)))
             {
                 // Note: All event handlers are called on the main thread.
 
@@ -131,6 +131,9 @@ namespace Confluent.Kafka.Examples.AdvancedConsumer
 
                 consumer.OnError += (_, error)
                     => Console.WriteLine($"Error: {error}");
+
+                consumer.OnConsumeError += (_, error)
+                    => Console.WriteLine($"Consume error: {error}");
 
                 consumer.OnPartitionsAssigned += (_, partitions) =>
                 {
@@ -159,7 +162,7 @@ namespace Confluent.Kafka.Examples.AdvancedConsumer
 
                 while (!cancelled)
                 {
-                    Message<Null, string> msg;
+                    Message<Ignore, string> msg;
                     if (!consumer.Consume(out msg, TimeSpan.FromMilliseconds(100)))
                     {
                         continue;

--- a/examples/SimpleConsumer/Program.cs
+++ b/examples/SimpleConsumer/Program.cs
@@ -42,9 +42,11 @@ namespace Confluent.Kafka.Examples.SimpleConsumer
             {
                 consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(topics.First(), 0, 0) });
                 
+                // Raised on critical errors, e.g. connection failures or all brokers down.
                 consumer.OnError += (_, error)
                     => Console.WriteLine($"Error: {error}");
 
+                // Raised on deserialization errors or when a consumed message has an error != NoError.
                 consumer.OnConsumeError += (_, error)
                     => Console.WriteLine($"Consume error: {error}");
                 

--- a/examples/SimpleConsumer/Program.cs
+++ b/examples/SimpleConsumer/Program.cs
@@ -38,13 +38,19 @@ namespace Confluent.Kafka.Examples.SimpleConsumer
                 { "bootstrap.servers", brokerList }
             };
 
-            using (var consumer = new Consumer<Null, string>(config, null, new StringDeserializer(Encoding.UTF8)))
+            using (var consumer = new Consumer<Ignore, string>(config, null, new StringDeserializer(Encoding.UTF8)))
             {
                 consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(topics.First(), 0, 0) });
+                
+                consumer.OnError += (_, error)
+                    => Console.WriteLine($"Error: {error}");
 
+                consumer.OnConsumeError += (_, error)
+                    => Console.WriteLine($"Consume error: {error}");
+                
                 while (true)
                 {
-                    Message<Null, string> msg;
+                    Message<Ignore, string> msg;
                     if (consumer.Consume(out msg, TimeSpan.FromSeconds(1)))
                     {
                         Console.WriteLine($"Topic: {msg.Topic} Partition: {msg.Partition} Offset: {msg.Offset} {msg.Value}");

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -67,22 +67,34 @@ namespace Confluent.Kafka
 
             if (KeyDeserializer == null)
             {
-                if (typeof(TKey) != typeof(Null))
+                if (typeof(TKey) == typeof(Null))
+                {
+                    KeyDeserializer = (IDeserializer<TKey>)new NullDeserializer();
+                }
+                else if (typeof(TKey) == typeof(Ignore))
+                {
+                    KeyDeserializer = (IDeserializer<TKey>)new IgnoreDeserializer();
+                }
+                else
                 {
                     throw new ArgumentNullException("Key deserializer must be specified.");
                 }
-                // TKey == Null -> cast is always valid.
-                KeyDeserializer = (IDeserializer<TKey>)new NullDeserializer();
             }
 
             if (ValueDeserializer == null)
             {
-                if (typeof(TValue) != typeof(Null))
+                if (typeof(TValue) == typeof(Null))
+                {
+                    ValueDeserializer = (IDeserializer<TValue>)new NullDeserializer();
+                }
+                else if (typeof(TValue) == typeof(Ignore))
+                {
+                    ValueDeserializer = (IDeserializer<TValue>)new IgnoreDeserializer();
+                }
+                else
                 {
                     throw new ArgumentNullException("Value deserializer must be specified.");
                 }
-                // TValue == Null -> cast is always valid.
-                ValueDeserializer = (IDeserializer<TValue>)new NullDeserializer();
             }
 
             var configWithoutKeyDeserializerProperties = KeyDeserializer.Configure(config, true);

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -65,6 +65,11 @@ namespace Confluent.Kafka
             KeyDeserializer = keyDeserializer;
             ValueDeserializer = valueDeserializer;
 
+            if (keyDeserializer != null && keyDeserializer == valueDeserializer)
+            {
+                throw new ArgumentException("Key and value deserializers must not be the same object.");
+            }
+
             if (KeyDeserializer == null)
             {
                 if (typeof(TKey) == typeof(Null))

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -310,6 +310,7 @@ namespace Confluent.Kafka
 
         /// <summary>
         ///     Raised when a consumed message has an error != NoError (both when Consume or Poll is used for polling).
+        ///     Also raised on deserialization errors.
         /// </summary>
         /// <remarks>
         ///     Executes on the same thread as every other Consumer event handler (except OnLog which may be called from an arbitrary thread).

--- a/src/Confluent.Kafka/Ignore.cs
+++ b/src/Confluent.Kafka/Ignore.cs
@@ -14,6 +14,9 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serialization;
+
+
 namespace Confluent.Kafka
 {
     /// <summary>

--- a/src/Confluent.Kafka/Ignore.cs
+++ b/src/Confluent.Kafka/Ignore.cs
@@ -17,12 +17,12 @@
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     A type for use in conjunction with <see cref="NullSerializer" />
-    ///     and <see cref="NullDeserializer" /> that enables null key or 
-    ///     values to be enforced when producing or consuming messages.
+    ///     A type for use in conjunction with <see cref="IgnoreDeserializer" />
+    ///     that enables message keys or values to be read as null, regardless
+    ///     of their value.
     /// </summary>
-    public sealed class Null
+    public sealed class Ignore
     {
-        private Null() {}
+        private Ignore() {}
     }
 }

--- a/src/Confluent.Kafka/Null.cs
+++ b/src/Confluent.Kafka/Null.cs
@@ -14,6 +14,9 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serialization;
+
+
 namespace Confluent.Kafka
 {
     /// <summary>

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -834,6 +834,11 @@ namespace Confluent.Kafka
             KeySerializer = keySerializer;
             ValueSerializer = valueSerializer;
 
+            if (keySerializer != null && keySerializer == valueSerializer)
+            {
+                throw new ArgumentException("Key and value serializers must not be the same object.");
+            }
+
             if (KeySerializer == null)
             {
                 if (typeof(TKey) != typeof(Null))

--- a/src/Confluent.Kafka/Serialization/IgnoreDeserializer.cs
+++ b/src/Confluent.Kafka/Serialization/IgnoreDeserializer.cs
@@ -1,0 +1,49 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka.Serialization
+{
+    /// <summary>
+    ///     A 'deserializer' that returns null regardless of the input data.
+    /// </summary>
+    public class IgnoreDeserializer : IDeserializer<Ignore>
+    {
+        /// <summary>
+        ///     'Deserializes' any data to a null value.
+        /// </summary>
+        /// <param name="data">
+        ///     The data to deserialize.
+        /// </param>        
+        /// <param name="topic">
+        ///     The topic associated with the data (ignored by this deserializer).
+        /// </param>
+        /// <returns>
+        ///     null
+        /// </returns>
+        public Ignore Deserialize(string topic, byte[] data)
+        {
+            return null;
+        }
+
+        /// <include file='../include_docs.xml' path='API/Member[@name="IDeserializer_Configure"]/*' />
+        public IEnumerable<KeyValuePair<string, object>> Configure(IEnumerable<KeyValuePair<string, object>> config, bool isKey)
+            => config;
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AddBroker.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AddBroker.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test that produces a message then consumes it.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void AddBrokers(string bootstrapServers, string topic, string partitionedTopic)
+        public static void AddBrokers(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             // This test assumes broker v0.10.0 or higher:
             // https://github.com/edenhill/librdkafka/wiki/Broker-version-compatibility

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -29,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Simple test of both Consumer.Assign overloads.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void AssignOverloads(string bootstrapServers, string topic, string partitionedTopic)
+        public static void AssignOverloads(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -45,9 +45,9 @@ namespace Confluent.Kafka.IntegrationTests
             Message<Null, string> dr;
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                dr = producer.ProduceAsync(topic, null, testString).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, null, testString).Result;
                 Assert.False(dr.Error.HasError);
-                var dr2 = producer.ProduceAsync(topic, null, testString2).Result;
+                var dr2 = producer.ProduceAsync(singlePartitionTopic, null, testString2).Result;
                 Assert.False(dr2.Error.HasError);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     higher than the offset of the last message on a partition.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void AssignPastEnd(string bootstrapServers, string topic, string partitionedTopic)
+        public static void AssignPastEnd(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -45,7 +45,7 @@ namespace Confluent.Kafka.IntegrationTests
             Message<Null, string> dr;
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                dr = producer.ProduceAsync(topic, null, testString).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, null, testString).Result;
                 Assert.True(dr.Offset >= 0);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ClosedHandle.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ClosedHandle.cs
@@ -27,7 +27,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     when Dispose has been called
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Producer_ClosedHandle(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Producer_ClosedHandle(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object>
             {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -30,12 +30,12 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Basic OffsetsForTimes test on Consumer.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static async Task Consumer_OffsetsForTimes(string bootstrapServers, string topic, string partitionedTopic)
+        public static async Task Consumer_OffsetsForTimes(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             const int N = 10;
             const int Partition = 0;
 
-            var messages = await ProduceMessages(bootstrapServers, topic, Partition, N);
+            var messages = await ProduceMessages(bootstrapServers, singlePartitionTopic, Partition, N);
 
             var consumerConfig = new Dictionary<string, object>
             {
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
                 // Getting the offset for the timestamp that very far in the past
                 var unixTimeEpoch = Timestamp.UnixTimeEpoch;
                 result = consumer.OffsetsForTimes(
-                        new[] { new TopicPartitionTimestamp(new TopicPartition(topic, Partition), new Timestamp(unixTimeEpoch, TimestampType.CreateTime)) },
+                        new[] { new TopicPartitionTimestamp(new TopicPartition(singlePartitionTopic, Partition), new Timestamp(unixTimeEpoch, TimestampType.CreateTime)) },
                         timeout)
                     .ToList();
 
@@ -86,7 +86,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Getting the offset for the timestamp that very far in the future
                 result = consumer.OffsetsForTimes(
-                        new[] { new TopicPartitionTimestamp(new TopicPartition(topic, Partition), new Timestamp(int.MaxValue, TimestampType.CreateTime)) },
+                        new[] { new TopicPartitionTimestamp(new TopicPartition(singlePartitionTopic, Partition), new Timestamp(int.MaxValue, TimestampType.CreateTime)) },
                         timeout)
                     .ToList();
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Simple Consumer Pause / Resume test.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static async Task Consumer_Pause_Resume(string bootstrapServers, string topic, string partitionedTopic)
+        public static async Task Consumer_Pause_Resume(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                     assignedPartitions = partitions;
                 };
 
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
 
                 while (assignedPartitions == null) 
                 {
@@ -61,10 +61,10 @@ namespace Confluent.Kafka.IntegrationTests
                 }
                 Assert.False(consumer.Consume(out message, TimeSpan.FromSeconds(1)));
 
-                Assert.False(producer.ProduceAsync(topic, null, "test value").Result.Error);
+                Assert.False(producer.ProduceAsync(singlePartitionTopic, null, "test value").Result.Error);
                 Assert.True(consumer.Consume(out message, TimeSpan.FromSeconds(30)));
                 consumer.Pause(assignedPartitions);
-                producer.ProduceAsync(topic, null, "test value 2").Wait();
+                producer.ProduceAsync(singlePartitionTopic, null, "test value 2").Wait();
                 Assert.False(consumer.Consume(out message, TimeSpan.FromSeconds(2)));
                 consumer.Resume(assignedPartitions);
                 Assert.True(consumer.Consume(out message, TimeSpan.FromSeconds(10)));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Consume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Consume.cs
@@ -30,10 +30,10 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Basic DeserializingConsumer test (consume mode).
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void DeserializingConsumer_Consume(string bootstrapServers, string topic, string partitionedTopic)
+        public static void DeserializingConsumer_Consume(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             int N = 2;
-            var firstProduced = Util.ProduceMessages(bootstrapServers, topic, 100, N);
+            var firstProduced = Util.ProduceMessages(bootstrapServers, singlePartitionTopic, 100, N);
 
             var consumerConfig = new Dictionary<string, object>
             {
@@ -60,7 +60,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.OnPartitionsRevoked += (_, partitions)
                     => consumer.Unassign();
 
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
 
                 int msgCnt = 0;
                 while (!done)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
@@ -30,10 +30,10 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Basic DeserializingConsumer test (poll mode).
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void DeserializingConsumer_Poll(string bootstrapServers, string topic, string partitionedTopic)
+        public static void DeserializingConsumer_Poll(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             int N = 2;
-            var firstProduced = Util.ProduceMessages(bootstrapServers, topic, 100, N);
+            var firstProduced = Util.ProduceMessages(bootstrapServers, singlePartitionTopic, 100, N);
 
             var consumerConfig = new Dictionary<string, object>
             {
@@ -69,7 +69,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.OnPartitionsRevoked += (_, partitions)
                     => consumer.Unassign();
 
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
 
                 while (!done)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
@@ -31,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     and values are surfaced via the OnConsumeError event.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void DeserializingConsumer_Poll_Error(string bootstrapServers, string topic, string partitionedTopic)
+        public static void DeserializingConsumer_Poll_Error(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -42,8 +42,8 @@ namespace Confluent.Kafka.IntegrationTests
             TopicPartitionOffset firstProduced = null;
             using (var producer = new Producer(producerConfig))
             {
-                firstProduced = producer.ProduceAsync(topic, Encoding.UTF8.GetBytes("key"), null).Result.TopicPartitionOffset;
-                producer.ProduceAsync(topic, null, Encoding.UTF8.GetBytes("val"));
+                firstProduced = producer.ProduceAsync(singlePartitionTopic, Encoding.UTF8.GetBytes("key"), null).Result.TopicPartitionOffset;
+                producer.ProduceAsync(singlePartitionTopic, null, Encoding.UTF8.GetBytes("val"));
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
@@ -87,7 +87,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.OnPartitionsRevoked += (_, partitions)
                     => consumer.Unassign();
 
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
 
                 while (!done)
                 {
@@ -130,7 +130,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.OnPartitionsRevoked += (_, partitions)
                     => consumer.Unassign();
 
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
 
                 while (!done)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     You should never do this, but the brokers don't actually prevent it.
         /// </remarks>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void DuplicateConsumerAssign(string bootstrapServers, string topic, string partitionedTopic)
+        public static void DuplicateConsumerAssign(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -48,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
             Message<Null, string> dr;
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                dr = producer.ProduceAsync(topic, null, testString).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, null, testString).Result;
                 Assert.NotNull(dr);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
@@ -56,8 +56,8 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer1 = new Consumer(consumerConfig))
             using (var consumer2 = new Consumer(consumerConfig))
             {
-                consumer1.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(topic, dr.Partition, 0) });
-                consumer2.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(topic, dr.Partition, 0) });
+                consumer1.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(singlePartitionTopic, dr.Partition, 0) });
+                consumer2.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(singlePartitionTopic, dr.Partition, 0) });
                 Message msg;
                 var haveMsg1 = consumer1.Consume(out msg, TimeSpan.FromSeconds(10));
                 Assert.NotNull(msg);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -32,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Segfault?
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void GarbageCollect(string bootstrapServers, string topic, string partitionedTopic)
+        public static void GarbageCollect(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object>
             {
@@ -47,12 +47,12 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                producer.ProduceAsync(topic, null, "test string").Wait();
+                producer.ProduceAsync(singlePartitionTopic, null, "test string").Wait();
             }
 
             using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))
             {
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
                 consumer.Poll(1000);
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -1,0 +1,82 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public static partial class Tests
+    {
+        /// <summary>
+        ///     Test that the ignore deserialier behaves as expected.
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public static void IgnoreTest(string bootstrapServers, string topic, string partitionedTopic)
+        {
+            var consumerConfig = new Dictionary<string, object>
+            {
+                { "group.id", Guid.NewGuid().ToString() },
+                { "bootstrap.servers", bootstrapServers }
+            };
+
+            var producerConfig = new Dictionary<string, object>
+            {
+                { "bootstrap.servers", bootstrapServers }
+            };
+
+            Message dr;
+            using (var producer = new Producer(producerConfig))
+            {
+                // Assume that all these produce calls succeed.
+                dr = producer.ProduceAsync(topic, null, null).Result;
+                producer.ProduceAsync(topic, null, new byte[] { 1 }).Wait();
+                producer.ProduceAsync(topic, new byte[] { 0 }, null).Wait();
+                producer.ProduceAsync(topic, new byte[] { 42 }, new byte[] { 42, 240 }).Wait();
+                producer.Flush(TimeSpan.FromSeconds(10));
+            }
+
+            using (var consumer = new Consumer<Ignore, Ignore>(consumerConfig, null, null))
+            {
+                consumer.Assign(new List<TopicPartitionOffset>() { dr.TopicPartitionOffset });
+
+                Message<Ignore, Ignore> msg;
+                Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
+                Assert.NotNull(msg);
+                Assert.Null(msg.Key);
+                Assert.Null(msg.Value);
+
+                Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
+                Assert.NotNull(msg);
+                Assert.Null(msg.Key);
+                Assert.Null(msg.Value);
+
+                Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
+                Assert.NotNull(msg);
+                Assert.Null(msg.Key);
+                Assert.Null(msg.Value);
+
+                Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
+                Assert.NotNull(msg);
+                Assert.Null(msg.Key);
+                Assert.Null(msg.Value);
+            }
+        }
+
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
@@ -31,10 +31,10 @@ namespace Confluent.Kafka.IntegrationTests
         ///     group using the ListGroup method (on a Consumer).
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void ListGroup(string bootstrapServers, string topic, string partitionedTopic)
+        public static void ListGroup(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             int N = 2;
-            var firstProduced = Util.ProduceMessages(bootstrapServers, topic, 100, N);
+            var firstProduced = Util.ProduceMessages(bootstrapServers, singlePartitionTopic, 100, N);
 
             var groupId = Guid.NewGuid().ToString();
             var consumerConfig = new Dictionary<string, object>
@@ -58,7 +58,7 @@ namespace Confluent.Kafka.IntegrationTests
                     consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
                 };
 
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
 
                 while (!done)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
@@ -27,7 +27,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Basic test that metadata request + serialization works.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Metadata(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Metadata(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> { { "bootstrap.servers", bootstrapServers } };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     as expected.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void NullVsEmpty(string bootstrapServers, string topic, string partitionedTopic)
+        public static void NullVsEmpty(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -45,10 +45,10 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new Producer(producerConfig))
             {
                 // Assume that all these produce calls succeed.
-                dr = producer.ProduceAsync(topic, (byte[])null, null).Result;
-                producer.ProduceAsync(topic, null, new byte[0]).Wait();
-                producer.ProduceAsync(topic, new byte[0], null).Wait();
-                producer.ProduceAsync(topic, new byte[0], new byte[0]).Wait();
+                dr = producer.ProduceAsync(singlePartitionTopic, (byte[])null, null).Result;
+                producer.ProduceAsync(singlePartitionTopic, null, new byte[0]).Wait();
+                producer.ProduceAsync(singlePartitionTopic, new byte[0], null).Wait();
+                producer.ProduceAsync(singlePartitionTopic, new byte[0], new byte[0]).Wait();
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnLog.cs
@@ -29,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Tests that log messages are received by OnLog on all Producer and Consumer variants.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void OnLog(string bootstrapServers, string topic, string partitionedTopic)
+        public static void OnLog(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.OnLog += (_, LogMessage)
                   => logCount += 1;
 
-                producer.ProduceAsync(topic, null, (byte[])null).Wait();
+                producer.ProduceAsync(singlePartitionTopic, null, (byte[])null).Wait();
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);
@@ -66,7 +66,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.OnLog += (_, LogMessage)
                   => logCount += 1;
 
-                dr = producer.ProduceAsync(topic, null, "test value").Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, null, "test value").Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);
@@ -80,7 +80,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 var sProducer = producer.GetSerializingProducer<Null, string>(null, new StringSerializer(Encoding.UTF8));
                 
-                sProducer.ProduceAsync(topic, null, "test value").Wait();
+                sProducer.ProduceAsync(singlePartitionTopic, null, "test value").Wait();
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -31,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void OnPartitionsAssignedNotSet(string bootstrapServers, string topic, string partitionedTopic)
+        public static void OnPartitionsAssignedNotSet(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var consumerConfig = new Dictionary<string, object>
             {
@@ -45,18 +45,18 @@ namespace Confluent.Kafka.IntegrationTests
             // Producing onto the topic to make sure it exists.
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                var dr = producer.ProduceAsync(topic, null, "test string").Result;
+                var dr = producer.ProduceAsync(singlePartitionTopic, null, "test string").Result;
                 Assert.NotEqual((long)dr.Offset, (long)Offset.Invalid); // TODO: remove long cast. this is fixed in PR #29
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))
             {
-                consumer.Subscribe(topic);
+                consumer.Subscribe(singlePartitionTopic);
                 Assert.Equal(consumer.Assignment.Count, 0);
                 consumer.Poll(TimeSpan.FromSeconds(10));
                 Assert.Equal(consumer.Assignment.Count, 1);
-                Assert.Equal(consumer.Assignment[0].Topic, topic);
+                Assert.Equal(consumer.Assignment[0].Topic, singlePartitionTopic);
             }
         }
     }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -38,7 +38,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Producer_ProduceAsync_Await(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Producer_ProduceAsync_Await(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
                 { "api.version.request", true }
             };
 
-            var task = Producer_ProduceAsync_Await_Task(producerConfig, topic);
+            var task = Producer_ProduceAsync_Await_Task(producerConfig, singlePartitionTopic);
             task.Wait();
         }
     }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_DeliveryHandler.cs
@@ -68,7 +68,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Producer_ProduceAsync_DeliveryHandler(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Producer_ProduceAsync_DeliveryHandler(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -76,42 +76,42 @@ namespace Confluent.Kafka.IntegrationTests
                 { "api.version.request", true }
             };
 
-            var dh = new DeliveryHandler_P(topic);
+            var dh = new DeliveryHandler_P(singlePartitionTopic);
 
             using (var producer = new Producer(producerConfig))
             {
                 producer.ProduceAsync(
-                    topic,
+                    singlePartitionTopic,
                     DeliveryHandler_P.TestKey, 0, DeliveryHandler_P.TestKey.Length,
                     DeliveryHandler_P.TestValue, 0, DeliveryHandler_P.TestValue.Length,
                     0, true, dh
                 );
 
                 producer.ProduceAsync(
-                    topic,
+                    singlePartitionTopic,
                     DeliveryHandler_P.TestKey, 0, DeliveryHandler_P.TestKey.Length,
                     DeliveryHandler_P.TestValue, 0, DeliveryHandler_P.TestValue.Length,
                     0, dh
                 );
 
                 producer.ProduceAsync(
-                    topic,
+                    singlePartitionTopic,
                     DeliveryHandler_P.TestKey, 0, DeliveryHandler_P.TestKey.Length,
                     DeliveryHandler_P.TestValue, 0, DeliveryHandler_P.TestValue.Length,
                     true, dh
                 );
 
                 producer.ProduceAsync(
-                    topic,
+                    singlePartitionTopic,
                     DeliveryHandler_P.TestKey, 0, DeliveryHandler_P.TestKey.Length,
                     DeliveryHandler_P.TestValue, 0, DeliveryHandler_P.TestValue.Length,
                     dh
                 );
 
-                producer.ProduceAsync(topic, DeliveryHandler_P.TestKey, DeliveryHandler_P.TestValue, dh);
+                producer.ProduceAsync(singlePartitionTopic, DeliveryHandler_P.TestKey, DeliveryHandler_P.TestValue, dh);
 
                 producer.ProduceAsync(
-                    topic,
+                    singlePartitionTopic,
                     DeliveryHandler_P.TestKey, 1, DeliveryHandler_P.TestKey.Length-2,
                     DeliveryHandler_P.TestValue, 2, DeliveryHandler_P.TestValue.Length-3,
                     dh

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_DeliveryHandler.cs
@@ -56,7 +56,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Producer_ProduceAsync_Null_DeliveryHandler(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Producer_ProduceAsync_Null_DeliveryHandler(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -64,16 +64,16 @@ namespace Confluent.Kafka.IntegrationTests
                 { "api.version.request", true }
             };
 
-            var dh = new DeliveryHandler_PN(topic);
+            var dh = new DeliveryHandler_PN(singlePartitionTopic);
 
             using (var producer = new Producer(producerConfig))
             {
-                producer.ProduceAsync(topic, null, 0, 0, null, 0, 0, 0, true, dh);
-                producer.ProduceAsync(topic, null, 0, 0, null, 0, 0, 0, dh);
-                producer.ProduceAsync(topic, null, 0, 0, null, 0, 0, true, dh);
-                producer.ProduceAsync(topic, null, 0, 0, null, 0, 0, dh);
-                producer.ProduceAsync(topic, null, null, dh);
-                Assert.Throws<ArgumentException>(() => producer.ProduceAsync(topic, null, -123, int.MinValue, null, int.MaxValue, 44, dh));
+                producer.ProduceAsync(singlePartitionTopic, null, 0, 0, null, 0, 0, 0, true, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, 0, 0, null, 0, 0, 0, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, 0, 0, null, 0, 0, true, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, 0, 0, null, 0, 0, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, null, dh);
+                Assert.Throws<ArgumentException>(() => producer.ProduceAsync(singlePartitionTopic, null, -123, int.MinValue, null, int.MaxValue, 44, dh));
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Producer_ProduceAsync_Null_Task(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Producer_ProduceAsync_Null_Task(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -29,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void Producer_ProduceAsync_Task(string bootstrapServers, string topic, string partitionedTopic)
+        public static void Producer_ProduceAsync_Task(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Await.cs
@@ -40,7 +40,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void SerializingProducer_ProduceAsync_Await(string bootstrapServers, string topic, string partitionedTopic)
+        public static void SerializingProducer_ProduceAsync_Await(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -48,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
                 { "api.version.request", true }
             };
 
-            var task = SerializingProducer_ProduceAsync_Await_Task(producerConfig, topic);
+            var task = SerializingProducer_ProduceAsync_Await_Task(producerConfig, singlePartitionTopic);
             task.Wait();
         }
     }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_DeliveryHandler.cs
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void SerializingProducer_ProduceAsync_DeliveryHandler(string bootstrapServers, string topic, string partitionedTopic)
+        public static void SerializingProducer_ProduceAsync_DeliveryHandler(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -65,14 +65,14 @@ namespace Confluent.Kafka.IntegrationTests
                 { "api.version.request", true }
             };
 
-            var dh = new DeliveryHandler_SP(topic);
+            var dh = new DeliveryHandler_SP(singlePartitionTopic);
 
             using (var producer = new Producer<string, string>(producerConfig, new StringSerializer(Encoding.UTF8), new StringSerializer(Encoding.UTF8)))
             {
-                producer.ProduceAsync(topic, "test key 0", "test val 0", 0, true, dh);
-                producer.ProduceAsync(topic, "test key 1", "test val 1", 0, dh);
-                producer.ProduceAsync(topic, "test key 2", "test val 2", true, dh);
-                producer.ProduceAsync(topic, "test key 3", "test val 3", dh);
+                producer.ProduceAsync(singlePartitionTopic, "test key 0", "test val 0", 0, true, dh);
+                producer.ProduceAsync(singlePartitionTopic, "test key 1", "test val 1", 0, dh);
+                producer.ProduceAsync(singlePartitionTopic, "test key 2", "test val 2", true, dh);
+                producer.ProduceAsync(singlePartitionTopic, "test key 3", "test val 3", dh);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_DeliveryHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_DeliveryHandler.cs
@@ -56,7 +56,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void SerializingProducer_ProduceAsync_Null_DeliveryHandler(string bootstrapServers, string topic, string partitionedTopic)
+        public static void SerializingProducer_ProduceAsync_Null_DeliveryHandler(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 
@@ -64,14 +64,14 @@ namespace Confluent.Kafka.IntegrationTests
                 { "api.version.request", true }
             };
 
-            var dh = new DeliveryHandler_SPN(topic);
+            var dh = new DeliveryHandler_SPN(singlePartitionTopic);
 
             using (var producer = new Producer<Null, Null>(producerConfig, null, null))
             {
-                producer.ProduceAsync(topic, null, null, 0, true, dh);
-                producer.ProduceAsync(topic, null, null, 0, dh);
-                producer.ProduceAsync(topic, null, null, true, dh);
-                producer.ProduceAsync(topic, null, null, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, null, 0, true, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, null, 0, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, null, true, dh);
+                producer.ProduceAsync(singlePartitionTopic, null, null, dh);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Null_Task.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void SerializingProducer_ProduceAsync_Null_Task(string bootstrapServers, string topic, string partitionedTopic)
+        public static void SerializingProducer_ProduceAsync_Null_Task(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializingProducer_ProduceAsync_Task.cs
@@ -31,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void SerializingProducer_ProduceAsync_Task(string bootstrapServers, string topic, string partitionedTopic)
+        public static void SerializingProducer_ProduceAsync_Task(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object> 
             { 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
 
-        public static void SimpleProduceConsume(string bootstrapServers, string topic, string partitionedTopic)
+        public static void SimpleProduceConsume(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             // This test assumes broker v0.10.0 or higher:
             // https://github.com/edenhill/librdkafka/wiki/Broker-version-compatibility
@@ -56,8 +56,8 @@ namespace Confluent.Kafka.IntegrationTests
             Message<Null, string> produceResult2;
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                produceResult1 = ProduceMessage(topic, producer, testString1);
-                produceResult2 = ProduceMessage(topic, producer, testString2);
+                produceResult1 = ProduceMessage(singlePartitionTopic, producer, testString1);
+                produceResult2 = ProduceMessage(singlePartitionTopic, producer, testString2);
             }
 
             using (var consumer = new Consumer(consumerConfig))

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Tests.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Tests.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                     new object[]
                     {
                         json["bootstrapServers"].ToString(),
-                        json["topic"].ToString(),
+                        json["singlePartitionTopic"].ToString(),
                         json["partitionedTopic"].ToString()
                     }
                 };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Tests for GetWatermarkOffsets and QueryWatermarkOffsets on producer and consumer.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public static void WatermarkOffsets(string bootstrapServers, string topic, string partitionedTopic)
+        public static void WatermarkOffsets(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
         {
             var producerConfig = new Dictionary<string, object>
             {
@@ -42,10 +42,10 @@ namespace Confluent.Kafka.IntegrationTests
             Message<Null, string> dr;
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
-                dr = producer.ProduceAsync(topic, null, testString).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, null, testString).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
 
-                var queryOffsets = producer.QueryWatermarkOffsets(new TopicPartition(topic, 0));
+                var queryOffsets = producer.QueryWatermarkOffsets(new TopicPartition(singlePartitionTopic, 0));
                 Assert.NotEqual(queryOffsets.Low, Offset.Invalid);
                 Assert.NotEqual(queryOffsets.High, Offset.Invalid);
 

--- a/test/Confluent.Kafka.IntegrationTests/kafka.parameters.json
+++ b/test/Confluent.Kafka.IntegrationTests/kafka.parameters.json
@@ -1,5 +1,5 @@
 {
    "bootstrapServers": "localhost:9092",
-   "topic": "test-topic-1",
+   "singlePartitionTopic": "test-topic-1",
    "partitionedTopic": "test-topic-2"
 }

--- a/test/Confluent.Kafka.UnitTests/Consumer.cs
+++ b/test/Confluent.Kafka.UnitTests/Consumer.cs
@@ -40,6 +40,18 @@ namespace Confluent.Kafka.UnitTests
             e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<Null, string>(config, null, new StringDeserializer(Encoding.UTF8)); });
             Assert.True(e.Message.Contains("group.id"));
 
+            e = Assert.Throws<ArgumentException>(() => 
+            {
+                var validConfig = new Dictionary<string, object>
+                {
+                    { "bootstrap.servers", "localhost:9092" },
+                    { "group.id", "my-group" }
+                };
+                var deserializer = new StringDeserializer(Encoding.UTF8);
+                var c = new Consumer<string, string>(validConfig, deserializer, deserializer); 
+            });
+            Assert.True(e.Message.Contains("must not be the same object"));
+
             // positve case covered by integration tests. here, avoiding creating a rd_kafka_t instance.
         }
     }


### PR DESCRIPTION
@edenhill - this PR includes a number of quick wins for things that commonly trip people up. it needs to target a new branch though, because we don't want the examples to be incompatible with the current release. what version are we moving to next, 0.12.0.x?

- Added an 'Ignore' deserializer - people don't expect the null deserializer to throw an exception if it receives a non-null value and it confuses them. I've retained the null deserializer (it's important), but changed the examples to use the new `IgnoreDeseiralizer` instead.
- Added `OnConsumeError` handlers to the examples. People will cut and paste from the examples, and it's important they know this is something they should be handling.
- Consumers and Producers now throw an exception if the same instance of a serializer / deserializer is passed into the constructor for both key and value. this is an error (they are initialized separately by the producer/consumer), and it's not clear from the API that it is.
