### PR TITLE
Correct assertions in tests

### DIFF
--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -58,12 +58,12 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(dr.TopicPartition, dr.Offset) });
                 Message<Null, string> msg;
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromSeconds(10)));
-                Assert.Equal(msg.Value, testString);
+                Assert.Equal(testString, msg.Value);
 
                 // Determine offset to consume from automatically.
                 consumer.Assign(new List<TopicPartition>() { dr.TopicPartition });
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromSeconds(10)));
-                Assert.Equal(msg.Value, testString2);
+                Assert.Equal(testString2, msg.Value);
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -59,8 +59,8 @@ namespace Confluent.Kafka.IntegrationTests
                         timeout)
                     .ToList();
 
-                Assert.Equal(result.Count, 1);
-                Assert.Equal(result[0].Offset, firstMessage.Offset);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(firstMessage.Offset, result[0].Offset);
                 Assert.False(result[0].Error.HasError);
 
                 // Getting the offset for the last produced message timestamp
@@ -69,8 +69,8 @@ namespace Confluent.Kafka.IntegrationTests
                         timeout)
                     .ToList();
 
-                Assert.Equal(result.Count, 1);
-                Assert.Equal(result[0].Offset, lastMessage.Offset);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(lastMessage.Offset, result[0].Offset);
                 Assert.False(result[0].Error.HasError);
 
                 // Getting the offset for the timestamp that very far in the past
@@ -80,8 +80,8 @@ namespace Confluent.Kafka.IntegrationTests
                         timeout)
                     .ToList();
 
-                Assert.Equal(result.Count, 1);
-                Assert.Equal(result[0].Offset, 0);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(0, result[0].Offset);
                 Assert.False(result[0].Error.HasError);
 
                 // Getting the offset for the timestamp that very far in the future
@@ -90,8 +90,8 @@ namespace Confluent.Kafka.IntegrationTests
                         timeout)
                     .ToList();
 
-                Assert.Equal(result.Count, 1);
-                Assert.Equal(result[0].Offset, 0);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(0, result[0].Offset);
                 Assert.False(result[0].Error.HasError);
             }
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Consume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Consume.cs
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.IntegrationTests
                     }
                 }
 
-                Assert.Equal(msgCnt, N);
+                Assert.Equal(N, msgCnt);
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 consumer.OnMessage += (_, msg) =>
                 {
-                    Assert.Equal(msg.Error.Code, ErrorCode.NoError);
+                    Assert.Equal(ErrorCode.NoError, msg.Error.Code);
                     Assert.Equal(TimestampType.CreateTime, msg.Timestamp.Type);
                     Assert.True(Math.Abs((DateTime.UtcNow - msg.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
                     msgCnt += 1;
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
                     consumer.Poll(TimeSpan.FromMilliseconds(100));
                 }
 
-                Assert.Equal(msgCnt, N);
+                Assert.Equal(N, msgCnt);
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DeserializingConsumer_Poll_Error.cs
@@ -94,8 +94,8 @@ namespace Confluent.Kafka.IntegrationTests
                     consumer.Poll(TimeSpan.FromMilliseconds(100));
                 }
 
-                Assert.Equal(msgCnt, 1);
-                Assert.Equal(errCnt, 1);
+                Assert.Equal(1, msgCnt);
+                Assert.Equal(1, errCnt);
             }
 
             // test value deserialization error behavior
@@ -137,8 +137,8 @@ namespace Confluent.Kafka.IntegrationTests
                     consumer.Poll(TimeSpan.FromMilliseconds(100));
                 }
 
-                Assert.Equal(msgCnt, 1);
-                Assert.Equal(errCnt, 1);
+                Assert.Equal(1, msgCnt);
+                Assert.Equal(1, errCnt);
             }
 
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -82,8 +82,8 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.NotNull(msg);
                 Assert.Null(msg.Key);
                 Assert.NotNull(msg.Value);
-                Assert.Equal(msg.Value[0], 42);
-                Assert.Equal(msg.Value[1], 240);
+                Assert.Equal(42, msg.Value[0]);
+                Assert.Equal(240, msg.Value[1]);
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ListGroup.cs
@@ -53,8 +53,8 @@ namespace Confluent.Kafka.IntegrationTests
 
                 consumer.OnPartitionsAssigned += (_, partitions) =>
                 {
-                    Assert.Equal(partitions.Count, 1);
-                    Assert.Equal(partitions[0], firstProduced.TopicPartition);
+                    Assert.Equal(1, partitions.Count);
+                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
                     consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
                 };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
@@ -71,12 +71,12 @@ namespace Confluent.Kafka.IntegrationTests
                 }
 
                 var brokers = new List<JToken>(deserialized["Brokers"].Children());
