### PR TITLE
Validate config values for 'not-null' (on `master`)

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -819,7 +819,10 @@ namespace Confluent.Kafka
             config
                 .Where(prop => prop.Key != "default.topic.config")
                 .ToList()
-                .ForEach((kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); });
+                .ForEach((kvp) => {
+                    if (kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
+                    configHandle.Set(kvp.Key, kvp.Value.ToString());
+                });
 
             // Note: Setting default topic configuration properties via default.topic.config is depreciated 
             // and this functionality will be removed in a future version of the library.
@@ -827,7 +830,10 @@ namespace Confluent.Kafka
             if (defaultTopicConfig != null)
             {
                 defaultTopicConfig.ToList().ForEach(
-                    (kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); }
+                    (kvp) => {
+                        if (kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter in 'default.topic.config' must not be null.");
+                        configHandle.Set(kvp.Key, kvp.Value.ToString());
+                    }
                 );
             }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -279,7 +279,10 @@ namespace Confluent.Kafka
                 modifiedConfig = modifiedConfig.Concat(new KeyValuePair<string, object>[] { new KeyValuePair<string, object>("produce.offset.report", "true") });
             }
 
-            modifiedConfig.ToList().ForEach((kvp) => { configHandle.Set(kvp.Key, kvp.Value.ToString()); });
+            modifiedConfig.ToList().ForEach((kvp) => {
+                if (kvp.Value == null) throw new ArgumentException($"'{kvp.Key}' configuration parameter must not be null.");
+                configHandle.Set(kvp.Key, kvp.Value.ToString());
+            });
 
             IntPtr configPtr = configHandle.DangerousGetHandle();
 

--- a/test/Confluent.Kafka.UnitTests/Producer.cs
+++ b/test/Confluent.Kafka.UnitTests/Producer.cs
@@ -1,0 +1,42 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Xunit;
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Confluent.Kafka.Serialization;
+
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class ProducerTests
+    {
+        [Fact]
+        public void Constuctor()
+        {
+            // Throw exception if a config value is null and ensure that exception mentions the
+            // respective config key.
+            var configWithNullValue = new Dictionary<string, object>
+            {
+                { "sasl.password", null }
+            };
+            configWithNullValue["sasl.password"] = null;
+            var e = Assert.Throws<ArgumentException>(() => { var c = new Producer<byte[], byte[]>(configWithNullValue, new ByteArraySerializer(), new ByteArraySerializer()); });
+            Assert.Contains("sasl.password", e.Message);
+        }
+    }
+}


### PR DESCRIPTION
Same feature as #543, cherry-picked to `master`.