### PR TITLE
Default serdes

### DIFF
--- a/src/Confluent.Kafka/Deserializers.cs
+++ b/src/Confluent.Kafka/Deserializers.cs
@@ -10,6 +10,56 @@ namespace Confluent.Kafka
     public static class Deserializers
     {
         /// <summary>
+        ///     Gets the default Deserializer for an intrinsic type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="forKey"></param>
+        public static Deserializer<T> GetDefault<T>(bool forKey)
+        {
+            if (typeof(T) == typeof(Null))
+            {
+                return Generators.Null(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(Ignore))
+            {
+                return Generators.Ignore(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(byte[]))
+            {
+                return Generators.ByteArray(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(string))
+            {
+                return Generators.UTF8(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(long))
+            {
+                return Generators.Long(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(int))
+            {
+                return Generators.Int32(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(float))
+            {
+                return Generators.Float(forKey) as Deserializer<T>;
+            }
+
+            if (typeof(T) == typeof(double))
+            {
+                return Generators.Double(forKey) as Deserializer<T>;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         ///     Deserializes a UTF8 encoded string.
         /// </summary>
         public static Deserializer<string> UTF8 = (topic, data, isNull) =>

--- a/src/Confluent.Kafka/Serializers.cs
+++ b/src/Confluent.Kafka/Serializers.cs
@@ -10,6 +10,56 @@ namespace Confluent.Kafka
     public static class Serializers
     {
         /// <summary>
+        ///     Gets the default Deserializer for an intrinsic type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="forKey"></param>
+        public static Serializer<T> GetDefault<T>(bool forKey)
+        {
+            if (typeof(T) == typeof(Null))
+            {
+                return Generators.Null(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(byte[]))
+            {
+                return Generators.ByteArray(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(string))
+            {
+                return Generators.UTF8(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(long))
+            {
+                return Generators.Long(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(int))
+            {
+                return Generators.Int32(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(float))
+            {
+                return Generators.Float(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(double))
+            {
+                return Generators.Double(forKey) as Serializer<T>;
+            }
+
+            if (typeof(T) == typeof(Ignore))
+            {
+                throw new ArgumentException("Serializer not valid for Ignore.");
+            }
+
+            return null;
+        }
+
+        /// <summary>
         ///     Encodes a string value in a byte array.
         /// </summary>
         public static Serializer<string> UTF8 = (topic, data) =>
@@ -166,6 +216,11 @@ namespace Confluent.Kafka
             ///     Generates a UTF8 serializer (invariant on the value of forKey).
             /// </summary>
             public static SerializerGenerator<string> UTF8 = (forKey) => Serializers.UTF8;
+
+            /// <summary>
+            ///     Generates a ByteArray serializer (invariant on the value of forKey)
+            /// </summary>
+            public static SerializerGenerator<byte[]> ByteArray = (forKey) => Serializers.ByteArray;
 
             /// <summary>
             ///     Generates a Null serializer (invariant on the value of forKey).

--- a/src/Confluent.Kafka/Serializers.cs
+++ b/src/Confluent.Kafka/Serializers.cs
@@ -10,7 +10,7 @@ namespace Confluent.Kafka
     public static class Serializers
     {
         /// <summary>
-        ///     Gets the default Deserializer for an intrinsic type
+        ///     Gets the default Serializer for an intrinsic type
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="forKey"></param>

--- a/test/Confluent.Kafka.UnitTests/Consumer.cs
+++ b/test/Confluent.Kafka.UnitTests/Consumer.cs
@@ -14,10 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
-using Xunit;
 using System;
-using System.Text;
-using System.Collections.Generic;
+using Xunit;
 
 
 namespace Confluent.Kafka.UnitTests
@@ -25,7 +23,7 @@ namespace Confluent.Kafka.UnitTests
     public class ConsumerTests
     {
         [Fact]
-        public void Constuctor()
+        public void Constuctor_Ensure_GroupId_Set()
         {
             // Throw exception if 'group.id' is not set in config and ensure that exception
             // mentions 'group.id'.
@@ -34,25 +32,50 @@ namespace Confluent.Kafka.UnitTests
             Assert.Contains("group.id", e.Message);
             e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<Null, string>(config); });
             Assert.Contains("group.id", e.Message);
+        }
 
+        [Fact]
+        public void Constuctor_Validate_Null_Config_Throws()
+        {
             // Throw exception if a config value is null and ensure that exception mentions the
             // respective config key.
             var configWithNullValue = CreateValidConfiguration();
             configWithNullValue.Set("sasl.password", null);
-            e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<byte[], byte[]>(configWithNullValue); });
+            var e = Assert.Throws<ArgumentException>(() => { var c = new Consumer<byte[], byte[]>(configWithNullValue); });
             Assert.Contains("sasl.password", e.Message);
+        }
 
+        [Fact]
+        public void Constuctor_Ensure_Different_Serializers()
+        {
             // Throw exception when serializer and deserializer are equal and ensure that exception
             // message indicates the issue.
-            e = Assert.Throws<ArgumentException>(() => 
+            var e = Assert.Throws<ArgumentException>(() =>
             {
                 var validConfig = CreateValidConfiguration();
                 var deserializer = Deserializers.UTF8;
-                var c = new Consumer<string, string>(validConfig, deserializer, deserializer); 
+                var c = new Consumer<string, string>(validConfig, deserializer, deserializer);
             });
             Assert.Contains("must not be the same object", e.Message);
 
             // positve case covered by integration tests. here, avoiding creating a rd_kafka_t instance.
+        }
+
+        [Fact]
+        public void Constuctor_Ensure_Default_Serializers()
+        {
+            var validConfig = CreateValidConfiguration();
+
+            // try creating some typical combinations
+            new Consumer<string, string>(validConfig);
+            new Consumer<byte[], byte[]>(validConfig);
+            new Consumer<byte[], string>(validConfig);
+            new Consumer<Null, string>(validConfig);
+            new Consumer<Ignore, string>(validConfig);
+            new Consumer<int, string>(validConfig);
+            new Consumer<long, string>(validConfig);
+            new Consumer<float, string>(validConfig);
+            new Consumer<double, string>(validConfig);
         }
 
         private static ConsumerConfig CreateValidConfiguration()


### PR DESCRIPTION
Wanted to "tidy" the Producer/Consumer ctors regarding serdes.

There are serdes defined for several of the dotnet intrinsic types, but they were not hooked up to the defaults created from the generic types of the P/C.

 * Added a `GetDefault<T>` factory methods in `Serializers` and `Deserializers`.
 * Hooked these up to the P/C ctors.
 * extended the tests a little.