-                Assert.Equal(metadata.Brokers.Count, brokers.Count);
+                Assert.Equal(brokers.Count, metadata.Brokers.Count);
                 for (int i=0; i<metadata.Brokers.Count; ++i)
                 {
-                    Assert.Equal(metadata.Brokers[i].BrokerId, brokers[i].Value<int>("BrokerId"));
-                    Assert.Equal(metadata.Brokers[i].Host, brokers[i].Value<string>("Host"));
-                    Assert.Equal(metadata.Brokers[i].Port, brokers[i].Value<int>("Port"));
+                    Assert.Equal(brokers[i].Value<int>("BrokerId"), metadata.Brokers[i].BrokerId);
+                    Assert.Equal(brokers[i].Value<string>("Host"), metadata.Brokers[i].Host);
+                    Assert.Equal(brokers[i].Value<int>("Port"), metadata.Brokers[i].Port);
                 }
             }
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -65,15 +65,15 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
                 Assert.NotNull(msg);
                 Assert.Null(msg.Key);
-                Assert.Equal(msg.Value, new byte[0]);
+                Assert.Equal(new byte[0], msg.Value);
 
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
-                Assert.Equal(msg.Key, new byte[0]);
+                Assert.Equal(new byte[0], msg.Key);
                 Assert.Null(msg.Value);
 
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromMinutes(1)));
-                Assert.Equal(msg.Key, new byte[0]);
-                Assert.Equal(msg.Value, new byte[0]);
+                Assert.Equal(new byte[0], msg.Key);
+                Assert.Equal(new byte[0], msg.Value);
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -46,17 +46,17 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new Producer<Null, string>(producerConfig, null, new StringSerializer(Encoding.UTF8)))
             {
                 var dr = producer.ProduceAsync(singlePartitionTopic, null, "test string").Result;
-                Assert.NotEqual((long)dr.Offset, (long)Offset.Invalid); // TODO: remove long cast. this is fixed in PR #29
+                Assert.NotEqual((long)Offset.Invalid, (long)dr.Offset); // TODO: remove long cast. this is fixed in PR #29
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
             using (var consumer = new Consumer<Null, string>(consumerConfig, null, new StringDeserializer(Encoding.UTF8)))
             {
                 consumer.Subscribe(singlePartitionTopic);
-                Assert.Equal(consumer.Assignment.Count, 0);
+                Assert.Equal(0, consumer.Assignment.Count);
                 consumer.Poll(TimeSpan.FromSeconds(10));
-                Assert.Equal(consumer.Assignment.Count, 1);
-                Assert.Equal(consumer.Assignment[0].Topic, singlePartitionTopic);
+                Assert.Equal(1, consumer.Assignment.Count);
+                Assert.Equal(singlePartitionTopic, consumer.Assignment[0].Topic);
             }
         }
     }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -75,8 +75,8 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.NotNull(msg);
             Assert.Equal(testString, msg.Value == null ? null : Encoding.UTF8.GetString(msg.Value, 0, msg.Value.Length));
             Assert.Equal(null, msg.Key);
-            Assert.Equal(msg.Timestamp.Type, dr.Timestamp.Type);
-            Assert.Equal(msg.Timestamp.UnixTimestampMs, dr.Timestamp.UnixTimestampMs);
+            Assert.Equal(dr.Timestamp.Type, msg.Timestamp.Type);
+            Assert.Equal(dr.Timestamp.UnixTimestampMs, msg.Timestamp.UnixTimestampMs);
         }
 
         private static Message<Null, string> ProduceMessage(string topic, Producer<Null, string> producer, string testString)
@@ -84,7 +84,7 @@ namespace Confluent.Kafka.IntegrationTests
             var result = producer.ProduceAsync(topic, null, testString).Result;
             Assert.NotNull(result);
             Assert.Equal(topic, result.Topic);
