### PR TITLE
Make parsing of enum values in config case insensitive

### DIFF
--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -290,7 +290,7 @@ namespace Confluent.Kafka
         {
             var result = Get(key);
             if (result == null) { return null; }
-            return Enum.Parse(type, result);
+            return Enum.Parse(type, result, true);
         }
 
         /// <summary>


### PR DESCRIPTION
There is a bug where you cannot read an enum config value after setting it:
```c#
var config = new ConsumerConfig
{
    AutoOffsetReset = AutoOffsetResetType.Earliest
};

Assert.AreEqual(config.AutoOffsetReset, AutoOffsetResetType.Earliest);
```
Because the value is converted to lower case it cannot be parsed afterwards.