### PR TITLE
Mirror subject name strategies from java client

### DIFF
--- a/src/Confluent.Kafka.Avro/GenericSerializerImpl.cs
+++ b/src/Confluent.Kafka.Avro/GenericSerializerImpl.cs
@@ -106,8 +106,8 @@ namespace Confluent.Kafka.Serialization
                 // better to use hash functions based on the writerSchemaString 
                 // object reference, not value.
                 string subject = this.isKey
-                    ? schemaRegistryClient.ConstructKeySubjectName(topic)
-                    : schemaRegistryClient.ConstructValueSubjectName(topic);
+                    ? schemaRegistryClient.ConstructKeySubjectName(topic, writerSchema.Fullname)
+                    : schemaRegistryClient.ConstructValueSubjectName(topic, writerSchema.Fullname);
                 var subjectSchemaPair = new KeyValuePair<string, string>(subject, writerSchemaString);
                 if (!registeredSchemas.Contains(subjectSchemaPair))
                 {

--- a/src/Confluent.Kafka.Avro/SpecificSerializerImpl.cs
+++ b/src/Confluent.Kafka.Avro/SpecificSerializerImpl.cs
@@ -22,6 +22,7 @@ using Confluent.SchemaRegistry;
 using System.Net;
 using System.IO;
 using System.Reflection;
+using Avro;
 
 
 namespace Confluent.Kafka.Serialization
@@ -39,7 +40,7 @@ namespace Confluent.Kafka.Serialization
 
         private SpecificWriter<T> avroWriter;
        
-        private HashSet<string> topicsRegistered = new HashSet<string>();
+        private HashSet<string> subjectsRegistered = new HashSet<string>();
 
         private object serializeLockObj = new object();
 
@@ -110,11 +111,11 @@ namespace Confluent.Kafka.Serialization
         {
             lock (serializeLockObj)
             {
-                if (!topicsRegistered.Contains(topic))
+                if (!subjectsRegistered.Contains(topic))
                 {
                     string subject = isKey
-                        ? schemaRegistryClient.ConstructKeySubjectName(topic)
-                        : schemaRegistryClient.ConstructValueSubjectName(topic);
+                        ? schemaRegistryClient.ConstructKeySubjectName(topic, GetSchemaName())
+                        : schemaRegistryClient.ConstructValueSubjectName(topic, GetSchemaName());
 
                     // first usage: register/get schema to check compatibility
 
@@ -122,7 +123,7 @@ namespace Confluent.Kafka.Serialization
                         ? schemaRegistryClient.RegisterSchemaAsync(subject, writerSchemaString).ConfigureAwait(false).GetAwaiter().GetResult()
                         : schemaRegistryClient.GetSchemaIdAsync(subject, writerSchemaString).ConfigureAwait(false).GetAwaiter().GetResult();
 
-                    topicsRegistered.Add(topic);
+                    subjectsRegistered.Add(topic);
                 }
             }
 
@@ -137,6 +138,15 @@ namespace Confluent.Kafka.Serialization
                 // TODO: maybe change the ISerializer interface so that this copy isn't necessary.
                 return stream.ToArray();
             }
+        }
+
+        private string GetSchemaName()
+        {
+            if (writerSchema is NamedSchema namedSchema)
+            {
+                return namedSchema.Fullname;
+            }
+            return writerSchema.Name;
         }
     }
 }

--- a/src/Confluent.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/ISchemaRegistryClient.cs
@@ -51,9 +51,9 @@ namespace Confluent.SchemaRegistry
         Task<bool> IsCompatibleAsync(string subject, string schema);
 
         /// <include file='include_docs.xml' path='API/Member[@name="ISchemaRegistryClient_ConstructKeySubjectName"]/*' />
-        string ConstructKeySubjectName(string topic);
+        string ConstructKeySubjectName(string topic, string schemaName);
 
         /// <include file='include_docs.xml' path='API/Member[@name="ISchemaRegistryClient_ConstructValueSubjectName"]/*' />