-            Assert.NotEqual<long>(result.Offset, Offset.Invalid);
+            Assert.NotEqual<long>(Offset.Invalid, result.Offset);
             Assert.Equal(TimestampType.CreateTime, result.Timestamp.Type);
             Assert.True(Math.Abs((DateTime.UtcNow - result.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             producer.Flush(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -46,8 +46,8 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.Flush(TimeSpan.FromSeconds(10));
 
                 var queryOffsets = producer.QueryWatermarkOffsets(new TopicPartition(singlePartitionTopic, 0));
-                Assert.NotEqual(queryOffsets.Low, Offset.Invalid);
-                Assert.NotEqual(queryOffsets.High, Offset.Invalid);
+                Assert.NotEqual(Offset.Invalid, queryOffsets.Low);
+                Assert.NotEqual(Offset.Invalid, queryOffsets.High);
 
                 // TODO: can anything be said about the high watermark offset c.f. dr.Offset?
                 //       I have seen queryOffsets.High < dr.Offset and also queryOffsets.High = dr.Offset + 1.
@@ -71,12 +71,12 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(consumer.Consume(out msg, TimeSpan.FromSeconds(10)));
 
                 var getOffsets = consumer.GetWatermarkOffsets(dr.TopicPartition);
-                Assert.Equal(getOffsets.Low, Offset.Invalid);
+                Assert.Equal(Offset.Invalid, getOffsets.Low);
                 // the offset of the next message to be read.
-                Assert.Equal((long)getOffsets.High, dr.Offset + 1);
+                Assert.Equal(dr.Offset + 1, (long)getOffsets.High);
 
                 var queryOffsets = consumer.QueryWatermarkOffsets(dr.TopicPartition);
-                Assert.NotEqual(queryOffsets.Low, Offset.Invalid);
+                Assert.NotEqual(Offset.Invalid, queryOffsets.Low);
                 Assert.Equal(getOffsets.High, queryOffsets.High);
             }
         }

--- a/test/Confluent.Kafka.IntegrationTests/Util.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Util.cs
@@ -59,7 +59,7 @@ namespace Confluent.Kafka.IntegrationTests
                         firstDeliveryReport = dr;
                     }
                     Assert.Equal(topic, dr.Topic);
-                    Assert.NotEqual<long>(dr.Offset, Offset.Invalid);
+                    Assert.NotEqual<long>(Offset.Invalid, dr.Offset);
                 }
 
                 producer.Flush(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.UnitTests/BrokerMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/BrokerMetadata.cs
@@ -22,21 +22,21 @@ namespace Confluent.Kafka.UnitTests
     public class BrokerMetadataTest
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var bm = new BrokerMetadata(42, "myhost", 8080);
-            Assert.Equal(bm.BrokerId, 42);
-            Assert.Equal(bm.Host, "myhost");
-            Assert.Equal(bm.Port, 8080);
+            Assert.Equal(42, bm.BrokerId);
+            Assert.Equal("myhost", bm.Host);
+            Assert.Equal(8080, bm.Port);
         }
 
         [Fact]
         public void ToStringTest()
         {
             var bm = new BrokerMetadata(42, "myhost", 8080);
-            Assert.True(bm.ToString().Contains(42.ToString()));
-            Assert.True(bm.ToString().Contains("myhost"));
-            Assert.True(bm.ToString().Contains(8080.ToString()));
+            Assert.Contains(42.ToString(), bm.ToString());
+            Assert.Contains("myhost", bm.ToString());
+            Assert.Contains(8080.ToString(), bm.ToString());
 
             // TODO: JSON based test. Note: there is coverage of this already in the Metdata integration test.
         }

--- a/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
+++ b/test/Confluent.Kafka.UnitTests/CommittedOffsets.cs
@@ -23,13 +23,13 @@ namespace Confluent.Kafka.UnitTests
     public class CommittedOffetsTest
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var tpos = new List<TopicPartitionOffsetError>();
             var err = new Error(ErrorCode.UnknownTopicOrPart);
             var co = new CommittedOffsets(tpos, err);
-            Assert.Same(co.Offsets, tpos);
-            Assert.Equal(co.Error, err);
+            Assert.Same(tpos, co.Offsets);
+            Assert.Equal(err, co.Error);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Consumer.cs
+++ b/test/Confluent.Kafka.UnitTests/Consumer.cs
@@ -26,15 +26,15 @@ namespace Confluent.Kafka.UnitTests
     public class ConsumerTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             // Throw exception if 'group.id' is not set in config and ensure that exception
             // mentions 'group.id'.
             var config = new Dictionary<string, object>();
             var e = Assert.Throws<ArgumentException>(() => { var c = new Consumer(config); });
-            Assert.True(e.Message.Contains("group.id"));
+            Assert.Contains("group.id", e.Message);
             e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<Null, string>(config, null, new StringDeserializer(Encoding.UTF8)); });
-            Assert.True(e.Message.Contains("group.id"));
+            Assert.Contains("group.id", e.Message);
 
             // Throw exception if a config value is null and ensure that exception mentions the
             // respective config key.
@@ -59,9 +59,9 @@ namespace Confluent.Kafka.UnitTests
                 var deserializer = new StringDeserializer(Encoding.UTF8);
                 var c = new Consumer<string, string>(validConfig, deserializer, deserializer); 
             });
-            Assert.True(e.Message.Contains("must not be the same object"));
+            Assert.Contains("must not be the same object", e.Message);
 
-            // positve case covered by integration tests. here, avoiding creating a rd_kafka_t instance.
+            // positive case covered by integration tests. here, avoiding creating a rd_kafka_t instance.
         }
 
         private static Dictionary<string, object> CreateValidConfiguration()

--- a/test/Confluent.Kafka.UnitTests/Error.cs
+++ b/test/Confluent.Kafka.UnitTests/Error.cs
@@ -22,16 +22,16 @@ namespace Confluent.Kafka.UnitTests
     public class ErrorTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var e = new Error(ErrorCode.Local_BadCompression);
-            Assert.Equal(e.Code, ErrorCode.Local_BadCompression);
+            Assert.Equal(ErrorCode.Local_BadCompression, e.Code);
             Assert.NotNull(e.Reason);
-            Assert.Equal(e.Reason, "Local: Invalid compressed data");
+            Assert.Equal("Local: Invalid compressed data", e.Reason);
 
             var e2 = new Error(ErrorCode.Local_BadMsg, "Dummy message");
-            Assert.Equal(e2.Code, ErrorCode.Local_BadMsg);
-            Assert.Equal(e2.Reason, "Dummy message");
+            Assert.Equal(ErrorCode.Local_BadMsg, e2.Code);
+            Assert.Equal("Dummy message", e2.Reason);
         }
 
         [Fact]
