### PR TITLE
use ThrowIfCancellationRequested to exit producer poll loop

### DIFF
--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -52,9 +52,10 @@ namespace Confluent.Kafka
         private Task StartPollTask(CancellationToken ct)
             => Task.Factory.StartNew(() =>
                 {
-                    while (!ct.IsCancellationRequested)
+                    while (true)
                     {
                         this.kafkaHandle.Poll((IntPtr)POLL_TIMEOUT_MS);
+                        ct.ThrowIfCancellationRequested();
                     }
                 }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
@@ -675,14 +676,29 @@ namespace Confluent.Kafka
         /// </remarks>
         public void Dispose()
         {
+            // TODO: If this method is called in a finalizer, can callbackTask potentially be null?
             topicHandles.Dispose();
 
             if (!this.manualPoll)
             {
-                // Note: It's necessary to wait on callbackTask before disposing kafkaHandle.
-                // TODO: If called in a finalizer, can callbackTask be potentially null?
                 callbackCts.Cancel();
-                callbackTask.Wait();
+                try
+                {
+                    // Note: It's necessary to wait on callbackTask before disposing kafkaHandle
+                    // since the poll loop makes use of this.
+                    callbackTask.Wait();
+                }
+                catch (AggregateException e)
+                {
+                    if (e.InnerException.GetType() != typeof(TaskCanceledException))
+                    {
+                        throw e.InnerException;
+                    }
+                }
+                finally
+                {
+                    callbackCts.Dispose();
+                }
             }
             kafkaHandle.Dispose();
         }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -54,8 +54,8 @@ namespace Confluent.Kafka
                 {
                     while (true)
                     {
-                        this.kafkaHandle.Poll((IntPtr)POLL_TIMEOUT_MS);
                         ct.ThrowIfCancellationRequested();
+                        this.kafkaHandle.Poll((IntPtr)POLL_TIMEOUT_MS);
                     }
                 }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 


### PR DESCRIPTION
@edenhill - fix for #412. 

This new functionality follows the example in: https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-cancellation 

I don't actually understand why the existing way of doing this is causing intermittent problems, however it doesn't matter as the new way is valid, and avoids the problem.