-        string ConstructValueSubjectName(string topic);
+        string ConstructValueSubjectName(string topic, string schemaName);
     }
 }

--- a/src/Confluent.SchemaRegistry/SubjectNameStrategies.cs
+++ b/src/Confluent.SchemaRegistry/SubjectNameStrategies.cs
@@ -1,0 +1,117 @@
+﻿// Copyright 2016-2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Confluent.SchemaRegistry
+{
+
+    /// <summary>
+    /// Keeps a map of ISubjectNameStrategy implementations
+    /// </summary>
+    public static class SubjectNameStrategies
+    {
+        /// <summary>
+        /// The default subject name strategy.
+        /// </summary>
+        public static readonly ISubjectNameStrategy Default = new TopicSubjectNameStrategy();
+        
+        private static Dictionary<string, ISubjectNameStrategy> map = new Dictionary<string, ISubjectNameStrategy>
+        {
+            {"topic_name_strategy", Default},
+            {"record_name_strategy", new RecordSubjectNameStrategy()},
+            {"topic_record_name_strategy", new TopicRecordSubjectNameStrategy()}
+        };
+
+        /// <summary>
+        /// Returns the ISubjectNameStrategy for the given name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">If the ISubjectNameStrategy is not found</exception>
+        public static ISubjectNameStrategy GetSubjectNameStrategy(string name)
+        {
+            if (map.ContainsKey(name))
+            {
+                return map[name];
+            }
+            throw new ArgumentException($"SubjectNameStrategy for name {name} is not supported.");
+        }
+
+        /// <summary>
+        /// Allow other ISubjectNameStrategies to be used.
+        /// </summary>
+        /// <param name="name">The name used to look up the SubjectNameStrategy</param>
+        /// <param name="strategy">The SubjectNameStrategy</param>
+        public static void Register(string name, ISubjectNameStrategy strategy)
+        {
+            map.Add(name, strategy);
+        }
+    }
+
+    /// <summary>
+    /// Common interface for subject name strategies.
+    /// </summary>
+    public interface ISubjectNameStrategy
+    {
+        /// <summary>
+        /// Returns the schema registry value subject name.
+        /// </summary>
+        /// <param name="topic">The topic name.</param>
+        /// <param name="isKey">If the message is a key or not.</param>
+        /// <param name="schemaName">The fully qualified schema name.</param>
+        /// <returns></returns>
+        string ConstructSubjectName(string topic, bool isKey, string schemaName);
+    }
+
+    /// <summary>
+    /// topic_name_strategy - The default. The subject is 'topic'-key or 'topic'-value.
+    /// </summary>
+    public class TopicSubjectNameStrategy : ISubjectNameStrategy
+    {
+        /// <inheritdoc />
+        public string ConstructSubjectName(string topic, bool isKey, string schemaName)
+        {
+            string keyOrValue = isKey ? "key" : "value";
+            return $"{topic}-{keyOrValue}";
+        }
+    }
+    
+    /// <summary>
+    /// record_name_strategy - The subject is the fully qualified name of the schema.
+    /// </summary>
+    public class RecordSubjectNameStrategy : ISubjectNameStrategy
+    {
+        /// <inheritdoc />
+        public string ConstructSubjectName(string topic, bool isKey, string schemaName)
+        {
+            return schemaName;
+        }
+    }
+    
+    /// <summary>
+    /// topic_record_name_strategy - The subject is 'topic'-'the fully qualifed name of the schema'.
+    /// </summary>
+    public class TopicRecordSubjectNameStrategy : ISubjectNameStrategy
+    {
+        /// <inheritdoc />
+        public string ConstructSubjectName(string topic, bool isKey, string schemaName)
+        {
+            return $"{topic}-{schemaName}";
+        }
+    }
+}

--- a/src/Confluent.SchemaRegistry/include_docs.xml
+++ b/src/Confluent.SchemaRegistry/include_docs.xml
@@ -108,25 +108,31 @@
 
 <Member name="ISchemaRegistryClient_ConstructKeySubjectName">
     <summary>