@@ -107,7 +107,6 @@ namespace Confluent.Kafka.UnitTests
             var e1 = new Error(ErrorCode.NotCoordinatorForGroup);
             var ec1 = ErrorCode.NotCoordinatorForGroup;
 
-            Assert.Equal((ErrorCode)e1, ec1);
             Assert.Equal(ec1, (ErrorCode)e1);
         }
     }

--- a/test/Confluent.Kafka.UnitTests/GroupInfo.cs
+++ b/test/Confluent.Kafka.UnitTests/GroupInfo.cs
@@ -23,18 +23,18 @@ namespace Confluent.Kafka.UnitTests
     public class GroupInfoTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var bmd = new BrokerMetadata(1, "host", 42);
             var members = new List<GroupMemberInfo>();
             var gi = new GroupInfo(bmd, "mygroup", new Error(ErrorCode.NoError), "mystate", "myprotocoltype", "myprotocol", members);
-            Assert.Equal(gi.Broker, bmd);
-            Assert.Equal(gi.Group, "mygroup");
-            Assert.Equal(gi.Error, new Error(ErrorCode.NoError));
-            Assert.Equal(gi.State, "mystate");
-            Assert.Equal(gi.ProtocolType, "myprotocoltype");
-            Assert.Equal(gi.Protocol, "myprotocol");
-            Assert.Same(gi.Members, members);
+            Assert.Equal(bmd, gi.Broker);
+            Assert.Equal("mygroup", gi.Group);
+            Assert.Equal(new Error(ErrorCode.NoError), gi.Error);
+            Assert.Equal("mystate", gi.State);
+            Assert.Equal("myprotocoltype", gi.ProtocolType);
+            Assert.Equal("myprotocol", gi.Protocol);
+            Assert.Same(members, gi.Members);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/GroupMemberInfo.cs
+++ b/test/Confluent.Kafka.UnitTests/GroupMemberInfo.cs
@@ -22,16 +22,16 @@ namespace Confluent.Kafka.UnitTests
     public class GroupMemberInfoTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var memberMetadata = new byte[0];
             var memberAssignment = new byte[0];
             var gmi = new GroupMemberInfo("mymember", "myclient", "clienthost", memberMetadata, memberAssignment);
