### PR TITLE
example code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,8 @@ optimizing communication with the Kafka brokers for you, batching requests as ap
 
 ```csharp
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
 
 class Program
 {
@@ -118,10 +115,7 @@ make use the `BeginProduce` method instead:
 
 ```csharp
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
 
 class Program
 {
@@ -152,11 +146,7 @@ class Program
 
 ```csharp
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using Confluent.Kafka;
-using Confluent.Kafka.Serialization;
 
 class Program
 {
@@ -183,9 +173,11 @@ class Program
                 catch (ConsumeException e)
                 {
                     Console.WriteLine($"Error occured: {e.Error.Reason}");
+                    break;
                 }
             }
             
+            // Ensure the consumer leaves the group cleanly and final offsets are committed.
             c.Close();
         }
     }

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ class Program
         { 
             GroupId = "test-consumer-group",
             BootstrapServers = "localhost:9092",
+            // Note: The AutoOffsetReset property determines the start offset in the event
+            // there are not yet any committed offsets for the consumer group for the
+            // topic/partitions of interest. By default, offsets are committed
+            // automatically, so in this example, consumption will only start from the
+            // eariest message in the topic 'my-topic' the first time you run the program.
             AutoOffsetReset = AutoOffsetResetType.Earliest
         };
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,12 @@ class Program
         {
             c.Subscribe("my-topic");
 
-            while (true)
+            bool consuming = true;
+            // The client will automatically recover from non-fatal errors. You typically
+            // don't need to take any action unless an error is marked as fatal.
+            c.OnError += (_, e) => consuming = !e.IsFatal;
+
+            while (consuming)
             {
                 try
                 {
@@ -178,7 +183,6 @@ class Program
                 catch (ConsumeException e)
                 {
                     Console.WriteLine($"Error occured: {e.Error.Reason}");
-                    break;
                 }
             }
             


### PR DESCRIPTION
quick cleanup. most importantly, the namespace `Confluent.Kafka.Serialization` actually no longer exists, so the examples on the README.md won't compile as is.