-        Returns the schema registry key subject name given a topic name.
+        Returns the schema registry key subject name given a topic and schema name.
     </summary>
     <param name="topic">
         The topic name.
     </param>
+    <param name="schemaName">
+        The the fully qualified schema name.
+    </param>
     <returns>
-        The key subject name given a topic name.
+        The key subject name given a topic and schema name.
     </returns>
 </Member>
 
 <Member name="ISchemaRegistryClient_ConstructValueSubjectName">
     <summary>
-        Returns the schema registry value subject name given a topic name.
+        Returns the schema registry value subject name given a topic and schema name.
     </summary>
     <param name="topic">
         The topic name.
     </param>
+    <param name="schemaName">
+        The the fully qualified schema name.
+    </param>
     <returns>
-        The value subject name given a topic name.
+        The value subject name given a topic and schema name.
     </returns>
 </Member>
 

--- a/test/Confluent.Kafka.Avro.UnitTests/Configuration.cs
+++ b/test/Confluent.Kafka.Avro.UnitTests/Configuration.cs
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.Avro.UnitTests
         {
             testTopic = "topic";
             var schemaRegistryMock = new Mock<ISchemaRegistryClient>();
-            schemaRegistryMock.Setup(x => x.ConstructValueSubjectName(testTopic)).Returns($"{testTopic}-value");
+            schemaRegistryMock.Setup(x => x.ConstructValueSubjectName(testTopic, It.IsAny<string>())).Returns($"{testTopic}-value");
             schemaRegistryMock.Setup(x => x.RegisterSchemaAsync("topic-value", It.IsAny<string>())).ReturnsAsync(
                 (string topic, string schema) => store.TryGetValue(schema, out int id) ? id : store[schema] = store.Count + 1
             );

--- a/test/Confluent.Kafka.Avro.UnitTests/SerializeDeserialize.cs
+++ b/test/Confluent.Kafka.Avro.UnitTests/SerializeDeserialize.cs
@@ -35,7 +35,7 @@ namespace Confluent.Kafka.Avro.UnitTests
         {
             testTopic = "topic";
             var schemaRegistryMock = new Mock<ISchemaRegistryClient>();
-            schemaRegistryMock.Setup(x => x.ConstructValueSubjectName(testTopic)).Returns($"{testTopic}-value");
+            schemaRegistryMock.Setup(x => x.ConstructValueSubjectName(testTopic, It.IsAny<string>())).Returns($"{testTopic}-value");
             schemaRegistryMock.Setup(x => x.RegisterSchemaAsync("topic-value", It.IsAny<string>())).ReturnsAsync(
                 (string topic, string schema) => store.TryGetValue(schema, out int id) ? id : store[schema] = store.Count + 1
             );

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/FillTheCache.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/FillTheCache.cs
@@ -51,7 +51,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             for (int i = 0; i < registerCount; ++i)
             {
                 var topicName = Guid.NewGuid().ToString();
-                var subject = sr.ConstructValueSubjectName(topicName);
+                var subject = sr.ConstructValueSubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
                 subjects.Add(subject);
 
                 var id = sr.RegisterSchemaAsync(subject, testSchema).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetAllSubjects.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetAllSubjects.cs
@@ -26,18 +26,54 @@ namespace Confluent.SchemaRegistry.IntegrationTests
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
         public static void GetAllSubjects(string server)
         {
+            GetAllSubjects(new Dictionary<string, object>{ { "schema.registry.url", server } });
+        }
+        
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void GetAllSubjectsTopicNameStrategy(string server)
+        {
+            GetAllSubjects(new Dictionary<string, object>
+            {
+                { "schema.registry.url", server },
+                { "schema.registry.subject.name.strategy", "topic_name_strategy" }
+            });
+        }
+        
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void GetAllSubjectsRecordNameStrategy(string server)
+        {
+            GetAllSubjects(new Dictionary<string, object>
+            {
+                { "schema.registry.url", server },
+                { "schema.registry.subject.name.strategy", "record_name_strategy" }
+            });
+        }
+        
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void GetAllSubjectsTopicRecordNameStrategy(string server)
+        {
+            GetAllSubjects(new Dictionary<string, object>
+            {
+                { "schema.registry.url", server },
+                { "schema.registry.subject.name.strategy", "topic_record_name_strategy" }
+            });
+        }
+        
+        private static void GetAllSubjects(Dictionary<string, object> config)
+        {
             var topicName = Guid.NewGuid().ToString();
+            var schemaName = Guid.NewGuid().ToString();
 
             var testSchema1 = 
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
+            var sr = new CachedSchemaRegistryClient(config);
 
             var subjectsBefore = sr.GetAllSubjectsAsync().Result;
 
-            var subject = sr.ConstructKeySubjectName(topicName);
+            var subject = sr.ConstructKeySubjectName(topicName, schemaName);
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
 
             var subjectsAfter = sr.GetAllSubjectsAsync().Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetId.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetId.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new Dictionary<string, object> { { "schema.registry.url", server } });
 
-            var subject = sr.ConstructKeySubjectName(topicName);
+            var subject = sr.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
             var id2 = sr.GetSchemaIdAsync(subject, testSchema1).Result;
 

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetLatestSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetLatestSchema.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
 
-            var subject = sr.ConstructValueSubjectName(topicName);
+            var subject = sr.ConstructValueSubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
 
             var schema = sr.GetLatestSchemaAsync(subject).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaById.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaById.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
 
-            var subject = sr.ConstructValueSubjectName(topicName);
+            var subject = sr.ConstructValueSubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
 
             var schema = sr.GetSchemaAsync(id).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaBySubjectAndVersion.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaBySubjectAndVersion.cs
@@ -26,21 +26,53 @@ namespace Confluent.SchemaRegistry.IntegrationTests
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
         public static void GetSchemaBySubjectAndVersion(string server)
         {
+            GetSchemaBySubjectAndVersion(new Dictionary<string, object>{ { "schema.registry.url", server } });
+        }
+        
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void GetSchemaBySubjectAndVersionTopicNameStrategy(string server)
+        {GetSchemaBySubjectAndVersion(new Dictionary<string, object>
+            {
+                { "schema.registry.url", server },
+                { "schema.registry.subject.name.strategy", "topic_name_strategy" }
+            });
+        }
+        
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void GetSchemaBySubjectAndVersionRecordNameStrategy(string server)
+        {GetSchemaBySubjectAndVersion(new Dictionary<string, object>
+            {
+                { "schema.registry.url", server },
+                { "schema.registry.subject.name.strategy", "record_name_strategy" }
+            });
+        }
+        
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void GetSchemaBySubjectAndVersionTopicRecordNameStrategy(string server)
+        {GetSchemaBySubjectAndVersion(new Dictionary<string, object>
+            {
+                { "schema.registry.url", server },
+                { "schema.registry.subject.name.strategy", "topic_record_name_strategy" }
+            });
+        }
+        
+        private static void GetSchemaBySubjectAndVersion(Dictionary<string, object> config)
+        {
             var topicName = Guid.NewGuid().ToString();
-
+    
             var testSchema1 = 
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
-
-            var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
-
-            var subject = sr.ConstructValueSubjectName(topicName);
+    
+            var sr = new CachedSchemaRegistryClient(config);
+    
+            var subject = sr.ConstructValueSubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-
+    
             var schema = sr.GetLatestSchemaAsync(subject).Result;
             var schemaString = sr.GetSchemaAsync(subject, schema.Version).Result;
-
+    
             Assert.Equal(schemaString, testSchema1);
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
 
-            var subject = sr.ConstructKeySubjectName(topicName);
+            var subject = sr.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
 
             var testSchema2 = // incompatible with testSchema1

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterIncompatibleSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterIncompatibleSchema.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
 
-            var subject = sr.ConstructKeySubjectName(topicName);
+            var subject = sr.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
 
             var testSchema2 = // incompatible with testSchema1

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterSameSchemaTwice.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterSameSchemaTwice.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new Dictionary<string, object>{ { "schema.registry.url", server } });
 
-            var subject = sr.ConstructKeySubjectName(topicName);
+            var subject = sr.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             Assert.Equal(topicName + "-key", subject);
 
             var id1 = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.UnitTests/CachedSchemaRegistryClient.cs
+++ b/test/Confluent.SchemaRegistry.UnitTests/CachedSchemaRegistryClient.cs
@@ -35,6 +35,17 @@ namespace Confluent.SchemaRegistry.UnitTests
             var config = new Dictionary<string, object>();
             Assert.Throws<ArgumentException>(() => new CachedSchemaRegistryClient(config));
         }
+        
+        [Fact]
+        public void InvalidSubjectNameStrategy()
+        {
+            var config = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "bad_value" }
+            };
+            Assert.Throws<ArgumentException>(() => new CachedSchemaRegistryClient(config));
+        }
 
         [Fact]
         public void ConstructKeySubjectName()