-            Assert.Equal(gmi.MemberId, "mymember");
-            Assert.Equal(gmi.ClientId, "myclient");
-            Assert.Equal(gmi.ClientHost, "clienthost");
-            Assert.Same(gmi.MemberMetadata, memberMetadata);
-            Assert.Same(gmi.MemberAssignment, memberAssignment);
+            Assert.Equal("mymember", gmi.MemberId);
+            Assert.Equal("myclient", gmi.ClientId);
+            Assert.Equal("clienthost", gmi.ClientHost);
+            Assert.Same(memberMetadata, gmi.MemberMetadata);
+            Assert.Same(memberAssignment, gmi.MemberAssignment);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Library.cs
+++ b/test/Confluent.Kafka.UnitTests/Library.cs
@@ -25,21 +25,21 @@ namespace Confluent.Kafka.UnitTests
         public void Version()
         {
             // test that an exception is not thrown.
-            Assert.NotEqual(Library.Version, 0);
+            Assert.NotEqual(0, Library.Version);
         }
 
         [Fact]
         public void VersionString()
         {
             // test that an exception is not thrown.
-            Assert.NotEqual(Library.VersionString, null);
+            Assert.NotEqual(null, Library.VersionString);
         }
 
         [Fact]
         public void DebugContexts()
         {
             // test that an exception is not thrown.      
-            Assert.NotEqual(Library.DebugContexts.Length, 0);
+            Assert.NotEqual(0, Library.DebugContexts.Length);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/LogMessage.cs
+++ b/test/Confluent.Kafka.UnitTests/LogMessage.cs
@@ -22,13 +22,13 @@ namespace Confluent.Kafka.UnitTests
     public class LogMessageTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var lm = new LogMessage("myname", 42, "myfacility", "mymessage");
-            Assert.Equal(lm.Name, "myname");
-            Assert.Equal(lm.Level, 42);
-            Assert.Equal(lm.Facility, "myfacility");
-            Assert.Equal(lm.Message, "mymessage");
+            Assert.Equal("myname", lm.Name);
+            Assert.Equal(42, lm.Level);
+            Assert.Equal("myfacility", lm.Facility);
+            Assert.Equal("mymessage", lm.Message);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Message.cs
+++ b/test/Confluent.Kafka.UnitTests/Message.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using System;
 using Xunit;
 
 
@@ -23,37 +22,37 @@ namespace Confluent.Kafka.UnitTests
     public class MessageTests
     {
         [Fact]
-        public void ConstuctorAndProps()
+        public void ConstructorAndProps()
         {
             byte[] key = new byte[0];
             byte[] val = new byte[0];
             var mi = new Message("tp1", 24, 33, key, val, new Timestamp(123456789, TimestampType.CreateTime), new Error(ErrorCode.NoError));
 
-            Assert.Equal(mi.Topic, "tp1");
-            Assert.Equal(mi.Partition, 24);
-            Assert.Equal(mi.Offset, 33);
-            Assert.Same(mi.Key, key);
-            Assert.Same(mi.Value, val);
-            Assert.Equal(mi.Timestamp, new Timestamp(123456789, TimestampType.CreateTime));
-            Assert.Equal(mi.Error, new Error(ErrorCode.NoError));
-            Assert.Equal(mi.TopicPartition, new TopicPartition("tp1", 24));
-            Assert.Equal(mi.TopicPartitionOffset, new TopicPartitionOffset("tp1", 24, 33));
+            Assert.Equal("tp1", mi.Topic);
+            Assert.Equal(24, mi.Partition);
+            Assert.Equal(33, mi.Offset);
+            Assert.Same(key, mi.Key);
+            Assert.Same(val, mi.Value);
+            Assert.Equal(new Timestamp(123456789, TimestampType.CreateTime), mi.Timestamp);
+            Assert.Equal(new Error(ErrorCode.NoError), mi.Error);
+            Assert.Equal(new TopicPartition("tp1", 24), mi.TopicPartition);
+            Assert.Equal(new TopicPartitionOffset("tp1", 24, 33), mi.TopicPartitionOffset);
         }
 
         [Fact]
-        public void ConstuctorAndProps_Generic()
+        public void ConstructorAndProps_Generic()
         {
             var mi = new Message<string, string>("tp1", 24, 33, "mykey", "myval", new Timestamp(123456789, TimestampType.CreateTime), new Error(ErrorCode.NoError));
 
-            Assert.Equal(mi.Topic, "tp1");
-            Assert.Equal(mi.Partition, 24);
-            Assert.Equal(mi.Offset, 33);
-            Assert.Equal(mi.Key, "mykey");
-            Assert.Equal(mi.Value, "myval");
-            Assert.Equal(mi.Timestamp, new Timestamp(123456789, TimestampType.CreateTime));
-            Assert.Equal(mi.Error, new Error(ErrorCode.NoError));
-            Assert.Equal(mi.TopicPartition, new TopicPartition("tp1", 24));
-            Assert.Equal(mi.TopicPartitionOffset, new TopicPartitionOffset("tp1", 24, 33));
+            Assert.Equal("tp1", mi.Topic);
+            Assert.Equal(24, mi.Partition);
+            Assert.Equal(33, mi.Offset);
+            Assert.Equal("mykey", mi.Key);
+            Assert.Equal("myval", mi.Value);
+            Assert.Equal(new Timestamp(123456789, TimestampType.CreateTime), mi.Timestamp);
+            Assert.Equal(new Error(ErrorCode.NoError), mi.Error);
+            Assert.Equal(new TopicPartition("tp1", 24), mi.TopicPartition);
+            Assert.Equal(new TopicPartitionOffset("tp1", 24, 33), mi.TopicPartitionOffset);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Metadata.cs
+++ b/test/Confluent.Kafka.UnitTests/Metadata.cs
@@ -23,15 +23,15 @@ namespace Confluent.Kafka.UnitTests
     public class MetadataTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var brokers = new List<BrokerMetadata>();
             var topics = new List<TopicMetadata>();
             var md = new Metadata(brokers, topics, 42, "broker1");
-            Assert.Same(md.Brokers, brokers);
-            Assert.Same(md.Topics, topics);
-            Assert.Equal(md.OriginatingBrokerId, 42);
-            Assert.Equal(md.OriginatingBrokerName, "broker1");
+            Assert.Same(brokers, md.Brokers);
+            Assert.Same(topics, md.Topics);
+            Assert.Equal(42, md.OriginatingBrokerId);
+            Assert.Equal("broker1", md.OriginatingBrokerName);
         }
 
         // TODO: ToString() tests. Note: there is coverage of this already in the Metdata integration test.

--- a/test/Confluent.Kafka.UnitTests/Offset.cs
+++ b/test/Confluent.Kafka.UnitTests/Offset.cs
@@ -33,14 +33,14 @@ namespace Confluent.Kafka.UnitTests
         [Fact]
         public void Constructor()
         {
-            Assert.Equal(new Offset(42).Value, 42);
+            Assert.Equal(42, new Offset(42).Value);
         }
 
         [Fact]
         public void Casts()
         {
             long offsetValue = new Offset(42);
-            Assert.Equal(offsetValue, 42);
+            Assert.Equal(42, offsetValue);
 
             Offset offset = 42;
             Assert.Equal(offset, new Offset(42));
@@ -92,14 +92,14 @@ namespace Confluent.Kafka.UnitTests
         {
             Assert.Equal(new Offset(42).ToString(), 42.ToString());
             Assert.Equal(new Offset(-42).ToString(), (-42).ToString());
-            Assert.True(Offset.Invalid.ToString().Contains("Invalid"));
-            Assert.True(Offset.Invalid.ToString().Contains((-1001).ToString()));
-            Assert.True(Offset.Stored.ToString().Contains("Stored"));
-            Assert.True(Offset.Stored.ToString().Contains((-1000).ToString()));
-            Assert.True(Offset.Beginning.ToString().Contains("Beginning"));
-            Assert.True(Offset.Beginning.ToString().Contains((-2).ToString()));
-            Assert.True(Offset.End.ToString().Contains("End"));
-            Assert.True(Offset.End.ToString().Contains((-1).ToString()));
+            Assert.Contains("Invalid", Offset.Invalid.ToString());
+            Assert.Contains((-1001).ToString(), Offset.Invalid.ToString());
+            Assert.Contains("Stored", Offset.Stored.ToString());
+            Assert.Contains((-1000).ToString(), Offset.Stored.ToString());
+            Assert.Contains("Beginning", Offset.Beginning.ToString());
+            Assert.Contains((-2).ToString(), Offset.Beginning.ToString());
+            Assert.Contains("End", Offset.End.ToString());
+            Assert.Contains((-1).ToString(), Offset.End.ToString());
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/PartitionMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/PartitionMetadata.cs
@@ -22,16 +22,16 @@ namespace Confluent.Kafka.UnitTests
     public class PartitionMetadataTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             int[] replicas = new int[0];
             int[] inSyncReplicas = new int[0];
             var pm = new PartitionMetadata(33, 1, replicas, inSyncReplicas, ErrorCode.Local_AllBrokersDown);
-            Assert.Equal(pm.PartitionId, 33);
-            Assert.Equal(pm.Leader, 1);
-            Assert.Same(pm.Replicas, replicas);
-            Assert.Same(pm.InSyncReplicas, inSyncReplicas);
-            Assert.Equal(pm.Error, new Error(ErrorCode.Local_AllBrokersDown));
+            Assert.Equal(33, pm.PartitionId);
+            Assert.Equal(1, pm.Leader);
+            Assert.Same(replicas, pm.Replicas);
+            Assert.Same(inSyncReplicas, pm.InSyncReplicas);
+            Assert.Equal(new Error(ErrorCode.Local_AllBrokersDown), pm.Error);
         }
 
         // TODO: ToString() tests. Note: there is coverage of this already in the Metdata integration test.

--- a/test/Confluent.Kafka.UnitTests/Producer.cs
+++ b/test/Confluent.Kafka.UnitTests/Producer.cs
@@ -26,7 +26,7 @@ namespace Confluent.Kafka.UnitTests
     public class ProducerTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             // Throw exception if a config value is null and ensure that exception mentions the
             // respective config key.

--- a/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
@@ -37,10 +37,10 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             var serializer = new IntSerializer();
             var bytes = serializer.Serialize("topic", 42);
-            Assert.Equal(bytes.Length, 4);
+            Assert.Equal(4, bytes.Length);
             // most significant byte in smallest address.
-            Assert.Equal(bytes[0], 0);
-            Assert.Equal(bytes[3], 42);
+            Assert.Equal(0, bytes[0]);
+            Assert.Equal(42, bytes[3]);
         }
 
         [Fact]

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -23,7 +23,7 @@ namespace Confluent.Kafka.UnitTests
     public class TimestampTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var ts1 = new Timestamp(123456789, TimestampType.CreateTime);
             var ts2 = new Timestamp(-123456789, TimestampType.LogAppendTime);
@@ -31,8 +31,8 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal(123456789, ts1.UnixTimestampMs);
             Assert.Equal(-123456789, ts2.UnixTimestampMs);
 
-            Assert.Equal(ts1.Type, TimestampType.CreateTime);
-            Assert.Equal(ts2.Type, TimestampType.LogAppendTime);
+            Assert.Equal(TimestampType.CreateTime, ts1.Type);
+            Assert.Equal(TimestampType.LogAppendTime, ts2.Type);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Confluent.Kafka.UnitTests
             var ts2 = Timestamp.UnixTimestampMsToDateTime(unixTime);
             Assert.Equal(1336305843220, unixTime);
             Assert.Equal(ts, ts2);
-            Assert.Equal(ts2.Kind, DateTimeKind.Utc);
+            Assert.Equal(DateTimeKind.Utc, ts2.Kind);
         }
 
         [Fact]

--- a/test/Confluent.Kafka.UnitTests/TopicMetadata.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicMetadata.cs
@@ -23,14 +23,14 @@ namespace Confluent.Kafka.UnitTests
     public class TopicMetadataTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var partitions = new List<PartitionMetadata>();
             var tm = new TopicMetadata("mytopic", partitions, ErrorCode.Local_AllBrokersDown);
 
-            Assert.Equal(tm.Topic, "mytopic");
+            Assert.Equal("mytopic", tm.Topic);
             Assert.Same(partitions, tm.Partitions);
-            Assert.Equal(tm.Error, new Error(ErrorCode.Local_AllBrokersDown));
+            Assert.Equal(new Error(ErrorCode.Local_AllBrokersDown), tm.Error);
         }
 
         // TODO: ToString() tests. Note: there is coverage of this already in the Metdata integration test.

