### PR TITLE
MessageAndMeta, flattened & nested.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ To add a reference to a dotnet core project, execute the following at the comman
 dotnet add package -v 0.11.4-RC2 Confluent.Kafka
 ```
 
-Pre-release nuget packages are available from the following nuget package source (Note: this is not a web url - you should specify it in the nuget package manger):
-[https://ci.appveyor.com/nuget/confluent-kafka-dotnet](https://ci.appveyor.com/nuget/confluent-kafka-dotnet). The version suffix of these nuget packages matches the appveyor build number. You can see which commit a 
-particular build number corresponds to by looking at the 
+Nuget packages corresponding to commits to release branches are available from the following nuget package source (Note: this is not a web url - you 
+should specify it in the nuget package manger):
+[https://ci.appveyor.com/nuget/confluent-kafka-dotnet](https://ci.appveyor.com/nuget/confluent-kafka-dotnet). The version suffix of these nuget packages 
+matches the appveyor build number. You can see which commit a particular build number corresponds to by looking at the 
 [AppVeyor build history](https://ci.appveyor.com/project/ConfluentClientEngineering/confluent-kafka-dotnet/history)
 
 

--- a/src/Confluent.Kafka/ConsumerRecord.cs
+++ b/src/Confluent.Kafka/ConsumerRecord.cs
@@ -22,61 +22,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Represents a message consumed from kafka cluster.
     /// </summary>
-    public class ConsumerRecord
+    public class ConsumerRecord : MessageAndMeta
     {
-        /// <summary>
-        ///     The topic associated with the consumed message.
-        /// </summary>
-        public string Topic { get; set; }
-
-        /// <summary>
-        ///     The partition associated with the consumed message.
-        /// </summary>
-        public Partition Partition { get; set; }
-
-        /// <summary>
-        ///     The offset associated with the consumed message.
-        /// </summary>
-        public Offset Offset { get; set; }
-
-        /// <summary>
-        ///     The error (or NoError) associated with the consumed message.
-        /// </summary>
-        public Error Error { get; set; }
-
-        /// <summary>
-        ///     The consumed Message.
-        /// </summary>
-        public Message Message { get; set; }
-
-        /// <summary>
-        ///     The TopicPartition associated with the message.
-        /// </summary>
-        public TopicPartition TopicPartition
-            => new TopicPartition(Topic, Partition);
-        
-        /// <summary>
-        ///     The TopicPartitionOffset associated with the consumed message.
-        /// </summary>
-        public TopicPartitionOffset TopicPartitionOffset
-            => new TopicPartitionOffset(Topic, Partition, Offset);
-
-        /// <summary>
-        ///     The TopicPartitionOffsetError asociated with the consumed message.
-        /// </summary>
-        public TopicPartitionOffsetError TopicPartitionOffsetError
-        {
-            get
-            {
-                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
-            }
-            set
-            {
-                Topic = value.Topic;
-                Partition = value.Partition;
-                Offset = value.Offset;
-                Error = value.Error;
-            }
-        }
     }
 }

--- a/src/Confluent.Kafka/ConsumerRecord_KV.cs
+++ b/src/Confluent.Kafka/ConsumerRecord_KV.cs
@@ -22,61 +22,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Represents a message consumed from kafka cluster.
     /// </summary>
-    public class ConsumerRecord<TKey, TValue>
+    public class ConsumerRecord<TKey, TValue> : MessageAndMeta<TKey, TValue>
     {
-        /// <summary>
-        ///     The topic associated with the consumed message.
-        /// </summary>
-        public string Topic { get; set; }
-
-        /// <summary>
-        ///     The partition associated with the consumed message.
-        /// </summary>
-        public Partition Partition { get; set; }
-
-        /// <summary>
-        ///     The offset associated with the consumed message.
-        /// </summary>
-        public Offset Offset { get; set; }
-
-        /// <summary>
-        ///     The error (or NoError) associated with the consumed message.
-        /// </summary>
-        public Error Error { get; set; }
-
-        /// <summary>
-        ///     The consumed Message.
-        /// </summary>
-        public Message<TKey, TValue> Message { get; set; }
-
-        /// <summary>
-        ///     The TopicPartition associated with the message.
-        /// </summary>
-        public TopicPartition TopicPartition
-            => new TopicPartition(Topic, Partition);
-
-        /// <summary>
-        ///     The TopicPartitionOffset associated with the consumed message.
-        /// </summary>
-        public TopicPartitionOffset TopicPartitionOffset
-            => new TopicPartitionOffset(Topic, Partition, Offset);
-
-        /// <summary>
-        ///     The TopicPartitionOffsetError asociated with the consumed message.
-        /// </summary>
-        public TopicPartitionOffsetError TopicPartitionOffsetError
-        {
-            get
-            {
-                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
-            }
-            set
-            {
-                Topic = value.Topic;
-                Partition = value.Partition;
-                Offset = value.Offset;
-                Error = value.Error;
-            }
-        }
     }
 }

--- a/src/Confluent.Kafka/DeliveryReport.cs
+++ b/src/Confluent.Kafka/DeliveryReport.cs
@@ -22,61 +22,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Encapsulates the result of a produce request.
     /// </summary>
-    public class DeliveryReport
+    public class DeliveryReport : MessageAndMeta
     {
-        /// <summary>
-        ///     The topic the message was produced to.
-        /// </summary>
-        public string Topic { get; set; }
-
-        /// <summary>
-        ///     The partition the message was produced to.
-        /// </summary>
-        public Partition Partition { get; set; }
-
-        /// <summary>
-        ///     The offset the message was produced to.
-        /// </summary>
-        public Offset Offset { get; set; }
-
-        /// <summary>
-        ///     An error (or NoError) associated with the produce request.
-        /// </summary>
-        public Error Error { get; set; }
-
-        /// <summary>
-        ///     The message that was produced.
-        /// </summary>
-        public Message Message { get; set; }
-
-        /// <summary>
-        ///     The TopicPartition the message was produced to.
-        /// </summary>
-        public TopicPartition TopicPartition
-            => new TopicPartition(Topic, Partition);
-
-        /// <summary>
-        ///     The TopicPartitionOffset associated with the produced message.
-        /// </summary>
-        public TopicPartitionOffset TopicPartitionOffset
-            => new TopicPartitionOffset(Topic, Partition, Offset);
-
-        /// <summary>
-        ///     The TopicPartitionOffsetError assoicated with the produced message.
-        /// </summary>
-        public TopicPartitionOffsetError TopicPartitionOffsetError
-        {
-            get
-            {
-                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
-            }
-            set
-            {
-                Topic = value.Topic;
-                Partition = value.Partition;
-                Offset = value.Offset;
-                Error = value.Error;
-            }
-        }
     }
 }

--- a/src/Confluent.Kafka/DeliveryReport_KV.cs
+++ b/src/Confluent.Kafka/DeliveryReport_KV.cs
@@ -22,61 +22,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Encapsulates the result of a produce request.
     /// </summary>
-    public class DeliveryReport<TKey, TValue>
+    public class DeliveryReport<TKey, TValue> : MessageAndMeta<TKey, TValue>
     {
-        /// <summary>
-        ///     The topic the message was produced to.
-        /// </summary>
-        public string Topic { get; set; }
-
-        /// <summary>
-        ///     The partition the message was produced to.
-        /// </summary>
-        public Partition Partition { get; set; }
-
-        /// <summary>
-        ///     The offset the message was produced to.
-        /// </summary>
-        public Offset Offset { get; set; }
-
-        /// <summary>
-        ///     An error (or NoError) associated with the produce request.
-        /// </summary>
-        public Error Error { get; set; }
-
-        /// <summary>
-        ///     The message that was produced.
-        /// </summary>
-        public Message<TKey, TValue> Message { get; set; }
-
-        /// <summary>
-        ///     The TopicPartition the message was produced to.
-        /// </summary>
-        public TopicPartition TopicPartition
-            => new TopicPartition(Topic, Partition);
-
-        /// <summary>
-        ///     The TopicPartitionOffset associated with the produced message.
-        /// </summary>
-        public TopicPartitionOffset TopicPartitionOffset
-            => new TopicPartitionOffset(Topic, Partition, Offset);
-
-        /// <summary>
-        ///     The TopicPartitionOffsetError assoicated with the produced message.
-        /// </summary>
-        public TopicPartitionOffsetError TopicPartitionOffsetError
-        {
-            get
-            {
-                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
-            }
-            set
-            {
-                Topic = value.Topic;
-                Partition = value.Partition;
-                Offset = value.Offset;
-                Error = value.Error;
-            }
-        }
     }
 }

--- a/src/Confluent.Kafka/MessageAndMeta.cs
+++ b/src/Confluent.Kafka/MessageAndMeta.cs
@@ -1,0 +1,118 @@
+// Copyright 2016-2017 Confluent Inc., 2015-2016 Andreas Heider
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from: rdkafka-dotnet, licensed under the 2-clause BSD License.
+//
+// Refer to LICENSE for more information.
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Encapsulates the result of a produce request.
+    /// </summary>
+    public class MessageAndMeta
+    {
+        /// <summary>
+        ///     The topic associated with the message.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        ///     The partition associated with the message.
+        /// </summary>
+        public Partition Partition { get; set; }
+
+        /// <summary>
+        ///     The partition offset associated with the message.
+        /// </summary>
+        public Offset Offset { get; set; }
+
+        /// <summary>
+        ///     An error (or NoError) associated with the message.
+        /// </summary>
+        public Error Error { get; set; }
+
+        /// <summary>
+        ///     The TopicPartition associated with the message.
+        /// </summary>
+        public TopicPartition TopicPartition
+            => new TopicPartition(Topic, Partition);
+
+        /// <summary>
+        ///     The TopicPartitionOffset associated with the message.
+        /// </summary>
+        public TopicPartitionOffset TopicPartitionOffset
+            => new TopicPartitionOffset(Topic, Partition, Offset);
+
+        /// <summary>
+        ///     The TopicPartitionOffsetError assoicated with the message.
+        /// </summary>
+        public TopicPartitionOffsetError TopicPartitionOffsetError
+        {
+            get
+            {
+                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
+            }
+            set
+            {
+                Topic = value.Topic;
+                Partition = value.Partition;
+                Offset = value.Offset;
+                Error = value.Error;
+            }
+        }
+
+        /// <summary>
+        ///     The message that was produced.
+        /// </summary>
+        public Message Message { get; set; }
+
+        /// <summary>
+        ///     The Kafka message Key.
+        /// </summary>
+        public byte[] Key
+        {
+            get { return Message.Key; }
+            set { Message.Key = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message Value.
+        /// </summary>
+        public byte[] Value
+        {
+            get { return Message.Value; }
+            set { Message.Value = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message timestamp.
+        /// </summary>
+        public Timestamp Timestamp
+        {
+            get { return Message.Timestamp; }
+            set { Message.Timestamp = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message headers.
+        /// </summary>
+        public Headers Headers
+        {
+            get { return Message.Headers; }
+            set { Message.Headers = value; }
+        }
+    }
+}

--- a/src/Confluent.Kafka/MessageAndMeta_KV.cs
+++ b/src/Confluent.Kafka/MessageAndMeta_KV.cs
@@ -1,0 +1,118 @@
+// Copyright 2016-2017 Confluent Inc., 2015-2016 Andreas Heider
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Derived from: rdkafka-dotnet, licensed under the 2-clause BSD License.
+//
+// Refer to LICENSE for more information.
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Encapsulates a Kafka message and contextual information about that message.
+    /// </summary>
+    public class MessageAndMeta<TKey, TValue>
+    {
+        /// <summary>
+        ///     The topic associated with the message.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        ///     The partition associated with the message.
+        /// </summary>
+        public Partition Partition { get; set; }
+
+        /// <summary>
+        ///     The partition offset associated with the message.
+        /// </summary>
+        public Offset Offset { get; set; }
+
+        /// <summary>
+        ///     An error (or NoError) associated with the message.
+        /// </summary>
+        public Error Error { get; set; }
+
+        /// <summary>
+        ///     The TopicPartition associated with the message.
+        /// </summary>
+        public TopicPartition TopicPartition
+            => new TopicPartition(Topic, Partition);
+
+        /// <summary>
+        ///     The TopicPartitionOffset associated with the message.
+        /// </summary>
+        public TopicPartitionOffset TopicPartitionOffset
+            => new TopicPartitionOffset(Topic, Partition, Offset);
+
+        /// <summary>
+        ///     The TopicPartitionOffsetError assoicated with the message.
+        /// </summary>
+        public TopicPartitionOffsetError TopicPartitionOffsetError
+        {
+            get
+            {
+                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
+            }
+            set
+            {
+                Topic = value.Topic;
+                Partition = value.Partition;
+                Offset = value.Offset;
+                Error = value.Error;
+            }
+        }
+
+        /// <summary>
+        ///     The Kafka message.
+        /// </summary>
+        public Message<TKey, TValue> Message { get; set; }
+
+        /// <summary>
+        ///     The Kafka message Key.
+        /// </summary>
+        public TKey Key
+        {
+            get { return Message.Key; }
+            set { Message.Key = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message Value.
+        /// </summary>
+        public TValue Value
+        {
+            get { return Message.Value; }
+            set { Message.Value = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message timestamp.
+        /// </summary>
+        public Timestamp Timestamp
+        {
+            get { return Message.Timestamp; }
+            set { Message.Timestamp = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message headers.
+        /// </summary>
+        public Headers Headers
+        {
+            get { return Message.Headers; }
+            set { Message.Headers = value; }
+        }
+    }
+}


### PR DESCRIPTION
This commit addresses the two deficiencies noted in the comments of the preceding PR - duplication of code between `ConsumerRecord` and `DeliveryReport` and the fact that `Message` is only nested but `TopicPartitionOffsetError` both is.. and isn't. I think it's convenient and makes a lot of structural sense to have everything both flattened and nested.