### PR TITLE
Support mono (issue #400) 

### DIFF
--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -204,10 +204,18 @@ namespace Confluent.Kafka.Impl
 
 #if NET45 || NET46 || NET47
 
+        private static bool IsWindows()
+        {
+            var os = Environment.OSVersion;
+            var platform = os.Platform;
+            return platform != PlatformID.MacOSX && platform != PlatformID.Unix;
+        }
+
         private static bool InitializeDotNetFramework(string userSpecifiedPath)
         {
             string path = userSpecifiedPath;
-            if (path == null)
+            bool isWindows = IsWindows();
+            if (path == null && isWindows)
             {
                 // in net45, librdkafka.dll is not in the process directory, we have to load it manually
                 // and also search in the same folder for its dependencies (LOAD_WITH_ALTERED_SEARCH_PATH)
@@ -232,7 +240,10 @@ namespace Confluent.Kafka.Impl
                 }
             }
 
-            if (WindowsNative.LoadLibraryEx(path, IntPtr.Zero, WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
+            if (isWindows && WindowsNative.LoadLibraryEx(
+                path,
+                IntPtr.Zero,
+                WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
             {
                 // catch the last win32 error by default and keep the associated default message
                 var win32Exception = new Win32Exception();

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -85,7 +85,7 @@ namespace Confluent.Kafka.Impl
                 {
                     // TODO: In practice, the following is always returning IntPtr.Zero. Why?
                     IntPtr error = dlerror();
-                    if (error == IntPtr.Zero) 
+                    if (error == IntPtr.Zero)
                     {
                         return "";
                     }
@@ -202,6 +202,120 @@ namespace Confluent.Kafka.Impl
             }
         }
 
+#if NET45 || NET46 || NET47
+
+        private static bool InitializeDotNetFramework(string userSpecifiedPath)
+        {
+            string path = userSpecifiedPath;
+            if (path == null)
+            {
+                // in net45, librdkafka.dll is not in the process directory, we have to load it manually
+                // and also search in the same folder for its dependencies (LOAD_WITH_ALTERED_SEARCH_PATH)
+                var is64 = IntPtr.Size == 8;
+                var baseUri = new Uri(Assembly.GetExecutingAssembly().GetName().EscapedCodeBase);
+                var baseDirectory = Path.GetDirectoryName(baseUri.LocalPath);
+                var dllDirectory = Path.Combine(
+                    baseDirectory,
+                    is64
+                        ? Path.Combine("librdkafka", "x64")
+                        : Path.Combine("librdkafka", "x86"));
+                path = Path.Combine(dllDirectory, "librdkafka.dll");
+
+                if (!File.Exists(path))
+                {
+                    dllDirectory = Path.Combine(
+                        baseDirectory,
+                        is64
+                            ? @"runtimes\win7-x64\native"
+                            : @"runtimes\win7-x86\native");
+                    path = Path.Combine(dllDirectory, "librdkafka.dll");
+                }
+            }
+
+            if (WindowsNative.LoadLibraryEx(path, IntPtr.Zero, WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
+            {
+                // catch the last win32 error by default and keep the associated default message
+                var win32Exception = new Win32Exception();
+                var additionalMessage =
+                    $"Error while loading librdkafka.dll or its dependencies from {path}. " +
+                    $"Check the directory exists, if not check your deployment process. " +
+                    $"You can also load the library and its dependencies by yourself " +
+                    $"before any call to Confluent.Kafka";
+
+                throw new InvalidOperationException(additionalMessage, win32Exception);
+            }
+
+            return SetDelegates(typeof(NativeMethods.NativeMethods));
+        }
+
+#else
+
+        private static bool InitializeDotNetCore(string userSpecifiedPath)
+        {
+            const int RTLD_NOW = 2;
+
+            var nativeMethodTypes = new List<Type>();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (userSpecifiedPath != null)
+                {
+                    if (WindowsNative.LoadLibraryEx(userSpecifiedPath, IntPtr.Zero, WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
+                    {
+                        // TODO: The Win32Exception class is not available in .NET Standard, which is the easy way to get the message string corresponding to
+                        // a win32 error. FormatMessage is not straightforward to p/invoke, so leaving this as a job for another day.
+                        throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. Win32 error: {Marshal.GetLastWin32Error()}");
+                    }
+                }
+
+                nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                if (userSpecifiedPath != null)
+                {
+                    if (PosixNative.dlopen(userSpecifiedPath, RTLD_NOW) == IntPtr.Zero)
+                    {
+                        throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. dlerror: '{PosixNative.LastError}'.");
+                    }
+                }
+
+                nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (userSpecifiedPath != null)
+                {
+                    if (PosixNative.dlopen(userSpecifiedPath, RTLD_NOW) == IntPtr.Zero)
+                    {
+                        throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. dlerror: '{PosixNative.LastError}'.");
+                    }
+
+                    nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
+                }
+                else
+                {
+                    nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
+                    nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods_Debian9));
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported platform: {RuntimeInformation.OSDescription}");
+            }
+
+            foreach (var t in nativeMethodTypes)
+            {
+                if (SetDelegates(t))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+#endif
+
         public static bool Initialize(string userSpecifiedPath)
         {
             lock (loadLockObj)
@@ -211,114 +325,10 @@ namespace Confluent.Kafka.Impl
                     return false;
                 }
 
-                isInitialized = false;
-
 #if NET45 || NET46 || NET47
-
-                string path = userSpecifiedPath;
-                if (path == null)
-                {
-                    // in net45, librdkafka.dll is not in the process directory, we have to load it manually
-                    // and also search in the same folder for its dependencies (LOAD_WITH_ALTERED_SEARCH_PATH)
-                    var is64 = IntPtr.Size == 8;
-                    var baseUri = new Uri(Assembly.GetExecutingAssembly().GetName().EscapedCodeBase);
-                    var baseDirectory = Path.GetDirectoryName(baseUri.LocalPath);
-                    var dllDirectory = Path.Combine(
-                        baseDirectory, 
-                        is64 
-                            ? Path.Combine("librdkafka", "x64")
-                            : Path.Combine("librdkafka", "x86"));
-                    path = Path.Combine(dllDirectory, "librdkafka.dll");
-
-                    if (!File.Exists(path))
-                    {
-                        dllDirectory = Path.Combine(
-                            baseDirectory, 
-                            is64 
-                                ? @"runtimes\win7-x64\native"
-                                : @"runtimes\win7-x86\native");
-                        path = Path.Combine(dllDirectory, "librdkafka.dll");
-                    }
-                }
-
-                if (WindowsNative.LoadLibraryEx(path, IntPtr.Zero, WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
-                {
-                    // catch the last win32 error by default and keep the associated default message
-                    var win32Exception = new Win32Exception();
-                    var additionalMessage =
-                        $"Error while loading librdkafka.dll or its dependencies from {path}. " +
-                        $"Check the directory exists, if not check your deployment process. " +
-                        $"You can also load the library and its dependencies by yourself " +
-                        $"before any call to Confluent.Kafka";
-
-                    throw new InvalidOperationException(additionalMessage, win32Exception);
-                }
-
-                isInitialized = SetDelegates(typeof(NativeMethods.NativeMethods));
-
+                isInitialized = InitializeDotNetFramework(userSpecifiedPath);
 #else
-
-                const int RTLD_NOW = 2;
-
-                var nativeMethodTypes = new List<Type>();
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    if (userSpecifiedPath != null)
-                    {
-                        if (WindowsNative.LoadLibraryEx(userSpecifiedPath, IntPtr.Zero, WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)
-                        {
-                            // TODO: The Win32Exception class is not available in .NET Standard, which is the easy way to get the message string corresponding to
-                            // a win32 error. FormatMessage is not straightforward to p/invoke, so leaving this as a job for another day.
-                            throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. Win32 error: {Marshal.GetLastWin32Error()}");
-                        }
-                    }
-
-                    nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    if (userSpecifiedPath != null)
-                    {
-                        if (PosixNative.dlopen(userSpecifiedPath, RTLD_NOW) == IntPtr.Zero)
-                        {
-                            throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. dlerror: '{PosixNative.LastError}'.");
-                        }
-                    }
-
-                    nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    if (userSpecifiedPath != null)
-                    {
-                        if (PosixNative.dlopen(userSpecifiedPath, RTLD_NOW) == IntPtr.Zero)
-                        {
-                            throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. dlerror: '{PosixNative.LastError}'.");
-                        }
-                    
-                        nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
-                    }
-                    else 
-                    {
-                        nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods));
-                        nativeMethodTypes.Add(typeof(NativeMethods.NativeMethods_Debian9));
-                    }
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Unsupported platform: {RuntimeInformation.OSDescription}");
-                }
-
-                foreach (var t in nativeMethodTypes)
-                {
-                    isInitialized = SetDelegates(t);
-                    if (isInitialized)
-                    {
-                        break;
-                    }
-                }
-
+                isInitialized = InitializeDotNetCore(userSpecifiedPath);
 #endif
 
                 if (!isInitialized)


### PR DESCRIPTION
I haven't tested it yet but this should prevent kernel32 from being invoked under Mac and Linux. From there, it should be possible to point to the correct file location via a configuration file using a dllmap

http://www.mono-project.com/docs/advanced/pinvoke/dllmap/

#400 
