### PR TITLE
Validate config values for 'not-null'

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -151,7 +151,7 @@ namespace Confluent.Kafka
             modifiedConfig
                 .ToList()
                 .ForEach((kvp) => {
-                    if(kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
+                    if (kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
                     configHandle.Set(kvp.Key, kvp.Value.ToString());
                 });
 
@@ -162,7 +162,7 @@ namespace Confluent.Kafka
             {
                 defaultTopicConfig.ToList().ForEach(
                     (kvp) => {
-                        if(kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter in 'default.topic.config' must not be null.");
+                        if (kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter in 'default.topic.config' must not be null.");
                         configHandle.Set(kvp.Key, kvp.Value.ToString());
                     }
                 );

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -150,7 +150,10 @@ namespace Confluent.Kafka
             var configHandle = SafeConfigHandle.Create();
             modifiedConfig
                 .ToList()
-                .ForEach((kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); });
+                .ForEach((kvp) => {
+                    if(kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
+                    configHandle.Set(kvp.Key, kvp.Value.ToString());
+                });
 
             // Note: Setting default topic configuration properties via default.topic.config is depreciated 
             // and this functionality will be removed in a future version of the library.
@@ -158,7 +161,10 @@ namespace Confluent.Kafka
             if (defaultTopicConfig != null)
             {
                 defaultTopicConfig.ToList().ForEach(
-                    (kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); }
+                    (kvp) => {
+                        if(kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter in 'default.topic.config' must not be null.");
+                        configHandle.Set(kvp.Key, kvp.Value.ToString());
+                    }
                 );
             }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -439,7 +439,11 @@ namespace Confluent.Kafka
 
             var configHandle = SafeConfigHandle.Create();
 
-            modifiedConfig.ToList().ForEach((kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); });
+            modifiedConfig.ToList().ForEach((kvp) => {
+                if(kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
+                configHandle.Set(kvp.Key, kvp.Value.ToString());
+            });
+
 
             IntPtr configPtr = configHandle.DangerousGetHandle();
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -440,7 +440,7 @@ namespace Confluent.Kafka
             var configHandle = SafeConfigHandle.Create();
 
             modifiedConfig.ToList().ForEach((kvp) => {
-                if(kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
+                if (kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
                 configHandle.Set(kvp.Key, kvp.Value.ToString());
             });
 

--- a/test/Confluent.Kafka.UnitTests/Consumer.cs
+++ b/test/Confluent.Kafka.UnitTests/Consumer.cs
@@ -25,34 +25,52 @@ namespace Confluent.Kafka.UnitTests
 {
     public class ConsumerTests
     {
-        /// <summary>
-        ///     Test that the Consumer constructor throws an exception if
-        ///     the group.id configuration parameter is not set and that
-        ///     the message of the exception mentions group.id (i.e. is
-        ///     not some unrelated exception).
-        /// </summary>
         [Fact]
         public void Constuctor()
         {
+            // Throw exception if 'group.id' is not set in config and ensure that exception
+            // mentions 'group.id'.
             var config = new Dictionary<string, object>();
             var e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<byte[], byte[]>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()); });
             Assert.Contains("group.id", e.Message);
             e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<Null, string>(config, null, new StringDeserializer(Encoding.UTF8)); });
             Assert.Contains("group.id", e.Message);
 
+            // Throw exception if a config value is null and ensure that exception mentions the
+            // respective config key.
+            var configWithNullValue = CreateValidConfiguration();
+            configWithNullValue["sasl.password"] = null;
+            e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<byte[], byte[]>(configWithNullValue, new ByteArrayDeserializer(), new ByteArrayDeserializer()); });
+            Assert.Contains("sasl.password", e.Message);
+
+            // Throw exception if a config value within default.topic.config is null and
+            // ensure that exception mentions the respective config key.
+            var configWithDefaultTopicNullValue = CreateValidConfiguration();
+            configWithDefaultTopicNullValue["default.topic.config"] = new Dictionary<string, object>() { { "auto.offset.reset", null } };
+            e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<byte[], byte[]>(configWithDefaultTopicNullValue, new ByteArrayDeserializer(), new ByteArrayDeserializer()); });
+            Assert.Contains("default.topic.config", e.Message);
+            Assert.Contains("auto.offset.reset", e.Message);
+
+            // Throw exception when serializer and deserializer are equal and ensure that exception
+            // message indicates the issue.
             e = Assert.Throws<ArgumentException>(() => 
             {
-                var validConfig = new Dictionary<string, object>
-                {
-                    { "bootstrap.servers", "localhost:9092" },
-                    { "group.id", "my-group" }
-                };
+                var validConfig = CreateValidConfiguration();
                 var deserializer = new StringDeserializer(Encoding.UTF8);
                 var c = new Consumer<string, string>(validConfig, deserializer, deserializer); 
             });
             Assert.Contains("must not be the same object", e.Message);
 
             // positve case covered by integration tests. here, avoiding creating a rd_kafka_t instance.
+        }
+
+        private static Dictionary<string, object> CreateValidConfiguration()
+        {
+            return new Dictionary<string, object>
+            {
+                { "bootstrap.servers", "localhost:9092" },
+                { "group.id", "my-group" }
+            };
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Producer.cs
+++ b/test/Confluent.Kafka.UnitTests/Producer.cs
@@ -1,0 +1,42 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Xunit;
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Confluent.Kafka.Serialization;
+
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class ProducerTests
+    {
+        [Fact]
+        public void Constuctor()
+        {
+            // Throw exception if a config value is null and ensure that exception mentions the
+            // respective config key.
+            var configWithNullValue = new Dictionary<string, object>
+            {
+                { "sasl.password", null }               
+            };
+            configWithNullValue["sasl.password"] = null;
+            var e = Assert.Throws<ArgumentException>(() => { var c = new Producer<byte[], byte[]>(configWithNullValue, new ByteArraySerializer(), new ByteArraySerializer()); });
+            Assert.Contains("sasl.password", e.Message);
+        }
+    }
+}


### PR DESCRIPTION
Recently, we provoked a generic NullReferenceException by accidentally passing a `null` value as configuration to the consumer constructor which took us some time to identify the parameter causing the trouble.

Therefore, this PR suggests to apply validation to the configuration passed to consumers and producers, checking all key-value-pairs' values for not null. In case the validation fails, an ArgumentExcpetion is thrown containing the configuration key name to make debugging more easy.

I've implemented the validation for the `1.0-experimental` branch. However - if more appropriate - I can supply the patch for another branch as well.

Looking forward to your feedback!