### PR TITLE
ProducerAsync return task which never completes

### DIFF
--- a/src/Confluent.Kafka/ErrorCode.cs
+++ b/src/Confluent.Kafka/ErrorCode.cs
@@ -415,7 +415,7 @@ namespace Confluent.Kafka
         IllegalSaslState = 34,
 
         /// <summary>
-        ///     Unuspported version
+        ///     Unsupported version
         /// </summary>
         UnsupportedVersion = 35
     };

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -231,9 +231,18 @@ namespace Confluent.Kafka
             Int32? partition, bool blockIfQueueFull
         )
         {
-            var deliveryCompletionSource = new TaskDeliveryHandler();
-            Produce(topic, val, valOffset, valLength, key, keyOffset, keyLength, timestamp, partition != null ? partition.Value : RD_KAFKA_PARTITION_UA, blockIfQueueFull, deliveryCompletionSource);
-            return deliveryCompletionSource.Task;
+            if (!this.disableDeliveryReports)
+            {
+                var deliveryCompletionSource = new TaskDeliveryHandler();
+                Produce(topic, val, valOffset, valLength, key, keyOffset, keyLength, timestamp, partition != null ? partition.Value : RD_KAFKA_PARTITION_UA, blockIfQueueFull, deliveryCompletionSource);
+                return deliveryCompletionSource.Task;
+            }
+            else
+            {
+                Produce(topic, val, valOffset, valLength, key, keyOffset, keyLength, timestamp, partition != null ? partition.Value : RD_KAFKA_PARTITION_UA, blockIfQueueFull, null);
+                var message = new Message(topic, -1, -1, key, val, new Timestamp(DateTime.UtcNow, TimestampType.NotAvailable), new Error(ErrorCode.NoError));
+                return Task.FromResult(message);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Quick fix for https://github.com/confluentinc/confluent-kafka-dotnet/issues/406.

Several points:
- Decided to return `NoError` instance for error instead of null, because this property is always filled
- Not sure about `Timestamp`, so used about `NotAvailable` type