@@ -45,7 +56,34 @@ namespace Confluent.SchemaRegistry.UnitTests
             };
 
             CachedSchemaRegistryClient src = new CachedSchemaRegistryClient(config);
-            Assert.Equal("mytopic-key", src.ConstructKeySubjectName("mytopic"));
+            Assert.Equal("mytopic-key", src.ConstructKeySubjectName("mytopic", "myschemaname"));
+            
+            var configTopicName = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "topic_name_strategy" }
+            };
+
+            CachedSchemaRegistryClient srcTopicName = new CachedSchemaRegistryClient(configTopicName);
+            Assert.Equal("mytopic-key", srcTopicName.ConstructKeySubjectName("mytopic", "myschemaname"));
+            
+            var configRecordName = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "record_name_strategy" }
+            };
+
+            CachedSchemaRegistryClient srcRecordName = new CachedSchemaRegistryClient(configRecordName);
+            Assert.Equal("myschemaname", srcRecordName.ConstructKeySubjectName("mytopic", "myschemaname"));
+            
+            var configTopicRecordName = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "topic_record_name_strategy" }
+            };
+
+            CachedSchemaRegistryClient srcTopicRecordName = new CachedSchemaRegistryClient(configTopicRecordName);
+            Assert.Equal("mytopic-myschemaname", srcTopicRecordName.ConstructKeySubjectName("mytopic", "myschemaname"));
         }
 
         [Fact]
