### PR TITLE
handle OperationCanceledException

### DIFF
--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -52,11 +52,15 @@ namespace Confluent.Kafka
         private Task StartPollTask(CancellationToken ct)
             => Task.Factory.StartNew(() =>
                 {
-                    while (true)
+                    try
                     {
-                        ct.ThrowIfCancellationRequested();
-                        this.kafkaHandle.Poll((IntPtr)POLL_TIMEOUT_MS);
+                        while (true)
+                        {
+                            ct.ThrowIfCancellationRequested();
+                            this.kafkaHandle.Poll((IntPtr)POLL_TIMEOUT_MS);
+                        }
                     }
+                    catch (OperationCanceledException) {}
                 }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
         private LibRdKafka.ErrorDelegate errorDelegate;


### PR DESCRIPTION
a problem introduced in #413 - the exception used to exit the while loop should be caught, it is not.