### PR TITLE
Implement IEquatable on structs to avoid equality boxing

### DIFF
--- a/src/Confluent.Kafka/Offset.cs
+++ b/src/Confluent.Kafka/Offset.cs
@@ -16,6 +16,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 
 namespace Confluent.Kafka
 {
@@ -27,7 +29,7 @@ namespace Confluent.Kafka
     ///     its purpose is to add some syntactical sugar 
     ///     related to special values.
     /// </remarks>
-    public struct Offset
+    public struct Offset : IEquatable<Offset>
     {
         private const long RD_KAFKA_OFFSET_BEGINNING = -2;
         private const long RD_KAFKA_OFFSET_END = -1;
@@ -100,13 +102,25 @@ namespace Confluent.Kafka
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is Offset))
+            if (obj is Offset o)
             {
-                return false;
+                return Equals(o);
             }
 
-            return ((Offset)obj).Value == this.Value;
+            return false;
         }
+
+        /// <summary>
+        ///     Tests whether this Offset value is equal to the specified Offset.
+        /// </summary>
+        /// <param name="other">
+        ///     The offset to test.
+        /// </param>
+        /// <returns>
+        ///     true if other has the same value. false otherwise.
+        /// </returns>
+        public bool Equals(Offset other)
+            => other.Value == Value;
 
         /// <summary>
         ///     Tests whether Offset value a is equal to Offset value b.

--- a/src/Confluent.Kafka/Partition.cs
+++ b/src/Confluent.Kafka/Partition.cs
@@ -16,6 +16,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 
 namespace Confluent.Kafka
 {
@@ -27,7 +29,7 @@ namespace Confluent.Kafka
     ///     its purpose is to add some syntactical sugar 
     ///     related to special values.
     /// </remarks>
-    public struct Partition
+    public struct Partition : IEquatable<Partition>
     {
         private const int RD_KAFKA_PARTITION_UA = -1;
 
@@ -70,13 +72,25 @@ namespace Confluent.Kafka
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is Partition))
+            if (obj is Partition p)
             {
-                return false;
+                return Equals(p);
             }
 
-            return ((Partition)obj).Value == this.Value;
+            return false;
         }
+
+        /// <summary>
+        ///     Tests whether this Partition value is equal to the specified Partition.
+        /// </summary>
+        /// <param name="other">
+        ///     The partition to test.
+        /// </param>
+        /// <returns>
+        ///     true if other has the same value. false otherwise.
+        /// </returns>
+        public bool Equals(Partition other)
+            => other.Value == Value;
 
         /// <summary>
         ///     Tests whether Partition value a is equal to Partition value b.

--- a/src/Confluent.Kafka/Timestamp.cs
+++ b/src/Confluent.Kafka/Timestamp.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Encapsulates a Kafka timestamp and its type.
     /// </summary>
-    public struct Timestamp
+    public struct Timestamp : IEquatable<Timestamp>
     {
         private const long RD_KAFKA_NO_TIMESTAMP = 0;
 
@@ -134,14 +134,25 @@ namespace Confluent.Kafka
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is Timestamp))
+            if (obj is Timestamp ts)
             {
-                return false;
+                return Equals(ts);
             }
 
-            var ts = (Timestamp)obj;
-            return ts.Type == Type && ts.UnixTimestampMs == UnixTimestampMs;
+            return false;
         }
+
+        /// <summary>
+        ///     Determines whether two Timestamps have the same value.
+        /// </summary>
+        /// <param name="other">
+        ///     The timestamp to test.
+        /// </param>
+        /// <returns>
+        ///     true if other has the same value. false otherwise.
+        /// </returns>
+        public bool Equals(Timestamp other)
+            => other.Type == Type && other.UnixTimestampMs == UnixTimestampMs;
 
         /// <summary>
         ///     Returns the hashcode for this Timestamp.


### PR DESCRIPTION
Micro-optimization to avoid boxing when comparing structs (Partition, Offset, and Timestamp). I noticed it when using TopicPartition as the key to a dictionary. `EqualityComparer<T>.Default` checks if a type implements IEquatable<T> and uses it if present, so this also helps the dictionary case when a custom equality comparer isn't used.

Here is a before/after micro benchmark
```
                    Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
-------------------------- |----------:|----------:|----------:|-------:|----------:|
           PartitionEquals |  5.276 ns | 0.0350 ns | 0.0310 ns | 0.0076 |      24 B |
 PartitionEqualityComparer |  5.555 ns | 0.0258 ns | 0.0228 ns | 0.0076 |      24 B |
       PartitionDictionary | 10.575 ns | 0.0326 ns | 0.0304 ns | 0.0076 |      24 B |



                    Method |      Mean |     Error |    StdDev | Allocated |
-------------------------- |----------:|----------:|----------:|----------:|
           PartitionEquals | 0.0410 ns | 0.0039 ns | 0.0034 ns |       0 B |
 PartitionEqualityComparer | 0.0404 ns | 0.0032 ns | 0.0027 ns |       0 B |
       PartitionDictionary | 7.4428 ns | 0.0343 ns | 0.0321 ns |       0 B |
```

```csharp
private readonly Dictionary<Partition, int> partitionDictionary = new Dictionary<Partition, int>()
{
    { new Partition(0), 0 }, { new Partition(1), 0 },
    { new Partition(2), 0 }, { new Partition(3), 0 }
};

[Benchmark]
public bool PartitionEquals()
{
    var partition1 = new Partition(100);
    var partition2 = new Partition(101);
    return partition1.Equals(partition2);
}

[Benchmark]
public bool PartitionEqualityComparer()
{
    var partition1 = new Partition(100);
    var partition2 = new Partition(101);
    return EqualityComparer<Partition>.Default.Equals(partition1, partition2);
}

[Benchmark]
public int PartitionDictionary()
{
    var key = new Partition(0);
    return partitionDictionary[key];
}
```