--- a/test/Confluent.Kafka.UnitTests/TopicPartition.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartition.cs
@@ -23,11 +23,11 @@ namespace Confluent.Kafka.UnitTests
     public class TopicPartitionTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var tp = new TopicPartition("mytopic", 42);
-            Assert.Equal(tp.Topic, "mytopic");
-            Assert.Equal(tp.Partition, 42);
+            Assert.Equal("mytopic", tp.Topic);
+            Assert.Equal(42, tp.Partition);
         }
 
         [Fact]
@@ -79,8 +79,8 @@ namespace Confluent.Kafka.UnitTests
         public void ToStringTest()
         {
             var tp = new TopicPartition("mytopic", 42);
-            Assert.True(tp.ToString().Contains(tp.Topic));
-            Assert.True(tp.ToString().Contains(tp.Partition.ToString()));
+            Assert.Contains(tp.Topic, tp.ToString());
+            Assert.Contains(tp.Partition.ToString(), tp.ToString());
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionError.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionError.cs
@@ -23,13 +23,13 @@ namespace Confluent.Kafka.UnitTests
     public class TopicPartitionErrorTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var tpe = new TopicPartitionError("mytopic", 42, ErrorCode.Local_BadMsg);
 
-            Assert.Equal(tpe.Topic, "mytopic");
-            Assert.Equal(tpe.Partition, 42);
-            Assert.Equal(tpe.Error, new Error(ErrorCode.Local_BadMsg));
+            Assert.Equal("mytopic", tpe.Topic);
+            Assert.Equal(42, tpe.Partition);
+            Assert.Equal(new Error(ErrorCode.Local_BadMsg), tpe.Error);
         }
 
         [Fact]
