### PR TITLE
Add Close() to IConsumer interface

### DIFF
--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -195,5 +195,10 @@ namespace Confluent.Kafka
         ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.OffsetsForTimes(IEnumerable{TopicPartitionTimestamp}, TimeSpan, CancellationToken)" />
         /// </summary>
         List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestampsToSearch, TimeSpan timeout, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.Close()" />
+        /// </summary>
+        void Close();
     }
 }


### PR DESCRIPTION
When I tried to use IConsumer, from the version 1.0.0-beta2 package, through DI in a project, I realized that the Close() method, meant to actually finalize a consumer, was not available in the interface, just in the concrete class.