### PR TITLE
[WIP] Add support for per-partition batch consume

### DIFF
--- a/src/Confluent.Kafka/ConsumerQueue.cs
+++ b/src/Confluent.Kafka/ConsumerQueue.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Confluent.Kafka.Serialization;
+
+namespace Confluent.Kafka
+{
+    public class ConsumerQueue<TKey, TValue> : Consumer<TKey, TValue>
+    {
+        private volatile Dictionary<TopicPartition, IntPtr> queues;
+
+        public ConsumerQueue(
+            IEnumerable<KeyValuePair<string, object>> config,
+            IDeserializer<TKey> keyDeserializer,
+            IDeserializer<TValue> valueDeserializer)
+            : base(config, keyDeserializer, valueDeserializer)
+        {
+        }
+
+        public override void Assign(IEnumerable<TopicPartitionOffset> partitions)
+        {
+            base.Assign(partitions);
+
+            var queue = partitions.ToDictionary(
+                p => p.TopicPartition,
+                p => kafkaHandle.ForwardPartitionToQueue(p.TopicPartition));
+
+            queues = queue;
+        }
+
+        public override void Unassign()
+        {
+            // Unforward queues per https://github.com/edenhill/librdkafka/issues/1335
+
+            foreach (var rkqu in queues.Values)
+            {
+                kafkaHandle.RestoreQueue(rkqu);
+                kafkaHandle.DestroyQueue(rkqu);
+            }
+
+            queues = null;
+
+            base.Unassign();
+        }
+
+        public IReadOnlyCollection<ConsumeResult<TKey, TValue>> ConsumeBatch(TopicPartition partition, int batchSize, int millisecondsTimeout)
+        {
+            var rkqu = queues[partition];
+            var messages = new IntPtr[batchSize];
+            var numMessages = kafkaHandle.QueuePoll(rkqu, messages, millisecondsTimeout);
+            var results = new ConsumeResult<TKey, TValue>[numMessages];
+            for (int i = 0; i < numMessages; i++)
+            {
+                results[i] = GetMessage(messages[i]);
+            }
+            return results;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -222,7 +222,12 @@ namespace Confluent.Kafka.Impl
             _event_topic_partition_list = (Func<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_event_topic_partition_list").CreateDelegate(typeof(Func<IntPtr, IntPtr>));
             _event_destroy = (Action<IntPtr>)methods.Single(m => m.Name == "rd_kafka_event_destroy").CreateDelegate(typeof(Action<IntPtr>));
             _queue_poll = (Func<IntPtr, IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_queue_poll").CreateDelegate(typeof(Func<IntPtr, IntPtr, IntPtr>));
-            
+            _queue_get_partition = (Func<IntPtr, string, int, IntPtr>)methods.Single(m => m.Name == "rd_kafka_queue_get_partition").CreateDelegate(typeof(Func<IntPtr, string, int, IntPtr>));
+            _queue_forward = (Action<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_queue_forward").CreateDelegate(typeof(Action<IntPtr, IntPtr>));
+            _consume_queue = (Func<IntPtr, int, IntPtr>)methods.Single(m => m.Name == "rd_kafka_consume_queue").CreateDelegate(typeof(Func<IntPtr, int, IntPtr>));
+            _consume_batch_queue = (Func<IntPtr, int, IntPtr[], IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_consume_batch_queue").CreateDelegate(typeof(Func<IntPtr, int, IntPtr[], IntPtr, IntPtr>));
+            _queue_get_consumer = (Func<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_queue_get_consumer").CreateDelegate(typeof(Func<IntPtr, IntPtr>));
+
             _AdminOptions_new = (Func<IntPtr, AdminOp, IntPtr>)methods.Single(m => m.Name == "rd_kafka_AdminOptions_new").CreateDelegate(typeof(Func<IntPtr, AdminOp, IntPtr>));
             _AdminOptions_destroy = (Action<IntPtr>)methods.Single(m => m.Name == "rd_kafka_AdminOptions_destroy").CreateDelegate(typeof(Action<IntPtr>));
             _AdminOptions_set_request_timeout = (Func<IntPtr, IntPtr, StringBuilder, UIntPtr, ErrorCode>)methods.Single(m => m.Name == "rd_kafka_AdminOptions_set_request_timeout").CreateDelegate(typeof(Func<IntPtr, IntPtr, StringBuilder, UIntPtr, ErrorCode>));
@@ -1177,6 +1182,25 @@ namespace Confluent.Kafka.Impl
         internal static IntPtr queue_poll(IntPtr rkqu, int timeout_ms)
             => _queue_poll(rkqu, (IntPtr)timeout_ms);
 
+        private static Func<IntPtr, string, int, IntPtr> _queue_get_partition;
+        internal static IntPtr queue_get_partition(IntPtr rk, string topic, int partition)
+            => _queue_get_partition(rk, topic, partition);
+
+        private static Action<IntPtr, IntPtr> _queue_forward;
+        internal static void queue_forward(IntPtr src, IntPtr dst)
+            => _queue_forward(src, dst);
+
+        private static Func<IntPtr, int, IntPtr> _consume_queue;
+        internal static IntPtr consume_queue(IntPtr rkqu, int timeout_ms)
+            => _consume_queue(rkqu, timeout_ms);
+
+        private static Func<IntPtr, int, IntPtr[], IntPtr, IntPtr> _consume_batch_queue;
+        internal static IntPtr consume_batch_queue(IntPtr rkqu, int timeout_ms, IntPtr[] rkmessages, IntPtr rkmessages_size)
+            => _consume_batch_queue(rkqu, timeout_ms, rkmessages, rkmessages_size);
+
+        private static Func<IntPtr, IntPtr> _queue_get_consumer;
+        internal static IntPtr queue_get_consumer(IntPtr rk)
+            => _queue_get_consumer(rk);
 
         //
         // Events

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
@@ -668,7 +668,23 @@ namespace Confluent.Kafka.Impl.NativeMethods
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr rd_kafka_queue_poll(IntPtr rkqu, IntPtr timeout_ms);
 
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_queue_get_partition(IntPtr rk,
+            [MarshalAs(UnmanagedType.LPStr)] string topic,
+            int partition);
 
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_queue_forward(IntPtr src, IntPtr dst);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_consume_queue(IntPtr rkqu, int timeout_ms);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_consume_batch_queue(IntPtr rkqu,
+            int timeout_ms, IntPtr[] rkmessages, IntPtr rkmessages_size);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_queue_get_consumer(IntPtr rk);
 
         //
         // Events


### PR DESCRIPTION
I did the bare minimum to show an example, but basically this solves 2 issues,

- The batching removes the need to build queues on top of Confluent.Kafka
- The per-partition consume lets consumers read partitions independently, so a slow partition won't slow down others

I'm not sure if this is compatible with autocommit. I'm terrible at API design, and I'm not sure how this should be implemented. This PR isn't to be merged, it's just a discussion if per-partition consuming is worth adding. If it is, I'm happy to update this PR with a new design.