@@ -83,10 +83,10 @@ namespace Confluent.Kafka.UnitTests
         {
             var tpe = new TopicPartitionError("mytopic", 42, ErrorCode.Local_BadMsg);
 
-            Assert.True(tpe.ToString().Contains(tpe.Topic));
-            Assert.True(tpe.ToString().Contains(tpe.Partition.ToString()));
-            Assert.True(tpe.ToString().Contains(tpe.Error.ToString()));
-            Assert.True(tpe.ToString().Contains(tpe.Error.Reason));
+            Assert.Contains(tpe.Topic, tpe.ToString());
+            Assert.Contains(tpe.Partition.ToString(), tpe.ToString());
+            Assert.Contains(tpe.Error.ToString(), tpe.ToString());
+            Assert.Contains(tpe.Error.Reason, tpe.ToString());
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Confluent.Kafka.UnitTests
         {
             var tpe = new TopicPartitionError("mytopic", 42, ErrorCode.NoError);
 
-            Assert.Equal(tpe.TopicPartition, new TopicPartition("mytopic", 42));
+            Assert.Equal(new TopicPartition("mytopic", 42), tpe.TopicPartition);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffset.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffset.cs
@@ -23,12 +23,12 @@ namespace Confluent.Kafka.UnitTests
     public class TopicPartitionOffsetTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var tpo = new TopicPartitionOffset("mytopic", 42, 107);
-            Assert.Equal(tpo.Topic, "mytopic");
-            Assert.Equal(tpo.Partition, 42);
-            Assert.Equal(tpo.Offset, 107);
+            Assert.Equal("mytopic", tpo.Topic);
+            Assert.Equal(42, tpo.Partition);
+            Assert.Equal(107, tpo.Offset);
         }
 
         [Fact]
@@ -81,16 +81,16 @@ namespace Confluent.Kafka.UnitTests
         public void ToStringTest()
         {
             var tpo = new TopicPartitionOffset("mytopic", 42, 107);
-            Assert.True(tpo.ToString().Contains(tpo.Topic));
-            Assert.True(tpo.ToString().Contains(tpo.Partition.ToString()));
-            Assert.True(tpo.ToString().Contains(tpo.Offset.ToString()));
+            Assert.Contains(tpo.Topic, tpo.ToString());
+            Assert.Contains(tpo.Partition.ToString(), tpo.ToString());
+            Assert.Contains(tpo.Offset.ToString(), tpo.ToString());
         }
 
         [Fact]
         public void Properties()
         {
             var tpo = new TopicPartitionOffset("mytopic", 42, 107);
-            Assert.Equal(tpo.TopicPartition, new TopicPartition("mytopic", 42));
+            Assert.Equal(new TopicPartition("mytopic", 42), tpo.TopicPartition);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionOffsetError.cs
@@ -23,14 +23,14 @@ namespace Confluent.Kafka.UnitTests
     public class TopicPartitionOffsetErrorTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.Local_BadMsg);
 
-            Assert.Equal(tpoe.Topic, "mytopic");
-            Assert.Equal(tpoe.Partition, 42);
-            Assert.Equal(tpoe.Offset, 107);
-            Assert.Equal(tpoe.Error, new Error(ErrorCode.Local_BadMsg));
+            Assert.Equal("mytopic", tpoe.Topic);
+            Assert.Equal(42, tpoe.Partition);
+            Assert.Equal(107, tpoe.Offset);
+            Assert.Equal(new Error(ErrorCode.Local_BadMsg), tpoe.Error);
         }
 
         [Fact]
@@ -85,11 +85,11 @@ namespace Confluent.Kafka.UnitTests
         {
             var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.Local_BadMsg);
 
