### PR TITLE
librdkafka directory path fix

### DIFF
--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -348,6 +348,13 @@ namespace Confluent.Kafka.Impl
                             is64 ? "x64" : "x86");
                         path = Path.Combine(dllDirectory, "librdkafka.dll");
                     }
+
+                    //As librdkafka DLLs getting dumped into bin/debug folder
+                    //in some cases, an attempt to get them from baseDirectory
+                    if (!File.Exists(path))
+                    {
+                        path = Path.Combine(baseDirectory, "librdkafka.dll");
+                    }
                 }
 
                 if (WindowsNative.LoadLibraryEx(path, IntPtr.Zero, WindowsNative.LoadLibraryFlags.LOAD_WITH_ALTERED_SEARCH_PATH) == IntPtr.Zero)


### PR DESCRIPTION
As librdkafka DLLs are getting dumped into bin/debug folder, in some cases, an attempt to get them from baseDirectory.