### PR TITLE
Structs and strings marshaling performance optimization

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -19,7 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>		
-    <PackageReference Include="librdkafka.redist" Version="0.11.3" />		
+    <PackageReference Include="librdkafka.redist" Version="0.11.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>		
     <PackageReference Include="librdkafka.redist" Version="0.11.3" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -406,7 +406,7 @@ namespace Confluent.Kafka.Impl
                 return false;
             }
 
-            var msg = Util.Marshal.PtrToStructure<rd_kafka_message>(msgPtr);
+            var msg = Util.Marshal.PtrToStructureUnsafe<rd_kafka_message>(msgPtr);
 
             byte[] val = null;
             if (msg.val != IntPtr.Zero)

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -31,15 +31,13 @@ namespace Confluent.Kafka.Internal
             /// </summary>
             public unsafe static string PtrToStringUTF8(IntPtr strPtr)
             {
-                // TODO: Is there a built in / vectorized / better way to implement this?
-                var length = 0;
-                
+                // TODO: Is there a built in / vectorized / better way to implement this?              
                 byte* pTraverse = (byte*)strPtr;
                 while (*pTraverse != 0) { pTraverse += 1; }
-                length = (int)(pTraverse - (byte*)strPtr);
+                var length = (int)(pTraverse - (byte*)strPtr);
 #if NET45
                 var strBuffer = new byte[length];
-                System.Runtime.InteropServices.Marshal.Copy(strPtr, strBuffer, 0, strBuffer.Length);
+                System.Runtime.InteropServices.Marshal.Copy(strPtr, strBuffer, 0, length);
                 return Encoding.UTF8.GetString(strBuffer);
 #else
                 // avoid unnecessary data copying on NET45+

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -40,17 +40,23 @@ namespace Confluent.Kafka.Internal
                 System.Runtime.InteropServices.Marshal.Copy(strPtr, strBuffer, 0, length);
                 return Encoding.UTF8.GetString(strBuffer);
 #else
-                // avoid unnecessary data copying on NET45+
+                // Avoid unnecessary data copying on NET45+
                 return Encoding.UTF8.GetString((byte*)strPtr.ToPointer(), length);
 #endif
             }
 
             /// <summary>
-            /// reinterpret_cast without strings marshaling
+            ///     Reinterpret_cast without strings marshaling
             /// </summary>
-            /// <typeparam name="T">Type of struct to cast</typeparam>
-            /// <param name="ptr">Raw pointer to use</param>
-            /// <returns></returns>
+            /// <typeparam name="T">
+            ///     Type of struct to cast
+            /// </typeparam>
+            /// <param name="ptr">
+            ///     Raw pointer to use
+            /// </param>
+            /// <returns>
+            ///     A value of type <typeparamref name="T"/>
+            /// </returns>
             public static unsafe T PtrToStructureUnsafe<T>(IntPtr ptr)
             {
                 return Unsafe.Read<T>(ptr.ToPointer());

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text;
 using SystemMarshal = System.Runtime.InteropServices.Marshal;
+using Unsafe = System.Runtime.CompilerServices.Unsafe;
 
 
 namespace Confluent.Kafka.Internal
@@ -43,22 +44,14 @@ namespace Confluent.Kafka.Internal
                 return Encoding.UTF8.GetString(strBuffer);
             }
 
-            public static T PtrToStructure<T>(IntPtr ptr)
+            public static unsafe T PtrToStructure<T>(IntPtr ptr)
             {
-#if NET45
-                return (T)SystemMarshal.PtrToStructure(ptr, typeof(T));
-#else
-                return SystemMarshal.PtrToStructure<T>(ptr);
-#endif
+                return Unsafe.Read<T>(ptr.ToPointer());
             }
 
             public static int SizeOf<T>()
             {
-#if NET45
-                return SystemMarshal.SizeOf(typeof(T));
-#else
-                return SystemMarshal.SizeOf<T>();
-#endif
+                return Unsafe.SizeOf<T>();
             }
 
             public static IntPtr OffsetOf<T>(string fieldName)

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -47,14 +47,33 @@ namespace Confluent.Kafka.Internal
 #endif
             }
 
-            public static unsafe T PtrToStructure<T>(IntPtr ptr)
+            /// <summary>
+            /// reinterpret_cast without strings marshaling
+            /// </summary>
+            /// <typeparam name="T">Type of struct to cast</typeparam>
+            /// <param name="ptr">Raw pointer to use</param>
+            /// <returns></returns>
+            public static unsafe T PtrToStructureUnsafe<T>(IntPtr ptr)
             {
                 return Unsafe.Read<T>(ptr.ToPointer());
             }
 
+            public static T PtrToStructure<T>(IntPtr ptr)
+            {
+#if NET45
+                return (T)SystemMarshal.PtrToStructure(ptr, typeof(T));
+#else
+                return SystemMarshal.PtrToStructure<T>(ptr);
+#endif
+            }
+
             public static int SizeOf<T>()
             {
-                return Unsafe.SizeOf<T>();
+#if NET45
+                return SystemMarshal.SizeOf(typeof(T));
+#else
+                return SystemMarshal.SizeOf<T>();
+#endif
             }
 
             public static IntPtr OffsetOf<T>(string fieldName)

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -129,7 +129,7 @@ namespace Confluent.Kafka
         /// </remarks>
         private static void DeliveryReportCallbackImpl(IntPtr rk, IntPtr rkmessage, IntPtr opaque)
         {
-            var msg = Util.Marshal.PtrToStructure<rd_kafka_message>(rkmessage);
+            var msg = Util.Marshal.PtrToStructureUnsafe<rd_kafka_message>(rkmessage);
 
             // the msg._private property has dual purpose. Here, it is an opaque pointer set
             // by Topic.Produce to be an IDeliveryHandler. When Consuming, it's for internal


### PR DESCRIPTION
Below are the results of measurements for  10 iterations per 10 mln. messages.
All values are in `msg/ms`.
`test\Confluent.Kafka.Benchmark` project was used for benchmarking.

  | average | median | std. dev
-- | -- | -- | --
produce (original) | 773,6 | 780 | 21,25653
produce (patched) | 796,8 | 805 | 20,33126
consume (original) | 548,9 | 552 | 9,658675
consume (patched) | 1722,6 | 1723 | 4,127953
poll (original) | 428,1 | 421 | 42,88461
poll (patched) | 1668,9 | 1675,5 | 28,72786

Here is a quick recap of the data above based on median values:

  | original (msg/ms) | patched (msg/ms) |  
-- | -- | -- | --
produce | 780 (+-21) | 805 (+-20) | ? might be 1.03x faster
poll | 421 (+-43) | 1675 (+-29) | ^ definitely 3.98x faster
consume | 552 (+-10) | 1723 (+-4) | ^ definitely 3.12x faster

Tests were performed on the following system:
OS: `Win10 x64 (1709)`
CPU: `Intel Core i7 6700HQ`
Kafka: `2.12-1.0.0`
Zookeeper: `3.4.11`
librdkafka: `0.11.3`
.NET Core: `2.0.3`
Java: `8`
JDK: `1.8.0_141`

  