-            Assert.True(tpoe.ToString().Contains(tpoe.Topic));
-            Assert.True(tpoe.ToString().Contains(tpoe.Partition.ToString()));
-            Assert.True(tpoe.ToString().Contains(tpoe.Offset.ToString()));
-            Assert.True(tpoe.ToString().Contains(tpoe.Error.ToString()));
-            Assert.True(tpoe.ToString().Contains(tpoe.Error.Reason));
+            Assert.Contains(tpoe.Topic, tpoe.ToString());
+            Assert.Contains(tpoe.Partition.ToString(), tpoe.ToString());
+            Assert.Contains(tpoe.Offset.ToString(), tpoe.ToString());
+            Assert.Contains(tpoe.Error.ToString(), tpoe.ToString());
+            Assert.Contains(tpoe.Error.Reason, tpoe.ToString());
         }
 
         [Fact]
@@ -97,8 +97,8 @@ namespace Confluent.Kafka.UnitTests
         {
             var tpoe = new TopicPartitionOffsetError("mytopic", 42, 107, ErrorCode.NoError);
 
-            Assert.Equal(tpoe.TopicPartition, new TopicPartition("mytopic", 42));
-            Assert.Equal(tpoe.TopicPartitionOffset, new TopicPartitionOffset("mytopic", 42, 107));
+            Assert.Equal(new TopicPartition("mytopic", 42), tpoe.TopicPartition);
+            Assert.Equal(new TopicPartitionOffset("mytopic", 42, 107), tpoe.TopicPartitionOffset);
         }
 
         [Fact]

--- a/test/Confluent.Kafka.UnitTests/TopicPartitionTimestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/TopicPartitionTimestamp.cs
@@ -22,13 +22,13 @@ namespace Confluent.Kafka.Tests
     public class TopicPartitionTimestampTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var timestamp = new Timestamp(123456789, TimestampType.CreateTime);
             var tpt = new TopicPartitionTimestamp("mytopic", 42, timestamp);
-            Assert.Equal(tpt.Topic, "mytopic");
-            Assert.Equal(tpt.Partition, 42);
-            Assert.Equal(tpt.Timestamp, timestamp);
+            Assert.Equal("mytopic", tpt.Topic);
+            Assert.Equal(42, tpt.Partition);
+            Assert.Equal(timestamp, tpt.Timestamp);
         }
 
         [Fact]
@@ -63,9 +63,9 @@ namespace Confluent.Kafka.Tests
         {
             var timestamp = new Timestamp(123456789, TimestampType.CreateTime);
             var tpt = new TopicPartitionTimestamp("mytopic", 42, timestamp);
-            Assert.True(tpt.ToString().Contains(tpt.Topic));
-            Assert.True(tpt.ToString().Contains(tpt.Partition.ToString()));
-            Assert.True(tpt.ToString().Contains(tpt.Timestamp.ToString()));
+            Assert.Contains(tpt.Topic, tpt.ToString());
+            Assert.Contains(tpt.Partition.ToString(), tpt.ToString());
+            Assert.Contains(tpt.Timestamp.ToString(), tpt.ToString());
         }
 
         [Fact]
@@ -73,10 +73,10 @@ namespace Confluent.Kafka.Tests
         {
             var timestamp = new Timestamp(123456789, TimestampType.CreateTime);
             var tpt = new TopicPartitionTimestamp("mytopic", 42, timestamp);
-            Assert.Equal(tpt.Topic, "mytopic");
-            Assert.Equal(tpt.Partition, 42);
-            Assert.Equal(tpt.TopicPartition, new TopicPartition("mytopic", 42));
-            Assert.Equal(tpt.Timestamp, timestamp);
+            Assert.Equal("mytopic", tpt.Topic);
+            Assert.Equal(42, tpt.Partition);
+            Assert.Equal(new TopicPartition("mytopic", 42), tpt.TopicPartition);
+            Assert.Equal(timestamp, tpt.Timestamp);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.UnitTests/WatermarkOffsets.cs
@@ -22,11 +22,11 @@ namespace Confluent.Kafka.UnitTests
     public class WatermarkOffsetTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constructor()
         {
             var wo = new WatermarkOffsets(42, 43);
-            Assert.Equal(wo.Low, new Offset(42));
-            Assert.Equal(wo.High, new Offset(43));
+            Assert.Equal(new Offset(42), wo.Low);
+            Assert.Equal(new Offset(43), wo.High);
         }
 
         [Fact]
@@ -34,8 +34,8 @@ namespace Confluent.Kafka.UnitTests
         {
             var wo = new WatermarkOffsets(42, 43);
             var str = wo.ToString();
-            Assert.True(str.Contains("42"));
-            Assert.True(str.Contains("43"));
+            Assert.Contains("42", str);
+            Assert.Contains("43", str);
             Assert.True(str.IndexOf("43") > str.IndexOf("42"));
         }
     }


### PR DESCRIPTION
- Put expected values on correct place (first argument), so that assert messages will be correct
- Use `Assert.Contains` instead of `Assert.True` + `Contains`