@@ -57,7 +95,34 @@ namespace Confluent.SchemaRegistry.UnitTests
             };
 
             CachedSchemaRegistryClient src = new CachedSchemaRegistryClient(config);
-            Assert.Equal("mytopic-value", src.ConstructValueSubjectName("mytopic"));
+            Assert.Equal("mytopic-value", src.ConstructValueSubjectName("mytopic", "myschemaname"));
+            
+            var configTopicName = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "topic_name_strategy" }
+            };
+
+            CachedSchemaRegistryClient srcTopicName = new CachedSchemaRegistryClient(configTopicName);
+            Assert.Equal("mytopic-value", srcTopicName.ConstructValueSubjectName("mytopic", "myschemaname"));
+            
+            var configRecordName = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "record_name_strategy" }
+            };
+
+            CachedSchemaRegistryClient srcRecordName = new CachedSchemaRegistryClient(configRecordName);
+            Assert.Equal("myschemaname", srcRecordName.ConstructValueSubjectName("mytopic", "myschemaname"));
+            
+            var configTopicRecordName = new Dictionary<string, object>
+            {
+                { "schema.registry.url", "irrelevanthost:8081" },
+                { "schema.registry.subject.name.strategy", "topic_record_name_strategy" }
+            };
+
+            CachedSchemaRegistryClient srcTopicRecordName = new CachedSchemaRegistryClient(configTopicRecordName);
+            Assert.Equal("mytopic-myschemaname", srcTopicRecordName.ConstructValueSubjectName("mytopic", "myschemaname"));
         }
     }
 }


### PR DESCRIPTION
The Java client supports configuring different strategies for the schema registry subject name.  This PR adds the same functionality to the dotnet client.