### PR TITLE
use the builder pattern to construct clients

### DIFF
--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.Examples
 
         static void ListGroups(string brokerList)
         {
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = brokerList }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = brokerList }).Build())
             {
                 var groups = adminClient.ListGroups(TimeSpan.FromSeconds(10));
                 Console.WriteLine($"Consumer Groups:");
@@ -52,7 +52,7 @@ namespace Confluent.Kafka.Examples
 
         static void PrintMetadata(string brokerList)
         {
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = brokerList }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = brokerList }).Build())
             {
                 var meta = adminClient.GetMetadata(TimeSpan.FromSeconds(20));
                 Console.WriteLine($"{meta.OriginatingBrokerId} {meta.OriginatingBrokerName}");

--- a/examples/ConfluentCloud/Program.cs
+++ b/examples/ConfluentCloud/Program.cs
@@ -59,7 +59,7 @@ namespace ConfluentCloudExample
                 SaslPassword = "<ccloud secret>"
             };
 
-            using (var producer = new Producer<Null, string>(pConfig))
+            using (var producer = new ProducerBuilder<Null, string>(pConfig).Build())
             {
                 producer.ProduceAsync("dotnet-test-topic", new Message<Null, string> { Value = "test value" })
                     .ContinueWith(task => task.IsFaulted
@@ -86,7 +86,7 @@ namespace ConfluentCloudExample
                 AutoOffsetReset = AutoOffsetReset.Earliest
             };
 
-            using (var consumer = new Consumer<Null, string>(cConfig))
+            using (var consumer = new ConsumerBuilder<Null, string>(cConfig).Build())
             {
                 consumer.Subscribe("dotnet-test-topic");
 

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Confluent Inc., 2015-2016 Andreas Heider
+// Copyright 2016-2018 Confluent Inc., 2015-2016 Andreas Heider
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -51,33 +52,34 @@ namespace Confluent.Kafka.Examples.ConsumerExample
 
             const int commitPeriod = 5;
 
-            using (var consumer = new Consumer<Ignore, string>(config))
+            using (var consumer =
+                new ConsumerBuilder<Ignore, string>(config)
+                    // Note: If a key or value deserializer is not specified, the deserializer
+                    //  corresponding to the appropriate type from Confluent.Kafka.Serdes will
+                    //  be used automatically (where available). The default deserializer for
+                    //  string is UTF8. The default deserializer for Ignore returns null for
+                    //  all input data (including non-null data).
+                    // Note: All handlers are called on the main .Consume thread.
+                    .SetErrorHandler((_, e) => Console.WriteLine($"Error: {e.Reason}"))
+                    .SetStatisticsHandler((_, json) => Console.WriteLine($"Statistics: {json}"))
+                    // The partition assignment handler is called when the consumer has been
+                    // notified of a new assignment set. You can use this callback to perform
+                    // actions such as retrieving offsets from an external source and manually
+                    // setting start offsets using the Assign method. You can even call Assign
+                    // with a different set of partitions than those in the assignment. If
+                    // you do not call Assign, the consumer will be automatically assigned to
+                    // the partitions of the assignment set and consumption will start from
+                    // last committed offsets or in accordance with the auto.offset.reset
+                    // configuration parameter for partitions where there is no committed offset.
+                    .SetPartitionAssignmentHandler((c, tps) => {
+                        Console.WriteLine($"Assigned partitions: [{string.Join(", ", tps)}], member id: {c.MemberId}");
+                    })
+                    // Called when the consumer's current assignment set has been revoked.
+                    .SetPartitionAssignmentRevokedHandler((_, tps) => {
+                        Console.WriteLine($"Revoked partitions: [{string.Join(", ", tps)}]");
+                    })
+                    .Build())
             {
-                // Note: All event handlers are called on the main .Consume thread.
-
-                // Raised when the consumer has been notified of a new assignment set.
-                // You can use this event to perform actions such as retrieving offsets
-                // from an external source / manually setting start offsets using
-                // the Assign method. You can even call Assign with a different set of
-                // partitions than those in the assignment. If you do not call Assign
-                // in a handler of this event, the consumer will be automatically
-                // assigned to the partitions of the assignment set and consumption
-                // will start from last committed offsets or in accordance with
-                // the auto.offset.reset configuration parameter for partitions where
-                // there is no committed offset.
-                consumer.OnPartitionsAssigned += (_, partitions)
-                    => Console.WriteLine($"Assigned partitions: [{string.Join(", ", partitions)}], member id: {consumer.MemberId}");
-
-                // Raised when the consumer's current assignment set has been revoked.
-                consumer.OnPartitionsRevoked += (_, partitions)
-                    => Console.WriteLine($"Revoked partitions: [{string.Join(", ", partitions)}]");
-
-                consumer.OnError += (_, e)
-                    => Console.WriteLine($"Error: {e.Reason}");
-
-                consumer.OnStatistics += (_, json)
-                    => Console.WriteLine($"Statistics: {json}");
-
                 consumer.Subscribe(topics);
 
                 while (!cancellationToken.IsCancellationRequested)
@@ -138,12 +140,12 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 EnableAutoCommit = true
             };
 
-            using (var consumer = new Consumer<Ignore, string>(config))
+            using (var consumer =
+                new ConsumerBuilder<Ignore, string>(config)
+                    .SetErrorHandler((_, e) => Console.WriteLine($"Error: {e.Reason}"))
+                    .Build())
             {
                 consumer.Assign(topics.Select(topic => new TopicPartitionOffset(topic, 0, Offset.Beginning)).ToList());
-
-                consumer.OnError += (_, e)
-                    => Console.WriteLine($"Error: {e.Reason}");
 
                 while (!cancellationToken.IsCancellationRequested)
                 {

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -52,33 +52,32 @@ namespace Confluent.Kafka.Examples.ConsumerExample
 
             const int commitPeriod = 5;
 
-            using (var consumer =
-                new ConsumerBuilder<Ignore, string>(config)
-                    // Note: If a key or value deserializer is not specified, the deserializer
-                    //  corresponding to the appropriate type from Confluent.Kafka.Serdes will
-                    //  be used automatically (where available). The default deserializer for
-                    //  string is UTF8. The default deserializer for Ignore returns null for
-                    //  all input data (including non-null data).
-                    // Note: All handlers are called on the main .Consume thread.
-                    .SetErrorHandler((_, e) => Console.WriteLine($"Error: {e.Reason}"))
-                    .SetStatisticsHandler((_, json) => Console.WriteLine($"Statistics: {json}"))
-                    // The partition assignment handler is called when the consumer has been
-                    // notified of a new assignment set. You can use this callback to perform
-                    // actions such as retrieving offsets from an external source and manually
-                    // setting start offsets using the Assign method. You can even call Assign
-                    // with a different set of partitions than those in the assignment. If
-                    // you do not call Assign, the consumer will be automatically assigned to
-                    // the partitions of the assignment set and consumption will start from
-                    // last committed offsets or in accordance with the auto.offset.reset
-                    // configuration parameter for partitions where there is no committed offset.
-                    .SetPartitionAssignmentHandler((c, tps) => {
-                        Console.WriteLine($"Assigned partitions: [{string.Join(", ", tps)}], member id: {c.MemberId}");
-                    })
-                    // Called when the consumer's current assignment set has been revoked.
-                    .SetPartitionAssignmentRevokedHandler((_, tps) => {
-                        Console.WriteLine($"Revoked partitions: [{string.Join(", ", tps)}]");
-                    })
-                    .Build())
+            // Note: If a key or value deserializer is not set (as is the case below), the 
+            // deserializer corresponding to the appropriate type from Confluent.Kafka.Serdes
+            // will be used automatically (where available). The default deserializer for string
+            // is UTF8. The default deserializer for Ignore returns null for all input data
+            // (including non-null data).
+            using (var consumer = new ConsumerBuilder<Ignore, string>(config)
+                // Note: All handlers are called on the main .Consume thread.
+                .SetErrorHandler((_, e) => Console.WriteLine($"Error: {e.Reason}"))
+                .SetStatisticsHandler((_, json) => Console.WriteLine($"Statistics: {json}"))
+                // The partition assignment handler is called when the consumer has been
+                // notified of a new assignment set. You can use this callback to perform
+                // actions such as retrieving offsets from an external source and manually
+                // setting start offsets using the Assign method. You can even call Assign
+                // with a different set of partitions than those in the assignment. If
+                // you do not call Assign, the consumer will be automatically assigned to
+                // the partitions of the assignment set and consumption will start from
+                // last committed offsets or in accordance with the auto.offset.reset
+                // configuration parameter for partitions where there is no committed offset.
+                .SetPartitionAssignmentHandler((c, tps) => {
+                    Console.WriteLine($"Assigned partitions: [{string.Join(", ", tps)}], member id: {c.MemberId}");
+                })
+                // Called when the consumer's current assignment set has been revoked.
+                .SetPartitionAssignmentRevokedHandler((_, tps) => {
+                    Console.WriteLine($"Revoked partitions: [{string.Join(", ", tps)}]");
+                })
+                .Build())
             {
                 consumer.Subscribe(topics);
 

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -61,6 +61,9 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 // Note: All handlers are called on the main .Consume thread.
                 .SetErrorHandler((_, e) => Console.WriteLine($"Error: {e.Reason}"))
                 .SetStatisticsHandler((_, json) => Console.WriteLine($"Statistics: {json}"))
+                .Build())
+            {
+
                 // The partitions assigned handler is called when the consumer has been
                 // notified of a new assignment set. You can use this callback to perform
                 // actions such as retrieving offsets from an external source and manually
@@ -70,15 +73,17 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 // the partitions of the assignment set and consumption will start from
                 // last committed offsets or in accordance with the auto.offset.reset
                 // configuration parameter for partitions where there is no committed offset.
-                .SetPartitionsAssignedHandler((c, tps) => {
-                    Console.WriteLine($"Assigned partitions: [{string.Join(", ", tps)}], member id: {c.MemberId}");
-                })
+                consumer.SetPartitionsAssignedHandler((_, tps) =>
+                {
+                    Console.WriteLine($"Assigned partitions: [{string.Join(", ", tps)}], member id: {consumer.MemberId}");
+                });
+
                 // Called when the consumer's current assignment set has been revoked.
-                .SetPartitionsRevokedHandler((_, tps) => {
+                consumer.SetPartitionsRevokedHandler((_, tps) =>
+                {
                     Console.WriteLine($"Revoked partitions: [{string.Join(", ", tps)}]");
-                })
-                .Build())
-            {
+                });
+
                 consumer.Subscribe(topics);
 
                 while (!cancellationToken.IsCancellationRequested)

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -61,7 +61,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 // Note: All handlers are called on the main .Consume thread.
                 .SetErrorHandler((_, e) => Console.WriteLine($"Error: {e.Reason}"))
                 .SetStatisticsHandler((_, json) => Console.WriteLine($"Statistics: {json}"))
-                // The partition assignment handler is called when the consumer has been
+                // The partitions assigned handler is called when the consumer has been
                 // notified of a new assignment set. You can use this callback to perform
                 // actions such as retrieving offsets from an external source and manually
                 // setting start offsets using the Assign method. You can even call Assign
@@ -70,11 +70,11 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 // the partitions of the assignment set and consumption will start from
                 // last committed offsets or in accordance with the auto.offset.reset
                 // configuration parameter for partitions where there is no committed offset.
-                .SetPartitionAssignmentHandler((c, tps) => {
+                .SetPartitionsAssignedHandler((c, tps) => {
                     Console.WriteLine($"Assigned partitions: [{string.Join(", ", tps)}], member id: {c.MemberId}");
                 })
                 // Called when the consumer's current assignment set has been revoked.
-                .SetPartitionAssignmentRevokedHandler((_, tps) => {
+                .SetPartitionsRevokedHandler((_, tps) => {
                     Console.WriteLine($"Revoked partitions: [{string.Join(", ", tps)}]");
                 })
                 .Build())

--- a/examples/MultiProducer/Program.cs
+++ b/examples/MultiProducer/Program.cs
@@ -33,8 +33,8 @@ namespace Confluent.Kafka.Examples.MultiProducer
         {
             var config = new ProducerConfig { BootstrapServers = args[0] };
 
-            using (var producer = new Producer<string, string>(config))
-            using (var producer2 = new Producer<Null, int>(producer.Handle))
+            using (var producer = new ProducerBuilder<string, string>(config).Build())
+            using (var producer2 = new DependentProducerBuilder<Null, int>(producer.Handle).Build())
             {
                 // write (string, string) data to topic "first-topic".
                 producer.ProduceAsync("first-topic", new Message<string, string> { Key = "my-key-value", Value = "my-value" });
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Examples.MultiProducer
                 // do so, you can use different producers to write to the same topic.
                 producer2.ProduceAsync("first-topic", new Message<Null, int> { Value = 107 });
 
-                // As the Tasks returned by ProducerAsync are not waited on there will still be messages in flight.
+                // As the Tasks returned by ProduceAsync are not waited on there will still be messages in flight.
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
         }

--- a/examples/Producer/Program.cs
+++ b/examples/Producer/Program.cs
@@ -41,7 +41,7 @@ namespace Confluent.Kafka.Examples.ProducerExample
 
             var config = new ProducerConfig { BootstrapServers = brokerList };
 
-            using (var producer = new Producer<string, string>(config))
+            using (var producer = new ProducerBuilder<string, string>(config).Build())
             {
                 Console.WriteLine("\n-----------------------------------------------------------------------");
                 Console.WriteLine($"Producer {producer.Name} producing on topic {topicName}.");

--- a/examples/Protobuf/Program.cs
+++ b/examples/Protobuf/Program.cs
@@ -17,6 +17,7 @@
 // Refer to LICENSE for more information.
 
 using Confluent.Kafka;
+using Confluent.Kafka.Serdes;
 using Google.Protobuf;
 using System;
 using System.Threading;
@@ -68,7 +69,10 @@ namespace Confluent.Kafka.Examples.Protobuf
             var consumeTask = Task.Run(() =>
             {
                 // consume a single message then exit.
-                using (var consumer = new Consumer<int, User>(consumerConfig, Deserializers.Int32, new ProtobufDeserializer<User>()))
+                using (var consumer =
+                    new ConsumerBuilder<int, User>(consumerConfig)
+                        .SetValueDeserializer(new ProtobufDeserializer<User>())
+                        .Build())
                 {
                     consumer.Subscribe("protobuf-test-topic");
                     var cr = consumer.Consume();
@@ -81,7 +85,10 @@ namespace Confluent.Kafka.Examples.Protobuf
 
             var producerConfig = new ProducerConfig { BootstrapServers = args[0] };
 
-            using (var producer = new Producer<int, User>(producerConfig, Serializers.Int32, new ProtobufSerializer<User>()))
+            using (var producer =
+                new ProducerBuilder<int, User>(producerConfig)
+                    .SetValueSerializer(new ProtobufSerializer<User>())
+                    .Build())
             {
                 await producer.ProduceAsync("protobuf-test-topic", new Message<int, User> { Key = 0, Value = new User { FavoriteColor = "green" } });
             }

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -462,16 +462,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new AdminClient instance.
         /// </summary>
-        /// <param name="config">
-        ///     A collection of librdkafka configuration parameters 
-        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
-        ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />). Only
-        ///     the bootstrap.servers property is required.
+        /// <param name="handle">
+        ///     An underlying librdkafka client handle that the AdminClient will use to 
+        ///     make broker requests. It is valid to provide either a Consumer, Producer
+        ///     or AdminClient handle.
         /// </param>
-        public AdminClient(IEnumerable<KeyValuePair<string, string>> config)
+        public AdminClient(Handle handle)
+        {                            
+            this.ownedClient = null;
+            this.handle = handle;
+            Init();
+        }
+
+        internal AdminClient(AdminClientBuilder builder)
         {
-            config = Config.GetCancellationDelayMaxMs(config, out this.cancellationDelayMaxMs);
+            var config = Config.ExtractCancellationDelayMaxMs(builder.config, out this.cancellationDelayMaxMs);
 
             if (config.Where(prop => prop.Key.StartsWith("dotnet.producer.")).Count() > 0 ||
                 config.Where(prop => prop.Key.StartsWith("dotnet.consumer.")).Count() > 0)
@@ -479,28 +484,19 @@ namespace Confluent.Kafka
                 throw new ArgumentException("AdminClient configuration must not include producer or consumer specific configuration properties.");
             }
 
-            this.ownedClient = new Producer(new ProducerConfig(config));
+            // build a producer instance to use as the underlying client.
+            var producerBuilder = new ProducerBuilder(config);
+            if (builder.logHandler != null) { producerBuilder.SetLogHandler((_, logMessage) => builder.logHandler(this, logMessage)); }
+            if (builder.errorHandler != null) { producerBuilder.SetErrorHandler((_, error) => builder.errorHandler(this, error)); }
+            if (builder.statsHandler != null) { producerBuilder.SetStatisticsHandler((_, stats) => builder.statsHandler(this, stats)); }
+            this.ownedClient = producerBuilder.Build();
+            
             this.handle = new Handle
             { 
                 Owner = this,
                 LibrdkafkaHandle = ownedClient.Handle.LibrdkafkaHandle
             };
 
-            Init();
-        }
-
-
-        /// <summary>
-        ///     Initialize a new AdminClient instance.
-        /// </summary>
-        /// <param name="handle">
-        ///     An underlying librdkafka client handle to use to make broker requests.
-        ///     It is valid to provide either a Consumer or Producer handle.
-        /// </param>
-        public AdminClient(Handle handle)
-        {
-            this.ownedClient = null;
-            this.handle = handle;
             Init();
         }
 
@@ -609,33 +605,6 @@ namespace Confluent.Kafka
         public Metadata GetMetadata(string topic, TimeSpan timeout)
             => kafkaHandle.GetMetadata(false, kafkaHandle.getKafkaTopicHandle(topic), timeout.TotalMillisecondsAsInt());
 
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.IClient.OnLog" />.
-        /// </summary>
-        public event EventHandler<LogMessage> OnLog
-        {
-            add { handle.Owner.OnLog += value; }
-            remove { handle.Owner.OnLog -= value; }
-        }
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.IClient.OnStatistics" />.
-        /// </summary>
-        public event EventHandler<string> OnStatistics
-        {
-            add { handle.Owner.OnStatistics += value; }
-            remove { handle.Owner.OnStatistics -= value; }
-        }
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.IClient.OnError" />.
-        /// </summary>
-        public event EventHandler<Error> OnError
-        {
-            add { handle.Owner.OnError += value; }
-            remove { handle.Owner.OnError -= value; }
-        }
 
         /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.IClient.AddBrokers(string)" />

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -476,7 +476,7 @@ namespace Confluent.Kafka
 
         internal AdminClient(AdminClientBuilder builder)
         {
-            var config = Config.ExtractCancellationDelayMaxMs(builder.config, out this.cancellationDelayMaxMs);
+            var config = Config.ExtractCancellationDelayMaxMs(builder.Config, out this.cancellationDelayMaxMs);
 
             if (config.Where(prop => prop.Key.StartsWith("dotnet.producer.")).Count() > 0 ||
                 config.Where(prop => prop.Key.StartsWith("dotnet.consumer.")).Count() > 0)
@@ -486,9 +486,9 @@ namespace Confluent.Kafka
 
             // build a producer instance to use as the underlying client.
             var producerBuilder = new ProducerBuilder(config);
-            if (builder.logHandler != null) { producerBuilder.SetLogHandler((_, logMessage) => builder.logHandler(this, logMessage)); }
-            if (builder.errorHandler != null) { producerBuilder.SetErrorHandler((_, error) => builder.errorHandler(this, error)); }
-            if (builder.statsHandler != null) { producerBuilder.SetStatisticsHandler((_, stats) => builder.statsHandler(this, stats)); }
+            if (builder.LogHandler != null) { producerBuilder.SetLogHandler((_, logMessage) => builder.LogHandler(this, logMessage)); }
+            if (builder.ErrorHandler != null) { producerBuilder.SetErrorHandler((_, error) => builder.ErrorHandler(this, error)); }
+            if (builder.StatisticsHandler != null) { producerBuilder.SetStatisticsHandler((_, stats) => builder.StatisticsHandler(this, stats)); }
             this.ownedClient = producerBuilder.Build();
             
             this.handle = new Handle

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -25,9 +25,24 @@ namespace Confluent.Kafka
     /// </summary>
     public class AdminClientBuilder
     {
+        /// <summary>
+        ///     The config dictionary.
+        /// </summary>
         public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+
+        /// <summary>
+        ///     The configured error handler.
+        /// </summary>
         public Action<AdminClient, Error> ErrorHandler { get; set; }
+        
+        /// <summary>
+        ///     The configured log handler.
+        /// </summary>
         public Action<AdminClient, LogMessage> LogHandler { get; set; }
+
+        /// <summary>
+        ///     The configured statistics handler.
+        /// </summary>
         public Action<AdminClient, string> StatisticsHandler { get; set; }
 
         /// <summary>

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -1,0 +1,115 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     A builder for <see cref="AdminClient" /> instances.
+    /// </summary>
+    public class AdminClientBuilder
+    {
+        internal IEnumerable<KeyValuePair<string, string>> config;
+        internal Action<AdminClient, Error> errorHandler;
+        internal Action<AdminClient, LogMessage> logHandler;
+        internal Action<AdminClient, string> statsHandler;
+
+        /// <summary>
+        ///     Initialize a new <see cref="AdminClientBuilder" /> instance.
+        /// </summary>
+        /// <param name="config">
+        ///     A collection of librdkafka configuration parameters 
+        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
+        ///     and parameters specific to this client (refer to: 
+        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     At a minimum, 'bootstrap.servers' and must be specified.
+        /// </param>
+        public AdminClientBuilder(IEnumerable<KeyValuePair<string, string>> config)
+        {
+            this.config = config;
+        }
+
+        /// <summary>
+        ///     Set the handler to call on librdkafka statistics events. Statistics are provided as a JSON formatted string as defined here:
+        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
+        /// </summary>
+        /// <remarks>
+        ///     You can enable statistics and set the statistics interval
+        ///     using the statistics.interval.ms configuration parameter
+        ///     (disabled by default).
+        ///
+        ///     Executes on the poll thread (a background thread managed by
+        ///     the admin client).
+        /// </remarks>
+        public AdminClientBuilder SetStatisticsHandler(Action<AdminClient, string> statisticsHandler)
+        {
+            this.statsHandler = statisticsHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call on error events e.g. connection failures or all
+        ///     brokers down. Note that the client will try to automatically recover from
+        ///     errors that are not marked as fatal - such errors should be interpreted
+        ///     as informational rather than catastrophic.
+        /// </summary>
+        /// <remarks>
+        ///     Executes on the poll thread (a background thread managed by the admin
+        ///     client).
+        /// </remarks>
+        public AdminClientBuilder SetErrorHandler(Action<AdminClient, Error> errorHandler)
+        {
+            this.errorHandler = errorHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call when there is information available
+        ///     to be logged. If not specified, a default callback that writes
+        ///     to stderr will be used.
+        /// </summary>
+        /// <remarks>
+        ///     By default not many log messages are generated.
+        ///
+        ///     For more verbose logging, specify one or more debug contexts
+        ///     using the 'debug' configuration property. The 'log_level'
+        ///     configuration property is also relevant, however logging is
+        ///     verbose by default given a debug context has been specified,
+        ///     so you typically shouldn't adjust this value.
+        ///
+        ///     Warning: Log handlers are called spontaneously from internal
+        ///     librdkafka threads and the application must not call any
+        ///     Confluent.Kafka APIs from within a log handler or perform any
+        ///     prolonged operations.
+        /// </remarks>
+        public AdminClientBuilder SetLogHandler(Action<AdminClient, LogMessage> logHandler)
+        {
+            this.logHandler = logHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Build the <see cref="AdminClient" /> instance.
+        /// </summary>
+        public AdminClient Build()
+        {
+            return new AdminClient(this);
+        }
+    }
+}

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -25,10 +25,10 @@ namespace Confluent.Kafka
     /// </summary>
     public class AdminClientBuilder
     {
-        internal IEnumerable<KeyValuePair<string, string>> config;
-        internal Action<AdminClient, Error> errorHandler;
-        internal Action<AdminClient, LogMessage> logHandler;
-        internal Action<AdminClient, string> statsHandler;
+        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+        public Action<AdminClient, Error> ErrorHandler { get; set; }
+        public Action<AdminClient, LogMessage> LogHandler { get; set; }
+        public Action<AdminClient, string> StatisticsHandler { get; set; }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientBuilder" /> instance.
@@ -42,7 +42,7 @@ namespace Confluent.Kafka
         /// </param>
         public AdminClientBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
-            this.config = config;
+            this.Config = config;
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Confluent.Kafka
         /// </remarks>
         public AdminClientBuilder SetStatisticsHandler(Action<AdminClient, string> statisticsHandler)
         {
-            this.statsHandler = statisticsHandler;
+            this.StatisticsHandler = statisticsHandler;
             return this;
         }
 
@@ -75,7 +75,7 @@ namespace Confluent.Kafka
         /// </remarks>
         public AdminClientBuilder SetErrorHandler(Action<AdminClient, Error> errorHandler)
         {
-            this.errorHandler = errorHandler;
+            this.ErrorHandler = errorHandler;
             return this;
         }
 
@@ -100,14 +100,14 @@ namespace Confluent.Kafka
         /// </remarks>
         public AdminClientBuilder SetLogHandler(Action<AdminClient, LogMessage> logHandler)
         {
-            this.logHandler = logHandler;
+            this.LogHandler = logHandler;
             return this;
         }
 
         /// <summary>
         ///     Build the <see cref="AdminClient" /> instance.
         /// </summary>
-        public AdminClient Build()
+        public virtual AdminClient Build()
         {
             return new AdminClient(this);
         }

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -53,7 +53,7 @@ namespace Confluent.Kafka
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
         ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' and must be specified.
+        ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </param>
         public AdminClientBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
@@ -61,11 +61,12 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Set the handler to call on librdkafka statistics events. Statistics are provided as a JSON formatted string as defined here:
-        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
+        ///     Set the handler to call on statistics events. Statistics are provided
+        ///     as a JSON formatted string as defined here:
+        ///     https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
         /// </summary>
         /// <remarks>
-        ///     You can enable statistics and set the statistics interval
+        ///     You can enable statistics by setting the statistics interval
         ///     using the statistics.interval.ms configuration parameter
         ///     (disabled by default).
         ///
@@ -74,6 +75,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public AdminClientBuilder SetStatisticsHandler(Action<AdminClient, string> statisticsHandler)
         {
+            if (this.StatisticsHandler != null)
+            {
+                throw new ArgumentException("Statistics handler may not be specified more than once.");
+            }
             this.StatisticsHandler = statisticsHandler;
             return this;
         }
@@ -81,7 +86,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Set the handler to call on error events e.g. connection failures or all
         ///     brokers down. Note that the client will try to automatically recover from
-        ///     errors that are not marked as fatal - such errors should be interpreted
+        ///     errors that are not marked as fatal. Non-fatal errors should be interpreted
         ///     as informational rather than catastrophic.
         /// </summary>
         /// <remarks>
@@ -90,6 +95,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public AdminClientBuilder SetErrorHandler(Action<AdminClient, Error> errorHandler)
         {
+            if (this.ErrorHandler != null)
+            {
+                throw new ArgumentException("Error handler may not be specified more than once.");
+            }
             this.ErrorHandler = errorHandler;
             return this;
         }
@@ -103,10 +112,7 @@ namespace Confluent.Kafka
         ///     By default not many log messages are generated.
         ///
         ///     For more verbose logging, specify one or more debug contexts
-        ///     using the 'debug' configuration property. The 'log_level'
-        ///     configuration property is also relevant, however logging is
-        ///     verbose by default given a debug context has been specified,
-        ///     so you typically shouldn't adjust this value.
+        ///     using the 'debug' configuration property.
         ///
         ///     Warning: Log handlers are called spontaneously from internal
         ///     librdkafka threads and the application must not call any
@@ -115,6 +121,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public AdminClientBuilder SetLogHandler(Action<AdminClient, LogMessage> logHandler)
         {
+            if (this.LogHandler != null)
+            {
+                throw new ArgumentException("Log handler may not be specified more than once.");
+            }
             this.LogHandler = logHandler;
             return this;
         }

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -28,22 +28,22 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The config dictionary.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+        internal protected IEnumerable<KeyValuePair<string, string>> Config { get; set; }
 
         /// <summary>
         ///     The configured error handler.
         /// </summary>
-        public Action<AdminClient, Error> ErrorHandler { get; set; }
+        internal protected Action<AdminClient, Error> ErrorHandler { get; set; }
         
         /// <summary>
         ///     The configured log handler.
         /// </summary>
-        public Action<AdminClient, LogMessage> LogHandler { get; set; }
+        internal protected Action<AdminClient, LogMessage> LogHandler { get; set; }
 
         /// <summary>
         ///     The configured statistics handler.
         /// </summary>
-        public Action<AdminClient, string> StatisticsHandler { get; set; }
+        internal protected Action<AdminClient, string> StatisticsHandler { get; set; }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientBuilder" /> instance.

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -208,7 +208,7 @@ namespace Confluent.Kafka
 
         private const int DefaultCancellationDelayMaxMs = 100;
 
-        internal static IEnumerable<KeyValuePair<string, string>> GetCancellationDelayMaxMs(
+        internal static IEnumerable<KeyValuePair<string, string>> ExtractCancellationDelayMaxMs(
             IEnumerable<KeyValuePair<string, string>> config, out int cancellationDelayMaxMs)
         {
             var cancellationDelayMaxString = config

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -57,7 +57,7 @@ namespace Confluent.Kafka
             base.Initialize(builder.ConstructBaseConfig(this));
 
             // setup key deserializer.
-            if (builder.keyDeserializer == null && builder.asyncKeyDeserializer == null)
+            if (builder.KeyDeserializer == null && builder.AsyncKeyDeserializer == null)
             {
                 if (!defaultDeserializers.TryGetValue(typeof(TKey), out object deserializer))
                 {
@@ -66,13 +66,13 @@ namespace Confluent.Kafka
                 }
                 this.keyDeserializer = (IDeserializer<TKey>)deserializer;
             }
-            else if (builder.keyDeserializer == null && builder.asyncKeyDeserializer != null)
+            else if (builder.KeyDeserializer == null && builder.AsyncKeyDeserializer != null)
             {
-                this.asyncKeyDeserializer = builder.asyncKeyDeserializer;
+                this.asyncKeyDeserializer = builder.AsyncKeyDeserializer;
             }
-            else if (builder.keyDeserializer != null && builder.asyncKeyDeserializer == null)
+            else if (builder.KeyDeserializer != null && builder.AsyncKeyDeserializer == null)
             {
-                this.keyDeserializer = builder.keyDeserializer;
+                this.keyDeserializer = builder.KeyDeserializer;
             }
             else
             {
@@ -80,7 +80,7 @@ namespace Confluent.Kafka
             }
 
             // setup value deserializer.
-            if (builder.valueDeserializer == null && builder.asyncValueDeserializer == null)
+            if (builder.ValueDeserializer == null && builder.AsyncValueDeserializer == null)
             {
                 if (!defaultDeserializers.TryGetValue(typeof(TValue), out object deserializer))
                 {
@@ -89,13 +89,13 @@ namespace Confluent.Kafka
                 }
                 this.valueDeserializer = (IDeserializer<TValue>)deserializer;
             }
-            else if (builder.valueDeserializer == null && builder.asyncValueDeserializer != null)
+            else if (builder.ValueDeserializer == null && builder.AsyncValueDeserializer != null)
             {
-                this.asyncValueDeserializer = builder.asyncValueDeserializer;
+                this.asyncValueDeserializer = builder.AsyncValueDeserializer;
             }
-            else if (builder.valueDeserializer != null && builder.asyncValueDeserializer == null)
+            else if (builder.ValueDeserializer != null && builder.AsyncValueDeserializer == null)
             {
-                this.valueDeserializer = builder.valueDeserializer;
+                this.valueDeserializer = builder.ValueDeserializer;
             }
             else
             {

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -36,7 +36,7 @@ namespace Confluent.Kafka
     public class Consumer<TKey, TValue> : ConsumerBase, IConsumer<TKey, TValue>
     {
         /// <summary>
-        ///     Set the partitions assiged handler.
+        ///     Set the partitions assigned handler.
         /// 
         ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
         ///     method (or another overload of this method) in this handler, or do not specify a partitions assigned handler,

--- a/src/Confluent.Kafka/ConsumerBase.cs
+++ b/src/Confluent.Kafka/ConsumerBase.cs
@@ -35,6 +35,18 @@ namespace Confluent.Kafka
     /// </summary>
     public class ConsumerBase : IConsumerBase, IClient
     {
+        internal class Config
+        {
+            internal IEnumerable<KeyValuePair<string, string>> config;
+            internal Action<Error> errorHandler;
+            internal Action<LogMessage> logHandler;
+            internal Action<string> statsHandler;
+            internal Action<List<TopicPartition>> partitionAssignmentHandler;
+            internal Action<List<TopicPartition>> partitionAssignmentRevokedHandler;
+            internal Action<CommittedOffsets> offsetsCommittedHandler;
+        }
+
+
         /// <summary>
         ///     value of the dotnet.cancellation.delay.max.ms configuration parameter.
         /// </summary>
@@ -49,41 +61,46 @@ namespace Confluent.Kafka
         /// </summary>
         private int assignCallCount = 0;
 
-        private readonly bool enableHeaderMarshaling = true;
-        private readonly bool enableTimestampMarshaling = true;
-        private readonly bool enableTopicNameMarshaling = true;
+        private bool enableHeaderMarshaling = true;
+        private bool enableTimestampMarshaling = true;
+        private bool enableTopicNameMarshaling = true;
 
-        private readonly SafeKafkaHandle kafkaHandle;
+        private SafeKafkaHandle kafkaHandle;
 
 
-        private readonly Librdkafka.ErrorDelegate errorCallbackDelegate;
+        private Action<Error> errorHandler;
+        private Librdkafka.ErrorDelegate errorCallbackDelegate;
         private void ErrorCallback(IntPtr rk, ErrorCode err, string reason, IntPtr opaque)
         {
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             if (kafkaHandle.IsClosed) { return; }
-            OnError?.Invoke(this, kafkaHandle.CreatePossiblyFatalError(err, reason));
+            errorHandler?.Invoke(kafkaHandle.CreatePossiblyFatalError(err, reason));
         }
 
-        private readonly Librdkafka.StatsDelegate statsCallbackDelegate;
+        private Action<string> statsHandler;
+        private Librdkafka.StatsDelegate statsCallbackDelegate;
         private int StatsCallback(IntPtr rk, IntPtr json, UIntPtr json_len, IntPtr opaque)
         {
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             if (kafkaHandle.IsClosed) { return 0; }
-            OnStatistics?.Invoke(this, Util.Marshal.PtrToStringUTF8(json));
+            statsHandler?.Invoke(Util.Marshal.PtrToStringUTF8(json));
             return 0; // instruct librdkafka to immediately free the json ptr.
         }
 
+        private Action<LogMessage> logHandler;
         private object loggerLockObj = new object();
-        private readonly Librdkafka.LogDelegate logCallbackDelegate;
+        private Librdkafka.LogDelegate logCallbackDelegate;
         private void LogCallback(IntPtr rk, SyslogLevel level, string fac, string buf)
         {
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             // Note: kafkaHandle can be null if the callback is during construction (in that case the delegate should be called).
             if (kafkaHandle != null && kafkaHandle.IsClosed) { return; }
-            OnLog?.Invoke(this, new LogMessage(Util.Marshal.PtrToStringUTF8(Librdkafka.name(rk)), level, fac, buf));
+            logHandler?.Invoke(new LogMessage(Util.Marshal.PtrToStringUTF8(Librdkafka.name(rk)), level, fac, buf));
         }
 
-        private readonly Librdkafka.RebalanceDelegate rebalanceDelegate;
+        private Action<List<TopicPartition>> partitionAssignmentHandler;
+        private Action<List<TopicPartition>> partitionAssignmentRevokedHandler;
+        private Librdkafka.RebalanceDelegate rebalanceDelegate;
         private void RebalanceCallback(
             IntPtr rk,
             ErrorCode err,
@@ -107,11 +124,10 @@ namespace Confluent.Kafka
 
             if (err == ErrorCode.Local_AssignPartitions)
             {
-                var handler = OnPartitionsAssigned;
-                if (handler != null && handler.GetInvocationList().Length > 0)
+                if (partitionAssignmentHandler != null)
                 {
                     assignCallCount = 0;
-                    handler(this, partitionList);
+                    partitionAssignmentHandler(partitionList);
                     if (assignCallCount == 1) { return; }
                     if (assignCallCount > 1)
                     {
@@ -123,11 +139,10 @@ namespace Confluent.Kafka
             }
             else if (err == ErrorCode.Local_RevokePartitions)
             {
-                var handler = OnPartitionsRevoked;
-                if (handler != null && handler.GetInvocationList().Length > 0)
+                if (partitionAssignmentRevokedHandler != null)
                 {
                     assignCallCount = 0;
-                    handler(this, partitionList);
+                    partitionAssignmentRevokedHandler(partitionList);
                     if (assignCallCount == 1) { return; }
                     if (assignCallCount > 1)
                     {
@@ -143,7 +158,8 @@ namespace Confluent.Kafka
             }
         }
 
-        private readonly Librdkafka.CommitDelegate commitDelegate;
+        private Action<CommittedOffsets> offsetsCommittedHandler;
+        private Librdkafka.CommitDelegate commitDelegate;
         private void CommitCallback(
             IntPtr rk,
             ErrorCode err,
@@ -153,43 +169,24 @@ namespace Confluent.Kafka
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             if (kafkaHandle.IsClosed) { return; }
 
-            OnOffsetsCommitted?.Invoke(this, new CommittedOffsets(
+            offsetsCommittedHandler?.Invoke(new CommittedOffsets(
                 SafeKafkaHandle.GetTopicPartitionOffsetErrorList(offsets),
                 kafkaHandle.CreatePossiblyFatalError(err, null)
             ));
         }
 
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.IClient.OnLog" />.
-        /// </summary>
-        public event EventHandler<LogMessage> OnLog;
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.IClient.OnError" />.
-        /// </summary>
-        public event EventHandler<Error> OnError;
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.IClient.OnStatistics" />.
-        /// </summary>
-        public event EventHandler<string> OnStatistics;
-
-        /// <summary>
-        ///     Creates a new <see cref="Confluent.Kafka.ConsumerBase" /> instance.
-        /// </summary>
-        /// <param name="config">
-        ///     A collection of librdkafka configuration parameters 
-        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
-        ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
-        ///     specified.
-        /// </param>
-        public ConsumerBase(IEnumerable<KeyValuePair<string, string>> config)
+        internal void Initialize(Config baseConfig)
         {
+            this.statsHandler = baseConfig.statsHandler;
+            this.logHandler = baseConfig.logHandler;
+            this.errorHandler = baseConfig.errorHandler;
+            this.offsetsCommittedHandler = baseConfig.offsetsCommittedHandler;
+            this.partitionAssignmentHandler = baseConfig.partitionAssignmentHandler;
+            this.partitionAssignmentRevokedHandler = baseConfig.partitionAssignmentRevokedHandler;
+
             Librdkafka.Initialize(null);
 
-            config = Config.GetCancellationDelayMaxMs(config, out this.cancellationDelayMaxMs);
+            var config = Confluent.Kafka.Config.ExtractCancellationDelayMaxMs(baseConfig.config, out this.cancellationDelayMaxMs);
 
             if (config.FirstOrDefault(prop => string.Equals(prop.Key, "group.id", StringComparison.Ordinal)).Value == null)
             {
@@ -261,6 +258,11 @@ namespace Confluent.Kafka
             }
         }
 
+        /// <remarks>
+        ///     If there's demand, we may allow instantiation of the <see cref="ConsumerBase" /> class from
+        ///     external code in the future. For now, dissallow this so it's considered an internal detail.
+        /// </remarks>
+        internal ConsumerBase() {}
 
         private static byte[] KeyAsByteArray(rd_kafka_message msg)
         {
@@ -284,7 +286,6 @@ namespace Confluent.Kafka
             }
             return valAsByteArray;
         }
-
 
         /// <summary>
         ///     Poll for new messages / events. Blocks until a consume result
@@ -480,55 +481,6 @@ namespace Confluent.Kafka
                 Librdkafka.message_destroy(msgPtr);
             }
         }
-
-
-        /// <summary>
-        ///     Raised when a new partition assignment is received.
-        /// 
-        ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
-        ///     method (or another overload of this method) in a handler added to this event, following execution of your handler(s),
-        ///     the consumer will be automatically assigned to the set of partitions as specified in the event data and 
-        ///     consumption will resume from the last committed offset for each partition, or if there is no committed offset, in
-        ///     accordance with the `auto.offset.reset` configuration property. This default behavior will not occur if you call Assign
-        ///     yourself in a handler added to this event. The set of partitions you assign to is not required to match the
-        ///     assignment given to you, but typically will.
-        /// </summary>
-        /// <remarks>
-        ///     Executes as a side-effect of
-        ///     <see cref="Confluent.Kafka.Consumer.Consume(CancellationToken)" />
-        ///     (on the same thread).
-        /// </remarks>
-        public event EventHandler<List<TopicPartition>> OnPartitionsAssigned;
-
-
-        /// <summary>
-        ///     Raised when a partition assignment is revoked.
-        /// 
-        ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Unassign" /> or 
-        ///     <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
-        ///     (or other overload) method in a handler added to this event, all partitions will be 
-        ///     automatically unassigned following execution of your handler(s). This default behavior 
-        ///     will not occur if you call Unassign (or Assign) yourself in a handler added to this event.
-        /// </summary>
-        /// <remarks>
-        ///     Executes as a side-effect of
-        ///     <see cref="Confluent.Kafka.Consumer.Consume(CancellationToken)" />
-        ///     and <see cref="Confluent.Kafka.ConsumerBase.Close()" />
-        ///     (on the same thread).
-        /// </remarks>
-        public event EventHandler<List<TopicPartition>> OnPartitionsRevoked;
-
-
-        /// <summary>
-        ///     Raised to report the result of (automatic) offset commits.
-        ///     Not raised as a result of the use of the Commit method.
-        /// </summary>
-        /// <remarks>
-        ///     Executes as a side-effect of
-        ///     <see cref="Confluent.Kafka.Consumer.Consume(CancellationToken)" />
-        ///     (on the same thread).
-        /// </remarks>
-        public event EventHandler<CommittedOffsets> OnOffsetsCommitted;
 
 
         /// <summary>
@@ -999,11 +951,9 @@ namespace Confluent.Kafka
         ///     do not call <see cref="Confluent.Kafka.ConsumerBase.Close" />
         ///     or <see cref="Confluent.Kafka.ConsumerBase.Unsubscribe" />,
         ///     the group will rebalance after a timeout specified by the group's 
-        ///     `session.timeout.ms`. Note: the
-        ///     <see cref="Confluent.Kafka.ConsumerBase.OnPartitionsRevoked" />
-        ///     and 
-        ///     <see cref="Confluent.Kafka.ConsumerBase.OnOffsetsCommitted" />
-        ///     events may be called as a side-effect of calling this method.
+        ///     `session.timeout.ms`. Note: the partition asignment and partition
+        ///     assignment revoked handlers may be called as a side-effect of
+        ///     calling this method.
         /// </summary>
         /// <exception cref="Confluent.Kafka.KafkaException">
         ///     Thrown if the operation fails.

--- a/src/Confluent.Kafka/ConsumerBase.cs
+++ b/src/Confluent.Kafka/ConsumerBase.cs
@@ -41,9 +41,6 @@ namespace Confluent.Kafka
             internal Action<Error> errorHandler;
             internal Action<LogMessage> logHandler;
             internal Action<string> statisticsHandler;
-            internal Action<List<TopicPartition>> partitionsAssignedHandler;
-            internal Action<List<TopicPartition>> partitionsRevokedHandler;
-            internal Action<CommittedOffsets> offsetsCommittedHandler;
         }
 
 
@@ -98,8 +95,15 @@ namespace Confluent.Kafka
             logHandler?.Invoke(new LogMessage(Util.Marshal.PtrToStringUTF8(Librdkafka.name(rk)), level, fac, buf));
         }
 
-        private Action<List<TopicPartition>> partitionsAssignedHandler;
-        private Action<List<TopicPartition>> partitionsRevokedHandler;
+        /// <summary>
+        ///     partitionsAssignedHandler.
+        /// </summary>
+        protected Action<List<TopicPartition>> partitionsAssignedHandler;
+
+        /// <summary>
+        ///     partitionsRevokedHandler.
+        /// </summary>
+        protected Action<List<TopicPartition>> partitionsRevokedHandler;
         private Librdkafka.RebalanceDelegate rebalanceDelegate;
         private void RebalanceCallback(
             IntPtr rk,
@@ -158,7 +162,10 @@ namespace Confluent.Kafka
             }
         }
 
-        private Action<CommittedOffsets> offsetsCommittedHandler;
+        /// <summary>
+        ///     offsetsCommittedHandler.
+        /// </summary>
+        protected Action<CommittedOffsets> offsetsCommittedHandler;
         private Librdkafka.CommitDelegate commitDelegate;
         private void CommitCallback(
             IntPtr rk,
@@ -180,9 +187,6 @@ namespace Confluent.Kafka
             this.statisticsHandler = baseConfig.statisticsHandler;
             this.logHandler = baseConfig.logHandler;
             this.errorHandler = baseConfig.errorHandler;
-            this.offsetsCommittedHandler = baseConfig.offsetsCommittedHandler;
-            this.partitionsAssignedHandler = baseConfig.partitionsAssignedHandler;
-            this.partitionsRevokedHandler = baseConfig.partitionsRevokedHandler;
 
             Librdkafka.Initialize(null);
 

--- a/src/Confluent.Kafka/ConsumerBase.cs
+++ b/src/Confluent.Kafka/ConsumerBase.cs
@@ -264,7 +264,7 @@ namespace Confluent.Kafka
 
         /// <remarks>
         ///     If there's demand, we may allow instantiation of the <see cref="ConsumerBase" /> class from
-        ///     external code in the future. For now, dissallow this so it's considered an internal detail.
+        ///     external code in the future. For now, disallow this so it's considered an internal detail.
         /// </remarks>
         internal ConsumerBase() {}
 

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -78,7 +78,7 @@ namespace Confluent.Kafka
                 logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
                     : logMessage => this.LogHandler(consumer, logMessage),
-                statsHandler = this.StatisticsHandler == null
+                statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
                     : stats => this.StatisticsHandler(consumer, stats),
                 partitionAssignmentRevokedHandler = this.PartitionAssignmentRevokedHandler == null
@@ -240,7 +240,7 @@ namespace Confluent.Kafka
                 logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
                     : logMessage => this.LogHandler(consumer, logMessage),
-                statsHandler = this.StatisticsHandler == null
+                statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
                     : stats => this.StatisticsHandler(consumer, stats),
                 partitionAssignmentRevokedHandler = this.PartitionAssignmentRevokedHandler == null

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -31,37 +31,65 @@ namespace Confluent.Kafka
     /// </summary>
     public class ConsumerBuilder
     {
-        internal IEnumerable<KeyValuePair<string, string>> config;
-        internal Action<Consumer, Error> errorHandler;
-        internal Action<Consumer, LogMessage> logHandler;
-        internal Action<Consumer, string> statsHandler;
-        internal Action<Consumer, List<TopicPartition>> partitionAssignmentHandler;
-        internal Action<Consumer, List<TopicPartition>> partitionAssignmentRevokedHandler;
-        internal Action<Consumer, CommittedOffsets> offsetsCommittedHandler;
+        /// <summary>
+        ///     The config dictionary.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+
+        /// <summary>
+        ///     The configured error handler.
+        /// </summary>
+        public Action<Consumer, Error> ErrorHandler { get; set; }
+
+        /// <summary>
+        ///     The configured log handler.
+        /// </summary>
+        public Action<Consumer, LogMessage> LogHandler { get; set; }
+
+        /// <summary>
+        ///     The configured statistics handler.
+        /// </summary>
+        public Action<Consumer, string> StatisticsHandler { get; set; }
+
+        /// <summary>
+        ///     The configured partition assignment handler.
+        /// </summary>
+        public Action<Consumer, List<TopicPartition>> PartitionAssignmentHandler { get; set; }
+
+        /// <summary>
+        ///     The configured partition assignment revoked handler.
+        /// </summary>
+        public Action<Consumer, List<TopicPartition>> PartitionAssignmentRevokedHandler { get; set; }
+
+        /// <summary>
+        ///     The configured offsets committed handler.
+        /// </summary>
+        public Action<Consumer, CommittedOffsets> OffsetsCommittedHandler { get; set; }
+
 
         internal ConsumerBase.Config ConstructBaseConfig(Consumer consumer)
         {
             return new ConsumerBase.Config
             {
-                config = config,
-                errorHandler = this.errorHandler == null
+                config = Config,
+                errorHandler = this.ErrorHandler == null
                     ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
-                    : error => this.errorHandler(consumer, error),
-                logHandler = this.logHandler == null
+                    : error => this.ErrorHandler(consumer, error),
+                logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
-                    : logMessage => this.logHandler(consumer, logMessage),
-                statsHandler = this.statsHandler == null
+                    : logMessage => this.LogHandler(consumer, logMessage),
+                statsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
-                    : stats => this.statsHandler(consumer, stats),
-                partitionAssignmentRevokedHandler = this.partitionAssignmentRevokedHandler == null
+                    : stats => this.StatisticsHandler(consumer, stats),
+                partitionAssignmentRevokedHandler = this.PartitionAssignmentRevokedHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.partitionAssignmentRevokedHandler(consumer, partitions),
-                partitionAssignmentHandler = this.partitionAssignmentHandler == null
+                    : partitions => this.PartitionAssignmentRevokedHandler(consumer, partitions),
+                partitionAssignmentHandler = this.PartitionAssignmentHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.partitionAssignmentHandler(consumer, partitions),
-                offsetsCommittedHandler = this.offsetsCommittedHandler == null
+                    : partitions => this.PartitionAssignmentHandler(consumer, partitions),
+                offsetsCommittedHandler = this.OffsetsCommittedHandler == null
                     ? default(Action<CommittedOffsets>)
-                    : offsets => this.offsetsCommittedHandler(consumer, offsets)
+                    : offsets => this.OffsetsCommittedHandler(consumer, offsets)
             };
         }
 
@@ -70,7 +98,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
-            this.config = config;
+            this.Config = config;
         }
 
         /// <summary>
@@ -79,7 +107,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder SetOffsetsCommittedHandler(
             Action<Consumer, CommittedOffsets> offsetsCommittedHandler)
         {
-            this.offsetsCommittedHandler = offsetsCommittedHandler;
+            this.OffsetsCommittedHandler = offsetsCommittedHandler;
             return this;
         }
 
@@ -89,7 +117,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder SetPartitionsRevokedHandler(
             Action<Consumer, List<TopicPartition>> partitionsRevokedHandler)
         {
-            this.partitionAssignmentRevokedHandler = partitionsRevokedHandler;
+            this.PartitionAssignmentRevokedHandler = partitionsRevokedHandler;
             return this;
         }
 
@@ -99,7 +127,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder SetPartitionsAssignedHandler(
             Action<Consumer, List<TopicPartition>> partitionsAssignedHandler)
         {
-            this.partitionAssignmentHandler = partitionsAssignedHandler;
+            this.PartitionAssignmentHandler = partitionsAssignedHandler;
             return this;
         }
 
@@ -108,7 +136,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder SetStatisticsHandler(Action<Consumer, string> statisticsHandler)
         {
-            this.statsHandler = statisticsHandler;
+            this.StatisticsHandler = statisticsHandler;
             return this;
         }
 
@@ -117,7 +145,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder SetErrorHandler(Action<Consumer, Error> errorHandler)
         {
-            this.errorHandler = errorHandler;
+            this.ErrorHandler = errorHandler;
             return this;
         }
 
@@ -126,14 +154,14 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder SetLogHandler(Action<Consumer, LogMessage> logHandler)
         {
-            this.logHandler = logHandler;
+            this.LogHandler = logHandler;
             return this;
         }
 
         /// <summary>
         ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.Build" />.
         /// </summary>
-        public Consumer Build()
+        public virtual Consumer Build()
         {
             return new Consumer(this);
         }
@@ -145,42 +173,85 @@ namespace Confluent.Kafka
     /// </summary>
     public class ConsumerBuilder<TKey, TValue>
     {
-        internal IEnumerable<KeyValuePair<string, string>> config;
-        internal Action<Consumer<TKey, TValue>, Error> errorHandler;
-        internal Action<Consumer<TKey, TValue>, LogMessage> logHandler;
-        internal Action<Consumer<TKey, TValue>, string> statisticsHandler;
-        internal Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentHandler;
-        internal Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentRevokedHandler;
-        internal Action<Consumer<TKey, TValue>, CommittedOffsets> offsetsCommittedHandler;
+        /// <summary>
+        ///     The config dictionary.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
 
-        internal IDeserializer<TKey> keyDeserializer;
-        internal IDeserializer<TValue> valueDeserializer;
-        internal IAsyncDeserializer<TKey> asyncKeyDeserializer;
-        internal IAsyncDeserializer<TValue> asyncValueDeserializer;
+        /// <summary>
+        ///     The configured error handler.
+        /// </summary>
+        public Action<Consumer<TKey, TValue>, Error> ErrorHandler { get; set; }
+
+        /// <summary>
+        ///     The configured log handler.
+        /// </summary>
+        public Action<Consumer<TKey, TValue>, LogMessage> LogHandler { get; set; }
+
+        /// <summary>
+        ///     The configured statistics handler.
+        /// </summary>
+        public Action<Consumer<TKey, TValue>, string> StatisticsHandler { get; set; }
+
+        /// <summary>
+        ///     The configured partition assignment handler.
+        /// </summary>
+        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionAssignmentHandler { get; set; }
+
+        /// <summary>
+        ///     The configured partition assignment revoked handler.
+        /// </summary>
+        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionAssignmentRevokedHandler { get; set; }
+
+        /// <summary>
+        ///     The configured offsets committed handler.
+        /// </summary>
+        public Action<Consumer<TKey, TValue>, CommittedOffsets> OffsetsCommittedHandler { get; set; }
+
+
+        /// <summary>
+        ///     The configured key deserializer.
+        /// </summary>
+        public IDeserializer<TKey> KeyDeserializer { get; set; }
+
+        /// <summary>
+        ///     The configured value deserializer.
+        /// </summary>
+        public IDeserializer<TValue> ValueDeserializer { get; set; }
+
+        /// <summary>
+        ///     The configured async key deserializer.
+        /// </summary>
+        public IAsyncDeserializer<TKey> AsyncKeyDeserializer { get; set; }
+
+        /// <summary>
+        ///     The configured async value deserializer.
+        /// </summary>
+        public IAsyncDeserializer<TValue> AsyncValueDeserializer { get; set; }
 
         internal ConsumerBase.Config ConstructBaseConfig(Consumer<TKey, TValue> consumer)
         {
             return new ConsumerBase.Config
             {
-                config = config,
-                errorHandler = this.errorHandler == null
+                config = Config,
+                errorHandler = this.ErrorHandler == null
                     ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
-                    : error => this.errorHandler(consumer, error),
-                logHandler = this.logHandler == null
+                    : error => this.ErrorHandler(consumer, error),
+                logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
-                    : logMessage => this.logHandler(consumer, logMessage),
-                statsHandler = this.statisticsHandler == null
+                    : logMessage => this.LogHandler(consumer, logMessage),
+                statsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
-                    : stats => this.statisticsHandler(consumer, stats),
-                partitionAssignmentRevokedHandler = this.partitionAssignmentRevokedHandler == null
+                    : stats => this.StatisticsHandler(consumer, stats),
+                partitionAssignmentRevokedHandler = this.PartitionAssignmentRevokedHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.partitionAssignmentRevokedHandler(consumer, partitions),
-                partitionAssignmentHandler = this.partitionAssignmentHandler == null
+                    : partitions => this.PartitionAssignmentRevokedHandler(consumer, partitions),
+                partitionAssignmentHandler = this.PartitionAssignmentHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.partitionAssignmentHandler(consumer, partitions),
-                offsetsCommittedHandler = this.offsetsCommittedHandler == null
+                    : partitions => this.PartitionAssignmentHandler(consumer, partitions),
+                offsetsCommittedHandler = this.OffsetsCommittedHandler == null
                     ? default(Action<CommittedOffsets>)
-                    : offsets => this.offsetsCommittedHandler(consumer, offsets)
+                    : offsets => this.OffsetsCommittedHandler(consumer, offsets)
             };
         }
 
@@ -197,7 +268,7 @@ namespace Confluent.Kafka
         /// </param>
         public ConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
-            this.config = config;
+            this.Config = config;
         }
 
         /// <summary>
@@ -211,7 +282,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetOffsetsCommittedHandler(
             Action<Consumer<TKey, TValue>, CommittedOffsets> offsetsCommittedHandler)
         {
-            this.offsetsCommittedHandler = offsetsCommittedHandler;
+            this.OffsetsCommittedHandler = offsetsCommittedHandler;
             return this;
         }
 
@@ -231,7 +302,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetPartitionAssignmentRevokedHandler(
             Action<Consumer<TKey,TValue>, List<TopicPartition>> partitionAssignmentRevokedHandler)
         {
-            this.partitionAssignmentRevokedHandler = partitionAssignmentRevokedHandler;
+            this.PartitionAssignmentRevokedHandler = partitionAssignmentRevokedHandler;
             return this;
         }
 
@@ -253,7 +324,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetPartitionAssignmentHandler(
             Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentHandler)
         {
-            this.partitionAssignmentHandler = partitionAssignmentHandler;
+            this.PartitionAssignmentHandler = partitionAssignmentHandler;
             return this;
         }
 
@@ -271,7 +342,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetStatisticsHandler(
             Action<Consumer<TKey, TValue>, string> statisticsHandler)
         {
-            this.statisticsHandler = statisticsHandler;
+            this.StatisticsHandler = statisticsHandler;
             return this;
         }
 
@@ -287,7 +358,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetErrorHandler(
             Action<Consumer<TKey, TValue>, Error> errorHandler)
         {
-            this.errorHandler = errorHandler;
+            this.ErrorHandler = errorHandler;
             return this;
         }
 
@@ -313,7 +384,7 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetLogHandler(
             Action<Consumer<TKey, TValue>, LogMessage> logHandler)
         {
-            this.logHandler = logHandler;
+            this.LogHandler = logHandler;
             return this;
         }
 
@@ -322,7 +393,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetKeyDeserializer(IDeserializer<TKey> deserializer)
         {
-            this.keyDeserializer = deserializer;
+            this.KeyDeserializer = deserializer;
             return this;
         }
 
@@ -331,32 +402,32 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetValueDeserializer(IDeserializer<TValue> deserializer)
         {
-            this.valueDeserializer = deserializer;
+            this.ValueDeserializer = deserializer;
             return this;
         }
 
         /// <summary>
-        ///     Set the deserializer to use to deserialize keys.
+        ///     Set the async deserializer to use to deserialize keys.
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetKeyDeserializer(IAsyncDeserializer<TKey> deserializer)
         {
-            this.asyncKeyDeserializer = deserializer;
+            this.AsyncKeyDeserializer = deserializer;
             return this;
         }
 
         /// <summary>
-        ///     Set the deserializer to use to deserialize values.
+        ///     Set the async deserializer to use to deserialize values.
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetValueDeserializer(IAsyncDeserializer<TValue> deserializer)
         {
-            this.asyncValueDeserializer = deserializer;
+            this.AsyncValueDeserializer = deserializer;
             return this;
         }
 
         /// <summary>
         ///     Build a new Consumer instance.
         /// </summary>
-        public Consumer<TKey, TValue> Build()
+        public virtual Consumer<TKey, TValue> Build()
         {
             return new Consumer<TKey, TValue>(this);
         }

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -1,0 +1,364 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka.Impl;
+using Confluent.Kafka.Internal;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     A builder class for <see cref="Consumer" /> instances.
+    /// </summary>
+    public class ConsumerBuilder
+    {
+        internal IEnumerable<KeyValuePair<string, string>> config;
+        internal Action<Consumer, Error> errorHandler;
+        internal Action<Consumer, LogMessage> logHandler;
+        internal Action<Consumer, string> statsHandler;
+        internal Action<Consumer, List<TopicPartition>> partitionAssignmentHandler;
+        internal Action<Consumer, List<TopicPartition>> partitionAssignmentRevokedHandler;
+        internal Action<Consumer, CommittedOffsets> offsetsCommittedHandler;
+
+        internal ConsumerBase.Config ConstructBaseConfig(Consumer consumer)
+        {
+            return new ConsumerBase.Config
+            {
+                config = config,
+                errorHandler = this.errorHandler == null
+                    ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
+                    : error => this.errorHandler(consumer, error),
+                logHandler = this.logHandler == null
+                    ? default(Action<LogMessage>)
+                    : logMessage => this.logHandler(consumer, logMessage),
+                statsHandler = this.statsHandler == null
+                    ? default(Action<string>)
+                    : stats => this.statsHandler(consumer, stats),
+                partitionAssignmentRevokedHandler = this.partitionAssignmentRevokedHandler == null
+                    ? default(Action<List<TopicPartition>>)
+                    : partitions => this.partitionAssignmentRevokedHandler(consumer, partitions),
+                partitionAssignmentHandler = this.partitionAssignmentHandler == null
+                    ? default(Action<List<TopicPartition>>)
+                    : partitions => this.partitionAssignmentHandler(consumer, partitions),
+                offsetsCommittedHandler = this.offsetsCommittedHandler == null
+                    ? default(Action<CommittedOffsets>)
+                    : offsets => this.offsetsCommittedHandler(consumer, offsets)
+            };
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.ConsumerBuilder(IEnumerable{KeyValuePair{string, string}})" />.
+        /// </summary>
+        public ConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config)
+        {
+            this.config = config;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetOffsetsCommittedHandler(Action{Consumer{TKey,TValue}, CommittedOffsets})" />.
+        /// </summary>
+        public ConsumerBuilder SetOffsetsCommittedHandler(
+            Action<Consumer, CommittedOffsets> offsetsCommittedHandler)
+        {
+            this.offsetsCommittedHandler = offsetsCommittedHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionAssignmentRevokedHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
+        /// </summary>
+        public ConsumerBuilder SetPartitionsRevokedHandler(
+            Action<Consumer, List<TopicPartition>> partitionsRevokedHandler)
+        {
+            this.partitionAssignmentRevokedHandler = partitionsRevokedHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionAssignmentHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
+        /// </summary>
+        public ConsumerBuilder SetPartitionsAssignedHandler(
+            Action<Consumer, List<TopicPartition>> partitionsAssignedHandler)
+        {
+            this.partitionAssignmentHandler = partitionsAssignedHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetStatisticsHandler(Action{Consumer{TKey,TValue}, string})" />.
+        /// </summary>
+        public ConsumerBuilder SetStatisticsHandler(Action<Consumer, string> statisticsHandler)
+        {
+            this.statsHandler = statisticsHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetErrorHandler(Action{Consumer{TKey,TValue}, Error})" />.
+        /// </summary>
+        public ConsumerBuilder SetErrorHandler(Action<Consumer, Error> errorHandler)
+        {
+            this.errorHandler = errorHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetLogHandler(Action{Consumer{TKey,TValue}, LogMessage})" />.
+        /// </summary>
+        public ConsumerBuilder SetLogHandler(Action<Consumer, LogMessage> logHandler)
+        {
+            this.logHandler = logHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.Build" />.
+        /// </summary>
+        public Consumer Build()
+        {
+            return new Consumer(this);
+        }
+    }
+
+
+    /// <summary>
+    ///     A builder class for <see cref="Consumer{TKey,TValue}" /> instances.
+    /// </summary>
+    public class ConsumerBuilder<TKey, TValue>
+    {
+        internal IEnumerable<KeyValuePair<string, string>> config;
+        internal Action<Consumer<TKey, TValue>, Error> errorHandler;
+        internal Action<Consumer<TKey, TValue>, LogMessage> logHandler;
+        internal Action<Consumer<TKey, TValue>, string> statisticsHandler;
+        internal Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentHandler;
+        internal Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentRevokedHandler;
+        internal Action<Consumer<TKey, TValue>, CommittedOffsets> offsetsCommittedHandler;
+
+        internal IDeserializer<TKey> keyDeserializer;
+        internal IDeserializer<TValue> valueDeserializer;
+        internal IAsyncDeserializer<TKey> asyncKeyDeserializer;
+        internal IAsyncDeserializer<TValue> asyncValueDeserializer;
+
+        internal ConsumerBase.Config ConstructBaseConfig(Consumer<TKey, TValue> consumer)
+        {
+            return new ConsumerBase.Config
+            {
+                config = config,
+                errorHandler = this.errorHandler == null
+                    ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
+                    : error => this.errorHandler(consumer, error),
+                logHandler = this.logHandler == null
+                    ? default(Action<LogMessage>)
+                    : logMessage => this.logHandler(consumer, logMessage),
+                statsHandler = this.statisticsHandler == null
+                    ? default(Action<string>)
+                    : stats => this.statisticsHandler(consumer, stats),
+                partitionAssignmentRevokedHandler = this.partitionAssignmentRevokedHandler == null
+                    ? default(Action<List<TopicPartition>>)
+                    : partitions => this.partitionAssignmentRevokedHandler(consumer, partitions),
+                partitionAssignmentHandler = this.partitionAssignmentHandler == null
+                    ? default(Action<List<TopicPartition>>)
+                    : partitions => this.partitionAssignmentHandler(consumer, partitions),
+                offsetsCommittedHandler = this.offsetsCommittedHandler == null
+                    ? default(Action<CommittedOffsets>)
+                    : offsets => this.offsetsCommittedHandler(consumer, offsets)
+            };
+        }
+
+        /// <summary>
+        ///     Initialize a new ConsumerBuilder instance.
+        /// </summary>
+        /// <param name="config">
+        ///     A collection of librdkafka configuration parameters 
+        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
+        ///     and parameters specific to this client (refer to: 
+        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
+        ///     specified.
+        /// </param>
+        public ConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config)
+        {
+            this.config = config;
+        }
+
+        /// <summary>
+        ///     A handler that is called to report the result of (automatic) offset 
+        ///     commits. It is not called as a result of the use of the Commit method.
+        /// </summary>
+        /// <remarks>
+        ///     <paramref name="offsetsCommittedHandler" /> executes as a side-effect of
+        ///     the Consumer.Consume call (on the same thread).
+        /// </remarks>
+        public ConsumerBuilder<TKey, TValue> SetOffsetsCommittedHandler(
+            Action<Consumer<TKey, TValue>, CommittedOffsets> offsetsCommittedHandler)
+        {
+            this.offsetsCommittedHandler = offsetsCommittedHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the partition assignment revoked handler.
+        /// 
+        ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Unassign" /> or 
+        ///     <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
+        ///     (or other overload) method in your handler, all partitions will be  automatically
+        ///     unassigned. This default behavior will not occur if you call Unassign (or Assign)
+        ///     yourself.
+        /// </summary>
+        /// <remarks>
+        ///     <paramref name="partitionAssignmentRevokedHandler" /> executes as a side-effect of
+        ///     the Consumer.Consume call (on the same thread).
+        /// </remarks>
+        public ConsumerBuilder<TKey, TValue> SetPartitionAssignmentRevokedHandler(
+            Action<Consumer<TKey,TValue>, List<TopicPartition>> partitionAssignmentRevokedHandler)
+        {
+            this.partitionAssignmentRevokedHandler = partitionAssignmentRevokedHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the partition assignment handler.
+        /// 
+        ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
+        ///     method (or another overload of this method) in this handler, or do not specify a partition assignment handler,
+        ///     the consumer will be automatically assigned to the partition assignment set provided by the consumer group and
+        ///     consumption will resume from the last committed offset for each partition, or if there is no committed offset,
+        ///     in accordance with the `auto.offset.reset` configuration property. This default behavior will not occur if
+        ///     you call Assign yourself in the handler. The set of partitions you assign to is not required to match the
+        ///     assignment provided by the consumer group, but typically will.
+        /// </summary>
+        /// <remarks>
+        ///     <paramref name="partitionAssignmentHandler" /> executes as a side-effect of
+        ///     the Consumer.Consume call (on the same thread).
+        /// </remarks>
+        public ConsumerBuilder<TKey, TValue> SetPartitionAssignmentHandler(
+            Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentHandler)
+        {
+            this.partitionAssignmentHandler = partitionAssignmentHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call on librdkafka statistics events. Statistics are provided as a JSON formatted string as defined here:
+        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
+        /// </summary>
+        /// <remarks>
+        ///     You can enable statistics and set the statistics interval
+        ///     using the statistics.interval.ms configuration parameter
+        ///     (disabled by default).
+        ///
+        ///     Executes as a side-effect of the Consume method (on the same thread).
+        /// </remarks>
+        public ConsumerBuilder<TKey, TValue> SetStatisticsHandler(
+            Action<Consumer<TKey, TValue>, string> statisticsHandler)
+        {
+            this.statisticsHandler = statisticsHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call on error events e.g. connection failures or all
+        ///     brokers down. Note that the client will try to automatically recover from
+        ///     errors that are not marked as fatal - such errors should be interpreted
+        ///     as informational rather than catastrophic.
+        /// </summary>
+        /// <remarks>
+        ///     Executes as a side-effect of the Consume method (on the same thread).
+        /// </remarks>
+        public ConsumerBuilder<TKey, TValue> SetErrorHandler(
+            Action<Consumer<TKey, TValue>, Error> errorHandler)
+        {
+            this.errorHandler = errorHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call when there is information available
+        ///     to be logged. If not specified, a default callback that writes
+        ///     to stderr will be used.
+        /// </summary>
+        /// <remarks>
+        ///     By default not many log messages are generated.
+        ///
+        ///     For more verbose logging, specify one or more debug contexts
+        ///     using the 'debug' configuration property. The 'log_level'
+        ///     configuration property is also relevant, however logging is
+        ///     verbose by default given a debug context has been specified,
+        ///     so you typically shouldn't adjust this value.
+        ///
+        ///     Warning: Log handlers are called spontaneously from internal
+        ///     librdkafka threads and the application must not call any
+        ///     Confluent.Kafka APIs from within a log handler or perform any
+        ///     prolonged operations.
+        /// </remarks>
+        public ConsumerBuilder<TKey, TValue> SetLogHandler(
+            Action<Consumer<TKey, TValue>, LogMessage> logHandler)
+        {
+            this.logHandler = logHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the deserializer to use to deserialize keys.
+        /// </summary>
+        public ConsumerBuilder<TKey, TValue> SetKeyDeserializer(IDeserializer<TKey> deserializer)
+        {
+            this.keyDeserializer = deserializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the deserializer to use to deserialize values.
+        /// </summary>
+        public ConsumerBuilder<TKey, TValue> SetValueDeserializer(IDeserializer<TValue> deserializer)
+        {
+            this.valueDeserializer = deserializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the deserializer to use to deserialize keys.
+        /// </summary>
+        public ConsumerBuilder<TKey, TValue> SetKeyDeserializer(IAsyncDeserializer<TKey> deserializer)
+        {
+            this.asyncKeyDeserializer = deserializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the deserializer to use to deserialize values.
+        /// </summary>
+        public ConsumerBuilder<TKey, TValue> SetValueDeserializer(IAsyncDeserializer<TValue> deserializer)
+        {
+            this.asyncValueDeserializer = deserializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Build a new Consumer instance.
+        /// </summary>
+        public Consumer<TKey, TValue> Build()
+        {
+            return new Consumer<TKey, TValue>(this);
+        }
+    }
+}

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -52,14 +52,14 @@ namespace Confluent.Kafka
         public Action<Consumer, string> StatisticsHandler { get; set; }
 
         /// <summary>
-        ///     The configured partition assignment handler.
+        ///     The configured partitions assigned handler.
         /// </summary>
-        public Action<Consumer, List<TopicPartition>> PartitionAssignmentHandler { get; set; }
+        public Action<Consumer, List<TopicPartition>> PartitionsAssignedHandler { get; set; }
 
         /// <summary>
-        ///     The configured partition assignment revoked handler.
+        ///     The configured partitions revoked handler.
         /// </summary>
-        public Action<Consumer, List<TopicPartition>> PartitionAssignmentRevokedHandler { get; set; }
+        public Action<Consumer, List<TopicPartition>> PartitionsRevokedHandler { get; set; }
 
         /// <summary>
         ///     The configured offsets committed handler.
@@ -81,12 +81,12 @@ namespace Confluent.Kafka
                 statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
                     : stats => this.StatisticsHandler(consumer, stats),
-                partitionAssignmentRevokedHandler = this.PartitionAssignmentRevokedHandler == null
+                partitionsRevokedHandler = this.PartitionsRevokedHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionAssignmentRevokedHandler(consumer, partitions),
-                partitionAssignmentHandler = this.PartitionAssignmentHandler == null
+                    : partitions => this.PartitionsRevokedHandler(consumer, partitions),
+                partitionsAssignedHandler = this.PartitionsAssignedHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionAssignmentHandler(consumer, partitions),
+                    : partitions => this.PartitionsAssignedHandler(consumer, partitions),
                 offsetsCommittedHandler = this.OffsetsCommittedHandler == null
                     ? default(Action<CommittedOffsets>)
                     : offsets => this.OffsetsCommittedHandler(consumer, offsets)
@@ -112,22 +112,22 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionAssignmentRevokedHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionsRevokedHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
         /// </summary>
         public ConsumerBuilder SetPartitionsRevokedHandler(
             Action<Consumer, List<TopicPartition>> partitionsRevokedHandler)
         {
-            this.PartitionAssignmentRevokedHandler = partitionsRevokedHandler;
+            this.PartitionsRevokedHandler = partitionsRevokedHandler;
             return this;
         }
 
         /// <summary>
-        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionAssignmentHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
+        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionsAssignedHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
         /// </summary>
         public ConsumerBuilder SetPartitionsAssignedHandler(
             Action<Consumer, List<TopicPartition>> partitionsAssignedHandler)
         {
-            this.PartitionAssignmentHandler = partitionsAssignedHandler;
+            this.PartitionsAssignedHandler = partitionsAssignedHandler;
             return this;
         }
 
@@ -194,14 +194,14 @@ namespace Confluent.Kafka
         public Action<Consumer<TKey, TValue>, string> StatisticsHandler { get; set; }
 
         /// <summary>
-        ///     The configured partition assignment handler.
+        ///     The configured partitions assigned handler.
         /// </summary>
-        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionAssignmentHandler { get; set; }
+        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionsAssignedHandler { get; set; }
 
         /// <summary>
-        ///     The configured partition assignment revoked handler.
+        ///     The configured partitions revoked handler.
         /// </summary>
-        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionAssignmentRevokedHandler { get; set; }
+        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionsRevokedHandler { get; set; }
 
         /// <summary>
         ///     The configured offsets committed handler.
@@ -243,12 +243,12 @@ namespace Confluent.Kafka
                 statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
                     : stats => this.StatisticsHandler(consumer, stats),
-                partitionAssignmentRevokedHandler = this.PartitionAssignmentRevokedHandler == null
+                partitionsRevokedHandler = this.PartitionsRevokedHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionAssignmentRevokedHandler(consumer, partitions),
-                partitionAssignmentHandler = this.PartitionAssignmentHandler == null
+                    : partitions => this.PartitionsRevokedHandler(consumer, partitions),
+                partitionsAssignedHandler = this.PartitionsAssignedHandler == null
                     ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionAssignmentHandler(consumer, partitions),
+                    : partitions => this.PartitionsAssignedHandler(consumer, partitions),
                 offsetsCommittedHandler = this.OffsetsCommittedHandler == null
                     ? default(Action<CommittedOffsets>)
                     : offsets => this.OffsetsCommittedHandler(consumer, offsets)
@@ -287,7 +287,7 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Set the partition assignment revoked handler.
+        ///     Set the partitions revoked handler.
         /// 
         ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Unassign" /> or 
         ///     <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
@@ -296,21 +296,21 @@ namespace Confluent.Kafka
         ///     yourself.
         /// </summary>
         /// <remarks>
-        ///     <paramref name="partitionAssignmentRevokedHandler" /> executes as a side-effect of
+        ///     <paramref name="partitionsRevokedHandler" /> executes as a side-effect of
         ///     the Consumer.Consume call (on the same thread).
         /// </remarks>
-        public ConsumerBuilder<TKey, TValue> SetPartitionAssignmentRevokedHandler(
-            Action<Consumer<TKey,TValue>, List<TopicPartition>> partitionAssignmentRevokedHandler)
+        public ConsumerBuilder<TKey, TValue> SetPartitionsRevokedHandler(
+            Action<Consumer<TKey,TValue>, List<TopicPartition>> partitionsRevokedHandler)
         {
-            this.PartitionAssignmentRevokedHandler = partitionAssignmentRevokedHandler;
+            this.PartitionsRevokedHandler = partitionsRevokedHandler;
             return this;
         }
 
         /// <summary>
-        ///     Set the partition assignment handler.
+        ///     Set the partitions assiged handler.
         /// 
         ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
-        ///     method (or another overload of this method) in this handler, or do not specify a partition assignment handler,
+        ///     method (or another overload of this method) in this handler, or do not specify a partitions assigned handler,
         ///     the consumer will be automatically assigned to the partition assignment set provided by the consumer group and
         ///     consumption will resume from the last committed offset for each partition, or if there is no committed offset,
         ///     in accordance with the `auto.offset.reset` configuration property. This default behavior will not occur if
@@ -318,13 +318,13 @@ namespace Confluent.Kafka
         ///     assignment provided by the consumer group, but typically will.
         /// </summary>
         /// <remarks>
-        ///     <paramref name="partitionAssignmentHandler" /> executes as a side-effect of
+        ///     <paramref name="partitionsAssignedHandler" /> executes as a side-effect of
         ///     the Consumer.Consume call (on the same thread).
         /// </remarks>
-        public ConsumerBuilder<TKey, TValue> SetPartitionAssignmentHandler(
-            Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionAssignmentHandler)
+        public ConsumerBuilder<TKey, TValue> SetPartitionsAssignedHandler(
+            Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionsAssignedHandler)
         {
-            this.PartitionAssignmentHandler = partitionAssignmentHandler;
+            this.PartitionsAssignedHandler = partitionsAssignedHandler;
             return this;
         }
 

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -193,8 +193,9 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Set the handler to call on librdkafka statistics events. Statistics are provided as a JSON formatted string as defined here:
-        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
+        ///     Set the handler to call on statistics events. Statistics 
+        ///     are provided as a JSON formatted string as defined here:
+        ///     https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
         /// </summary>
         /// <remarks>
         ///     You can enable statistics and set the statistics interval
@@ -206,6 +207,10 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetStatisticsHandler(
             Action<Consumer<TKey, TValue>, string> statisticsHandler)
         {
+            if (this.StatisticsHandler != null)
+            {
+                throw new ArgumentException("Statistics handler may not be specified more than once.");
+            }
             this.StatisticsHandler = statisticsHandler;
             return this;
         }
@@ -213,7 +218,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Set the handler to call on error events e.g. connection failures or all
         ///     brokers down. Note that the client will try to automatically recover from
-        ///     errors that are not marked as fatal - such errors should be interpreted
+        ///     errors that are not marked as fatal. Non-fatal errors should be interpreted
         ///     as informational rather than catastrophic.
         /// </summary>
         /// <remarks>
@@ -222,6 +227,10 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetErrorHandler(
             Action<Consumer<TKey, TValue>, Error> errorHandler)
         {
+            if (this.ErrorHandler != null)
+            {
+                throw new ArgumentException("Error handler may not be specified more than once.");
+            }
             this.ErrorHandler = errorHandler;
             return this;
         }
@@ -235,10 +244,7 @@ namespace Confluent.Kafka
         ///     By default not many log messages are generated.
         ///
         ///     For more verbose logging, specify one or more debug contexts
-        ///     using the 'debug' configuration property. The 'log_level'
-        ///     configuration property is also relevant, however logging is
-        ///     verbose by default given a debug context has been specified,
-        ///     so you typically shouldn't adjust this value.
+        ///     using the 'debug' configuration property.
         ///
         ///     Warning: Log handlers are called spontaneously from internal
         ///     librdkafka threads and the application must not call any
@@ -248,6 +254,10 @@ namespace Confluent.Kafka
         public ConsumerBuilder<TKey, TValue> SetLogHandler(
             Action<Consumer<TKey, TValue>, LogMessage> logHandler)
         {
+            if (this.LogHandler != null)
+            {
+                throw new ArgumentException("Log handler may not be specified more than once.");
+            }
             this.LogHandler = logHandler;
             return this;
         }
@@ -257,6 +267,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetKeyDeserializer(IDeserializer<TKey> deserializer)
         {
+            if (this.KeyDeserializer != null || this.AsyncKeyDeserializer != null)
+            {
+                throw new ArgumentException("Key deserializer may not be specified more than once.");
+            }
             this.KeyDeserializer = deserializer;
             return this;
         }
@@ -266,6 +280,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetValueDeserializer(IDeserializer<TValue> deserializer)
         {
+            if (this.ValueDeserializer != null || this.AsyncValueDeserializer != null)
+            {
+                throw new ArgumentException("Value deserializer may not be specified more than once.");
+            }
             this.ValueDeserializer = deserializer;
             return this;
         }
@@ -275,6 +293,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetKeyDeserializer(IAsyncDeserializer<TKey> deserializer)
         {
+            if (this.KeyDeserializer != null || this.AsyncKeyDeserializer != null)
+            {
+                throw new ArgumentException("Key deserializer may not be specified more than once.");
+            }
             this.AsyncKeyDeserializer = deserializer;
             return this;
         }
@@ -284,6 +306,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumerBuilder<TKey, TValue> SetValueDeserializer(IAsyncDeserializer<TValue> deserializer)
         {
+            if (this.ValueDeserializer != null || this.AsyncValueDeserializer != null)
+            {
+                throw new ArgumentException("Value deserializer may not be specified more than once.");
+            }
             this.AsyncValueDeserializer = deserializer;
             return this;
         }

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -34,37 +34,22 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The config dictionary.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+        internal protected IEnumerable<KeyValuePair<string, string>> Config { get; set; }
 
         /// <summary>
         ///     The configured error handler.
         /// </summary>
-        public Action<Consumer, Error> ErrorHandler { get; set; }
+        internal protected Action<Consumer, Error> ErrorHandler { get; set; }
 
         /// <summary>
         ///     The configured log handler.
         /// </summary>
-        public Action<Consumer, LogMessage> LogHandler { get; set; }
+        internal protected Action<Consumer, LogMessage> LogHandler { get; set; }
 
         /// <summary>
         ///     The configured statistics handler.
         /// </summary>
-        public Action<Consumer, string> StatisticsHandler { get; set; }
-
-        /// <summary>
-        ///     The configured partitions assigned handler.
-        /// </summary>
-        public Action<Consumer, List<TopicPartition>> PartitionsAssignedHandler { get; set; }
-
-        /// <summary>
-        ///     The configured partitions revoked handler.
-        /// </summary>
-        public Action<Consumer, List<TopicPartition>> PartitionsRevokedHandler { get; set; }
-
-        /// <summary>
-        ///     The configured offsets committed handler.
-        /// </summary>
-        public Action<Consumer, CommittedOffsets> OffsetsCommittedHandler { get; set; }
+        internal protected Action<Consumer, string> StatisticsHandler { get; set; }
 
 
         internal ConsumerBase.Config ConstructBaseConfig(Consumer consumer)
@@ -80,16 +65,7 @@ namespace Confluent.Kafka
                     : logMessage => this.LogHandler(consumer, logMessage),
                 statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
-                    : stats => this.StatisticsHandler(consumer, stats),
-                partitionsRevokedHandler = this.PartitionsRevokedHandler == null
-                    ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionsRevokedHandler(consumer, partitions),
-                partitionsAssignedHandler = this.PartitionsAssignedHandler == null
-                    ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionsAssignedHandler(consumer, partitions),
-                offsetsCommittedHandler = this.OffsetsCommittedHandler == null
-                    ? default(Action<CommittedOffsets>)
-                    : offsets => this.OffsetsCommittedHandler(consumer, offsets)
+                    : stats => this.StatisticsHandler(consumer, stats)
             };
         }
 
@@ -99,36 +75,6 @@ namespace Confluent.Kafka
         public ConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
             this.Config = config;
-        }
-
-        /// <summary>
-        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetOffsetsCommittedHandler(Action{Consumer{TKey,TValue}, CommittedOffsets})" />.
-        /// </summary>
-        public ConsumerBuilder SetOffsetsCommittedHandler(
-            Action<Consumer, CommittedOffsets> offsetsCommittedHandler)
-        {
-            this.OffsetsCommittedHandler = offsetsCommittedHandler;
-            return this;
-        }
-
-        /// <summary>
-        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionsRevokedHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
-        /// </summary>
-        public ConsumerBuilder SetPartitionsRevokedHandler(
-            Action<Consumer, List<TopicPartition>> partitionsRevokedHandler)
-        {
-            this.PartitionsRevokedHandler = partitionsRevokedHandler;
-            return this;
-        }
-
-        /// <summary>
-        ///     Refer to <see cref="ConsumerBuilder{TKey,TValue}.SetPartitionsAssignedHandler(Action{Consumer{TKey,TValue}, List{TopicPartition}})" />.
-        /// </summary>
-        public ConsumerBuilder SetPartitionsAssignedHandler(
-            Action<Consumer, List<TopicPartition>> partitionsAssignedHandler)
-        {
-            this.PartitionsAssignedHandler = partitionsAssignedHandler;
-            return this;
         }
 
         /// <summary>
@@ -176,58 +122,42 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The config dictionary.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+        internal protected IEnumerable<KeyValuePair<string, string>> Config { get; set; }
 
         /// <summary>
         ///     The configured error handler.
         /// </summary>
-        public Action<Consumer<TKey, TValue>, Error> ErrorHandler { get; set; }
+        internal protected Action<Consumer<TKey, TValue>, Error> ErrorHandler { get; set; }
 
         /// <summary>
         ///     The configured log handler.
         /// </summary>
-        public Action<Consumer<TKey, TValue>, LogMessage> LogHandler { get; set; }
+        internal protected Action<Consumer<TKey, TValue>, LogMessage> LogHandler { get; set; }
 
         /// <summary>
         ///     The configured statistics handler.
         /// </summary>
-        public Action<Consumer<TKey, TValue>, string> StatisticsHandler { get; set; }
-
-        /// <summary>
-        ///     The configured partitions assigned handler.
-        /// </summary>
-        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionsAssignedHandler { get; set; }
-
-        /// <summary>
-        ///     The configured partitions revoked handler.
-        /// </summary>
-        public Action<Consumer<TKey, TValue>, List<TopicPartition>> PartitionsRevokedHandler { get; set; }
-
-        /// <summary>
-        ///     The configured offsets committed handler.
-        /// </summary>
-        public Action<Consumer<TKey, TValue>, CommittedOffsets> OffsetsCommittedHandler { get; set; }
-
+        internal protected Action<Consumer<TKey, TValue>, string> StatisticsHandler { get; set; }
 
         /// <summary>
         ///     The configured key deserializer.
         /// </summary>
-        public IDeserializer<TKey> KeyDeserializer { get; set; }
+        internal protected IDeserializer<TKey> KeyDeserializer { get; set; }
 
         /// <summary>
         ///     The configured value deserializer.
         /// </summary>
-        public IDeserializer<TValue> ValueDeserializer { get; set; }
+        internal protected IDeserializer<TValue> ValueDeserializer { get; set; }
 
         /// <summary>
         ///     The configured async key deserializer.
         /// </summary>
-        public IAsyncDeserializer<TKey> AsyncKeyDeserializer { get; set; }
+        internal protected IAsyncDeserializer<TKey> AsyncKeyDeserializer { get; set; }
 
         /// <summary>
         ///     The configured async value deserializer.
         /// </summary>
-        public IAsyncDeserializer<TValue> AsyncValueDeserializer { get; set; }
+        internal protected IAsyncDeserializer<TValue> AsyncValueDeserializer { get; set; }
 
         internal ConsumerBase.Config ConstructBaseConfig(Consumer<TKey, TValue> consumer)
         {
@@ -242,16 +172,7 @@ namespace Confluent.Kafka
                     : logMessage => this.LogHandler(consumer, logMessage),
                 statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
-                    : stats => this.StatisticsHandler(consumer, stats),
-                partitionsRevokedHandler = this.PartitionsRevokedHandler == null
-                    ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionsRevokedHandler(consumer, partitions),
-                partitionsAssignedHandler = this.PartitionsAssignedHandler == null
-                    ? default(Action<List<TopicPartition>>)
-                    : partitions => this.PartitionsAssignedHandler(consumer, partitions),
-                offsetsCommittedHandler = this.OffsetsCommittedHandler == null
-                    ? default(Action<CommittedOffsets>)
-                    : offsets => this.OffsetsCommittedHandler(consumer, offsets)
+                    : stats => this.StatisticsHandler(consumer, stats)
             };
         }
 
@@ -269,63 +190,6 @@ namespace Confluent.Kafka
         public ConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
             this.Config = config;
-        }
-
-        /// <summary>
-        ///     A handler that is called to report the result of (automatic) offset 
-        ///     commits. It is not called as a result of the use of the Commit method.
-        /// </summary>
-        /// <remarks>
-        ///     <paramref name="offsetsCommittedHandler" /> executes as a side-effect of
-        ///     the Consumer.Consume call (on the same thread).
-        /// </remarks>
-        public ConsumerBuilder<TKey, TValue> SetOffsetsCommittedHandler(
-            Action<Consumer<TKey, TValue>, CommittedOffsets> offsetsCommittedHandler)
-        {
-            this.OffsetsCommittedHandler = offsetsCommittedHandler;
-            return this;
-        }
-
-        /// <summary>
-        ///     Set the partitions revoked handler.
-        /// 
-        ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Unassign" /> or 
-        ///     <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
-        ///     (or other overload) method in your handler, all partitions will be  automatically
-        ///     unassigned. This default behavior will not occur if you call Unassign (or Assign)
-        ///     yourself.
-        /// </summary>
-        /// <remarks>
-        ///     <paramref name="partitionsRevokedHandler" /> executes as a side-effect of
-        ///     the Consumer.Consume call (on the same thread).
-        /// </remarks>
-        public ConsumerBuilder<TKey, TValue> SetPartitionsRevokedHandler(
-            Action<Consumer<TKey,TValue>, List<TopicPartition>> partitionsRevokedHandler)
-        {
-            this.PartitionsRevokedHandler = partitionsRevokedHandler;
-            return this;
-        }
-
-        /// <summary>
-        ///     Set the partitions assiged handler.
-        /// 
-        ///     If you do not call the <see cref="Confluent.Kafka.ConsumerBase.Assign(IEnumerable{TopicPartition})" />
-        ///     method (or another overload of this method) in this handler, or do not specify a partitions assigned handler,
-        ///     the consumer will be automatically assigned to the partition assignment set provided by the consumer group and
-        ///     consumption will resume from the last committed offset for each partition, or if there is no committed offset,
-        ///     in accordance with the `auto.offset.reset` configuration property. This default behavior will not occur if
-        ///     you call Assign yourself in the handler. The set of partitions you assign to is not required to match the
-        ///     assignment provided by the consumer group, but typically will.
-        /// </summary>
-        /// <remarks>
-        ///     <paramref name="partitionsAssignedHandler" /> executes as a side-effect of
-        ///     the Consumer.Consume call (on the same thread).
-        /// </remarks>
-        public ConsumerBuilder<TKey, TValue> SetPartitionsAssignedHandler(
-            Action<Consumer<TKey, TValue>, List<TopicPartition>> partitionsAssignedHandler)
-        {
-            this.PartitionsAssignedHandler = partitionsAssignedHandler;
-            return this;
         }
 
         /// <summary>

--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -25,12 +25,30 @@ namespace Confluent.Kafka
     /// </summary>
     public class DependentProducerBuilder<TKey, TValue>
     {
-        internal Handle handle;
+        /// <summary>
+        ///     The configured client handle.
+        /// </summary>
+        public Handle handle { get; set; }
         
-        internal ISerializer<TKey> keySerializer;
-        internal ISerializer<TValue> valueSerializer;
-        internal IAsyncSerializer<TKey> asyncKeySerializer;
-        internal IAsyncSerializer<TValue> asyncValueSerializer;
+        /// <summary>
+        ///     The configured key serializer.
+        /// </summary>
+        public ISerializer<TKey> KeySerializer { get; set; }
+
+        /// <summary>
+        ///     The configured value serializer.
+        /// </summary>
+        public ISerializer<TValue> ValueSerializer { get; set; }
+
+        /// <summary>
+        ///     The configured async key serializer.
+        /// </summary>
+        public IAsyncSerializer<TKey> AsyncKeySerializer { get; set; }
+
+        /// <summary>
+        ///     The configured async value serializer.
+        /// </summary>
+        public IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
 
 
         /// <summary>
@@ -48,7 +66,7 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetKeySerializer(ISerializer<TKey> serializer)
         {
-            this.keySerializer = serializer;
+            this.KeySerializer = serializer;
             return this;
         }
 
@@ -57,32 +75,32 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
         {
-            this.valueSerializer = serializer;
+            this.ValueSerializer = serializer;
             return this;
         }
 
         /// <summary>
-        ///     The serializer to use to serialize keys.
+        ///     The async serializer to use to serialize keys.
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSerializer<TKey> serializer)
         {
-            this.asyncKeySerializer = serializer;
+            this.AsyncKeySerializer = serializer;
             return this;
         }
 
         /// <summary>
-        ///     The serializer to use to serialize values.
+        ///     The async serializer to use to serialize values.
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
-            this.asyncValueSerializer = serializer;
+            this.AsyncValueSerializer = serializer;
             return this;
         }
 
         /// <summary>
         ///     Build a new Producer instance.
         /// </summary>
-        public Producer<TKey, TValue> Build()
+        public virtual Producer<TKey, TValue> Build()
         {
             return new Producer<TKey, TValue>(this);
         }

--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -1,0 +1,90 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     A builder class for <see cref="Producer{TKey, TValue}" /> instances.
+    /// </summary>
+    public class DependentProducerBuilder<TKey, TValue>
+    {
+        internal Handle handle;
+        
+        internal ISerializer<TKey> keySerializer;
+        internal ISerializer<TValue> valueSerializer;
+        internal IAsyncSerializer<TKey> asyncKeySerializer;
+        internal IAsyncSerializer<TValue> asyncValueSerializer;
+
+
+        /// <summary>
+        ///     An underlying librdkafka client handle that the Producer will use to 
+        ///     make broker requests. The handle must be from another Producer
+        ///     instance (not Consumer or AdminClient).
+        /// </summary>
+        public DependentProducerBuilder(Handle handle)
+        {
+            this.handle = handle;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize keys.
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetKeySerializer(ISerializer<TKey> serializer)
+        {
+            this.keySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
+        {
+            this.valueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize keys.
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSerializer<TKey> serializer)
+        {
+            this.asyncKeySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
+        {
+            this.asyncValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Build a new Producer instance.
+        /// </summary>
+        public Producer<TKey, TValue> Build()
+        {
+            return new Producer<TKey, TValue>(this);
+        }
+    }
+}

--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -21,7 +21,8 @@ using System.Collections.Generic;
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     A builder class for <see cref="Producer{TKey, TValue}" /> instances.
+    ///     A builder class for <see cref="Producer{TKey, TValue}" /> instances
+    ///     that leverage an existing client handle.
     /// </summary>
     public class DependentProducerBuilder<TKey, TValue>
     {

--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -29,7 +29,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The configured client handle.
         /// </summary>
-        public Handle handle { get; set; }
+        public Handle Handle { get; set; }
         
         /// <summary>
         ///     The configured key serializer.
@@ -59,7 +59,7 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder(Handle handle)
         {
-            this.handle = handle;
+            this.Handle = handle;
         }
 
         /// <summary>

--- a/src/Confluent.Kafka/Deserializers.cs
+++ b/src/Confluent.Kafka/Deserializers.cs
@@ -18,7 +18,7 @@ using System;
 using System.Text;
 
 
-namespace Confluent.Kafka
+namespace Confluent.Kafka.Serdes
 {
     /// <summary>
     ///     Deserializers for use with <see cref="Consumer{TKey,TValue}" />.

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -93,6 +93,7 @@ namespace Confluent.Kafka
         ///     Refer to <see cref="Confluent.Kafka.AdminClient.DescribeConfigsAsync(IEnumerable{ConfigResource}, DescribeConfigsOptions)" />
         /// </summary>
         Task<List<DescribeConfigsResult>> DescribeConfigsAsync(IEnumerable<ConfigResource> resources, DescribeConfigsOptions options = null);
+
     }
 
 }

--- a/src/Confluent.Kafka/IClient.cs
+++ b/src/Confluent.Kafka/IClient.cs
@@ -68,59 +68,5 @@ namespace Confluent.Kafka
         ///     that may have been specified a second time.
         /// </returns>
         int AddBrokers(string brokers);
-
-
-        /// <summary>
-        ///     Raised when there is information that should be logged.
-        ///     If not specified, a default callback that writes to stderr
-        ///     will be used.
-        /// </summary>
-        /// <remarks>
-        ///     By default not many log messages are generated.
-        ///
-        ///     For more verbose logging, specify one or more debug contexts
-        ///     using the 'debug' configuration property. The 'log_level'
-        ///     configuration property is also relevant, however logging is
-        ///     verbose by default given a debug context has been specified,
-        ///     so you typically shouldn't adjust this value.
-        ///
-        ///     Warning: Log handlers are called spontaneously from internal
-        ///     librdkafka threads and the application must not call any
-        ///     Confluent.Kafka APIs from within a log handler or perform any
-        ///     prolonged operations.
-        /// </remarks>
-        event EventHandler<LogMessage> OnLog;
-
-
-        /// <summary>
-        ///     Raised on error events e.g. connection failures or all brokers
-        ///     down. Note that the client will try to automatically recover from
-        ///     errors that are not marked as fatal - these errors should be
-        ///     seen as informational rather than catastrophic.
-        /// </summary>
-        /// <remarks>
-        ///     On the Consumer, executes as a side-effect of
-        ///     <see cref="Confluent.Kafka.Consumer.Consume(System.Threading.CancellationToken)" />
-        ///     (on the same thread) and on the Producer and AdminClient, on the
-        ///     background poll thread.
-        /// </remarks>
-        event EventHandler<Error> OnError;
-
-        /// <summary>
-        ///     Raised on librdkafka statistics events - a JSON
-        ///     formatted string as defined here:
-        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
-        /// </summary>
-        /// <remarks>
-        ///     You can enable statistics and set the statistics interval
-        ///     using the statistics.interval.ms configuration parameter
-        ///     (disabled by default).
-        ///
-        ///     On the Consumer, executes as a side-effect of
-        ///     <see cref="Confluent.Kafka.Consumer.Consume(System.Threading.CancellationToken)" />
-        ///     (on the same thread) and on the Producer and AdminClient, on the
-        ///     background poll thread.
-        /// </remarks>
-        event EventHandler<string> OnStatistics;
     }
 }

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 
@@ -25,6 +26,21 @@ namespace Confluent.Kafka
     /// </summary>
     public interface IConsumer : IConsumerBase, IClient
     {
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.SetPartitionsAssignedHandler(Action{IConsumer{TKey,TValue},List{TopicPartition}})" />.
+        /// </summary>
+        void SetPartitionsAssignedHandler(Action<IConsumer, List<TopicPartition>> value);
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.SetPartitionsRevokedHandler(Action{IConsumer{TKey,TValue},List{TopicPartition}})" />.
+        /// </summary>
+        void SetPartitionsRevokedHandler(Action<IConsumer, List<TopicPartition>> value);
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.SetOffsetsCommittedHandler(Action{IConsumer{TKey,TValue},CommittedOffsets})" />.
+        /// </summary>
+        void SetOffsetsCommittedHandler(Action<IConsumer, CommittedOffsets> value);
+
 
         /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.Consumer.Consume(CancellationToken)" />
@@ -46,6 +62,21 @@ namespace Confluent.Kafka
     /// </summary>
     public interface IConsumer<TKey, TValue> : IConsumerBase, IClient
     {
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.SetPartitionsAssignedHandler(Action{IConsumer{TKey,TValue},List{TopicPartition}})" />.
+        /// </summary>
+        void SetPartitionsAssignedHandler(Action<IConsumer<TKey, TValue>, List<TopicPartition>> value);
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.SetPartitionsRevokedHandler(Action{IConsumer{TKey,TValue},List{TopicPartition}})" />.
+        /// </summary>
+        void SetPartitionsRevokedHandler(Action<IConsumer<TKey, TValue>, List<TopicPartition>> value);
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.SetOffsetsCommittedHandler(Action{IConsumer{TKey,TValue},CommittedOffsets})" />.
+        /// </summary>
+        void SetOffsetsCommittedHandler(Action<IConsumer<TKey, TValue>, CommittedOffsets> value);
+
         /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.Consume(CancellationToken)" />
         /// </summary>

--- a/src/Confluent.Kafka/IConsumerBase.cs
+++ b/src/Confluent.Kafka/IConsumerBase.cs
@@ -38,24 +38,6 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.OnPartitionsAssigned" />
-        /// </summary>
-        event EventHandler<List<TopicPartition>> OnPartitionsAssigned;
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.OnPartitionsRevoked" />
-        /// </summary>
-        event EventHandler<List<TopicPartition>> OnPartitionsRevoked;
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.OnOffsetsCommitted" />
-        /// </summary>
-        event EventHandler<CommittedOffsets> OnOffsetsCommitted;
-
-
-        /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.Assignment" />
         /// </summary>
         List<TopicPartition> Assignment { get; }

--- a/src/Confluent.Kafka/IConsumerBase.cs
+++ b/src/Confluent.Kafka/IConsumerBase.cs
@@ -26,8 +26,8 @@ using Confluent.Kafka.Internal;
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     Defines a high-level Apache Kafka consumer, excluding
-    ///     any methods for consuming messages.
+    ///     Defines a high-level Apache Kafka consumer, excluding any methods
+    ///     for consuming messages.
     /// </summary>
     public interface IConsumerBase : IClient
     {

--- a/src/Confluent.Kafka/IProducerBase.cs
+++ b/src/Confluent.Kafka/IProducerBase.cs
@@ -38,12 +38,10 @@ namespace Confluent.Kafka
         /// </summary>
         int Poll(TimeSpan timeout);
 
-
         /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.ProducerBase.Flush(TimeSpan)" />
         /// </summary>
         int Flush(TimeSpan timeout);
-
 
         /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.ProducerBase.Flush(CancellationToken)" />

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -25,7 +25,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     A high level producer with serialization capability.
     /// </summary>
-    public class Producer<TKey, TValue> : ProducerBase
+    public class Producer<TKey, TValue> : ProducerBase, IProducer<TKey, TValue>
     {
         private ISerializer<TKey> keySerializer;
         private ISerializer<TValue> valueSerializer;
@@ -100,16 +100,16 @@ namespace Confluent.Kafka
         {
             base.Initialize(builder.handle);
             InitializeSerializers(
-                builder.keySerializer, builder.valueSerializer,
-                builder.asyncKeySerializer, builder.asyncValueSerializer);
+                builder.KeySerializer, builder.ValueSerializer,
+                builder.AsyncKeySerializer, builder.AsyncValueSerializer);
         }
 
         internal Producer(ProducerBuilder<TKey, TValue> builder)
         {
             base.Initialize(builder.ConstructBaseConfig(this));
             InitializeSerializers(
-                builder.keySerializer, builder.valueSerializer,
-                builder.asyncKeySerializer, builder.asyncValueSerializer);
+                builder.KeySerializer, builder.ValueSerializer,
+                builder.AsyncKeySerializer, builder.AsyncValueSerializer);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     A high level producer.
     /// </summary>
-    public class Producer : ProducerBase
+    public class Producer : ProducerBase, IProducer
     {
         internal Producer(ProducerBuilder builder)
         {

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Confluent.Kafka.Serdes;
 
 namespace Confluent.Kafka
 {
@@ -29,8 +29,8 @@ namespace Confluent.Kafka
     {
         private ISerializer<TKey> keySerializer;
         private ISerializer<TValue> valueSerializer;
-        private IAsyncSerializer<TKey> taskKeySerializer;
-        private IAsyncSerializer<TValue> taskValueSerializer;
+        private IAsyncSerializer<TKey> asyncKeySerializer;
+        private IAsyncSerializer<TValue> asyncValueSerializer;
 
         private static readonly Dictionary<Type, object> defaultSerializers = new Dictionary<Type, object>
         {
@@ -43,187 +43,74 @@ namespace Confluent.Kafka
             { typeof(byte[]), Serializers.ByteArray }
         };
 
-
-        /// <summary>
-        ///     Creates a new <see cref="Producer" /> instance.
-        /// </summary>
-        /// <param name="handle">
-        ///     An existing librdkafka producer handle to use for 
-        ///     communications with Kafka brokers.
-        /// </param>
-        /// <param name="keySerializer">
-        ///     The serializer to use to serialize keys.
-        /// </param>
-        /// <param name="valueSerializer">
-        ///     The serializer to use to serialize values.
-        /// </param>
-        public Producer(
-            Handle handle,
-            ISerializer<TKey> keySerializer = null,
-            ISerializer<TValue> valueSerializer = null
-        ) : base(handle) => Init(keySerializer, valueSerializer);
-
-
-        /// <summary>
-        ///     Creates a new <see cref="Confluent.Kafka.Producer" /> instance.
-        /// </summary>
-        /// <param name="config">
-        ///     A collection of librdkafka configuration parameters 
-        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
-        ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' must be specified.
-        /// </param>
-        /// <param name="keySerializer">
-        ///     The serializer to use to serialize keys.
-        /// </param>
-        /// <param name="valueSerializer">
-        ///     The serializer to use to serialize values.
-        /// </param>
-        public Producer(
-            IEnumerable<KeyValuePair<string, string>> config,
-            ISerializer<TKey> keySerializer = null,
-            ISerializer<TValue> valueSerializer = null
-        ) : base(config) => Init(keySerializer, valueSerializer);
-
-
-        private void Init(ISerializer<TKey> keySerializer, ISerializer<TValue> valueSerializer)
+        private void InitializeSerializers(
+            ISerializer<TKey> keySerializer,
+            ISerializer<TValue> valueSerializer,
+            IAsyncSerializer<TKey> asyncKeySerializer,
+            IAsyncSerializer<TValue> asyncValueSerializer)
         {
-            this.keySerializer = keySerializer;
-            this.valueSerializer = valueSerializer;
-
-            if (this.keySerializer == null)
+            // setup key serializer.
+            if (keySerializer == null && asyncKeySerializer == null)
             {
                 if (!defaultSerializers.TryGetValue(typeof(TKey), out object serializer))
                 {
                     throw new ArgumentNullException(
-                        $"Key serializer not specified and there is no default serializer defined for type {typeof(TKey)}");
+                        $"Key serializer not specified and there is no default serializer defined for type {typeof(TKey).Name}.");
                 }
                 this.keySerializer = (ISerializer<TKey>)serializer;
             }
+            else if (keySerializer == null && asyncKeySerializer != null)
+            {
+                this.asyncKeySerializer = asyncKeySerializer;
+            }
+            else if (keySerializer != null && asyncKeySerializer == null)
+            {
+                this.keySerializer = keySerializer;
+            }
+            else
+            {
+                throw new ArgumentException("Invalid key serializer configuration.");
+            }
 
-            if (this.valueSerializer == null)
+            // setup value serializer.
+            if (valueSerializer == null && asyncValueSerializer == null)
             {
                 if (!defaultSerializers.TryGetValue(typeof(TValue), out object serializer))
                 {
                     throw new ArgumentNullException(
-                        $"Value serializer not specified and there is no default serializer defined for type {typeof(TValue)}");
+                        $"Key serializer not specified and there is no default serializer defined for type {typeof(TKey).Name}.");
                 }
                 this.valueSerializer = (ISerializer<TValue>)serializer;
             }
+            else if (valueSerializer == null && asyncValueSerializer != null)
+            {
+                this.asyncValueSerializer = asyncValueSerializer;
+            }
+            else if (valueSerializer != null && asyncValueSerializer == null)
+            {
+                this.valueSerializer = valueSerializer;
+            }
+            else
+            {
+                throw new ArgumentException("Invalid value serializer configuration.");
+            }
         }
 
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
-        /// </summary>
-        public Producer(
-            IEnumerable<KeyValuePair<string, string>> config,
-            ISerializer<TKey> keySerializer,
-            IAsyncSerializer<TValue> taskValueSerializer
-        ) : base(config) => Init(keySerializer, taskValueSerializer);
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
-        /// </summary>
-        public Producer(
-            Handle handle,
-            ISerializer<TKey> keySerializer,
-            IAsyncSerializer<TValue> taskValueSerializer
-        ) : base(handle) => Init(keySerializer, taskValueSerializer);
-
-
-        private void Init(ISerializer<TKey> keySerializer, IAsyncSerializer<TValue> taskValueSerializer)
+        internal Producer(DependentProducerBuilder<TKey, TValue> builder)
         {
-            this.keySerializer = keySerializer;
-            this.taskValueSerializer = taskValueSerializer;
-
-            if (this.keySerializer == null)
-            {
-                throw new ArgumentNullException("Key serializer must be specified.");
-            }
-
-            if (this.taskValueSerializer == null)
-            {
-                throw new ArgumentNullException("Value serializer must be specified.");
-            }
+            base.Initialize(builder.handle);
+            InitializeSerializers(
+                builder.keySerializer, builder.valueSerializer,
+                builder.asyncKeySerializer, builder.asyncValueSerializer);
         }
-        
 
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
-        /// </summary>
-        public Producer(
-            IEnumerable<KeyValuePair<string, string>> config,
-            IAsyncSerializer<TKey> taskKeySerializer,
-            ISerializer<TValue> valueSerializer
-        ) : base(config) => Init(taskKeySerializer, valueSerializer);
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
-        /// </summary>
-        public Producer(
-            Handle handle,
-            IAsyncSerializer<TKey> taskKeySerializer,
-            ISerializer<TValue> valueSerializer
-        ) : base(handle) => Init(taskKeySerializer, valueSerializer);
-
-
-        private void Init(IAsyncSerializer<TKey> taskKeySerializer, ISerializer<TValue> valueSerializer)
+        internal Producer(ProducerBuilder<TKey, TValue> builder)
         {
-            this.taskKeySerializer = taskKeySerializer;
-            this.valueSerializer = valueSerializer;
-
-            if (this.taskKeySerializer == null)
-            {
-                throw new ArgumentNullException("Key serializer must be specified.");
-            }
-
-            if (this.valueSerializer == null)
-            {
-                throw new ArgumentNullException("Value serializer must be specified.");
-            }
+            base.Initialize(builder.ConstructBaseConfig(this));
+            InitializeSerializers(
+                builder.keySerializer, builder.valueSerializer,
+                builder.asyncKeySerializer, builder.asyncValueSerializer);
         }
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
-        /// </summary>
-        public Producer(
-            IEnumerable<KeyValuePair<string, string>> config,
-            IAsyncSerializer<TKey> keySerializer,
-            IAsyncSerializer<TValue> valueSerializer
-        ) : base(config) => Init(keySerializer, valueSerializer);
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
-        /// </summary>
-        public Producer(
-            Handle handle,
-            IAsyncSerializer<TKey> keySerializer,
-            IAsyncSerializer<TValue> valueSerializer
-        ) : base(handle) => Init(keySerializer, valueSerializer);
-
-
-        private void Init(IAsyncSerializer<TKey> taskKeySerializer, IAsyncSerializer<TValue> taskValueSerializer)
-        {
-            this.taskKeySerializer = taskKeySerializer;
-            this.taskValueSerializer = taskValueSerializer;
-
-            if (this.taskKeySerializer == null)
-            {
-                throw new ArgumentNullException("Key serializer must be specified.");
-            }
-
-            if (this.taskValueSerializer == null)
-            {
-                throw new ArgumentNullException("Value serializer must be specified.");
-            }
-        }
-
 
         /// <summary>
         ///     Asynchronously send a single message to a Kafka topic/partition.
@@ -248,14 +135,14 @@ namespace Confluent.Kafka
         {
             var keyBytes = (keySerializer != null)
                 ? keySerializer.Serialize(message.Key, true, message, topicPartition)
-                : taskKeySerializer.SerializeAsync(message.Key, true, message, topicPartition)
+                : asyncKeySerializer.SerializeAsync(message.Key, true, message, topicPartition)
                     .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();
 
             var valBytes = (valueSerializer != null)
                 ? valueSerializer.Serialize(message.Value, false, message, topicPartition)
-                : taskValueSerializer.SerializeAsync(message.Value, false, message, topicPartition)
+                : asyncValueSerializer.SerializeAsync(message.Value, false, message, topicPartition)
                     .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();
@@ -373,14 +260,14 @@ namespace Confluent.Kafka
 
             var keyBytes = (keySerializer != null)
                 ? keySerializer.Serialize(message.Key, true, message, topicPartition)
-                : taskKeySerializer.SerializeAsync(message.Key, true, message, topicPartition)
+                : asyncKeySerializer.SerializeAsync(message.Key, true, message, topicPartition)
                     .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();
 
             var valBytes = (valueSerializer != null)
                 ? valueSerializer.Serialize(message.Value, false, message, topicPartition)
-                : taskValueSerializer.SerializeAsync(message.Value, false, message, topicPartition)
+                : asyncValueSerializer.SerializeAsync(message.Value, false, message, topicPartition)
                     .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();
@@ -522,26 +409,10 @@ namespace Confluent.Kafka
     /// </summary>
     public class Producer : ProducerBase
     {
-        /// <summary>
-        ///     Creates a new Producer instance.
-        /// </summary>
-        /// <param name="config">
-        ///     A collection of librdkafka configuration parameters 
-        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
-        ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' must be specified.
-        /// </param>
-        public Producer(IEnumerable<KeyValuePair<string, string>> config) : base(config) {}
-
-        /// <summary>
-        ///     Creates a new <see cref="Producer" /> instance.
-        /// </summary>
-        /// <param name="handle">
-        ///     An existing librdkafka producer handle to use for 
-        ///     communications with Kafka brokers.
-        /// </param>
-        public Producer(Handle handle): base(handle) {}
+        internal Producer(ProducerBuilder builder)
+        {
+            base.Initialize(builder.ConstructBaseConfig(this));
+        }
 
         /// <summary>
         ///     Asynchronously send a single message to a Kafka topic/partition.

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -78,7 +78,7 @@ namespace Confluent.Kafka
                 if (!defaultSerializers.TryGetValue(typeof(TValue), out object serializer))
                 {
                     throw new ArgumentNullException(
-                        $"Key serializer not specified and there is no default serializer defined for type {typeof(TKey).Name}.");
+                        $"Value serializer not specified and there is no default serializer defined for type {typeof(TKey).Name}.");
                 }
                 this.valueSerializer = (ISerializer<TValue>)serializer;
             }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -98,7 +98,7 @@ namespace Confluent.Kafka
 
         internal Producer(DependentProducerBuilder<TKey, TValue> builder)
         {
-            base.Initialize(builder.handle);
+            base.Initialize(builder.Handle);
             InitializeSerializers(
                 builder.KeySerializer, builder.ValueSerializer,
                 builder.AsyncKeySerializer, builder.AsyncValueSerializer);

--- a/src/Confluent.Kafka/ProducerBase.cs
+++ b/src/Confluent.Kafka/ProducerBase.cs
@@ -36,28 +36,36 @@ namespace Confluent.Kafka
     /// </summary>
     public class ProducerBase : IProducerBase
     {
+        internal class Config
+        {
+            internal IEnumerable<KeyValuePair<string, string>> config;
+            internal Action<Error> errorHandler;
+            internal Action<LogMessage> logHandler;
+            internal Action<string> statsHandler;
+        }
+        
         private int cancellationDelayMaxMs;
         private bool disposeHasBeenCalled = false;
         private object disposeHasBeenCalledLockObj = new object();
 
-        private readonly bool manualPoll = false;
-        internal readonly bool enableDeliveryReports = true;
-        internal readonly bool enableDeliveryReportKey = true;
-        internal readonly bool enableDeliveryReportValue = true;
-        internal readonly bool enableDeliveryReportTimestamp = true;
-        internal readonly bool enableDeliveryReportHeaders = true;
-        internal readonly bool enableDeliveryReportPersistedStatus = true;
+        private bool manualPoll = false;
+        internal bool enableDeliveryReports = true;
+        internal bool enableDeliveryReportKey = true;
+        internal bool enableDeliveryReportValue = true;
+        internal bool enableDeliveryReportTimestamp = true;
+        internal bool enableDeliveryReportHeaders = true;
+        internal bool enableDeliveryReportPersistedStatus = true;
 
-        private readonly SafeKafkaHandle ownedKafkaHandle;
-        private readonly Handle borrowedHandle;
+        private SafeKafkaHandle ownedKafkaHandle;
+        private Handle borrowedHandle;
 
         internal SafeKafkaHandle KafkaHandle
             => ownedKafkaHandle != null 
                 ? ownedKafkaHandle
                 : borrowedHandle.LibrdkafkaHandle;
 
-        private readonly Task callbackTask;
-        private readonly CancellationTokenSource callbackCts;
+        private Task callbackTask;
+        private CancellationTokenSource callbackCts;
 
         private Task StartPollTask(CancellationToken ct)
             => Task.Factory.StartNew(() =>
@@ -74,33 +82,36 @@ namespace Confluent.Kafka
                 }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
 
-        private readonly Librdkafka.ErrorDelegate errorCallbackDelegate;
+        private Action<Error> errorHandler;
+        private Librdkafka.ErrorDelegate errorCallbackDelegate;
         private void ErrorCallback(IntPtr rk, ErrorCode err, string reason, IntPtr opaque)
         {
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             if (ownedKafkaHandle.IsClosed) { return; }
-            onError?.Invoke(this, KafkaHandle.CreatePossiblyFatalError(err, reason));
+            errorHandler?.Invoke(KafkaHandle.CreatePossiblyFatalError(err, reason));
         }
 
 
-        private readonly Librdkafka.StatsDelegate statsCallbackDelegate;
+        private Action<string> statsHandler;
+        private Librdkafka.StatsDelegate statsCallbackDelegate;
         private int StatsCallback(IntPtr rk, IntPtr json, UIntPtr json_len, IntPtr opaque)
         {
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             if (ownedKafkaHandle.IsClosed) { return 0; }
-            onStatistics?.Invoke(this, Util.Marshal.PtrToStringUTF8(json));
+            statsHandler?.Invoke(Util.Marshal.PtrToStringUTF8(json));
             return 0; // instruct librdkafka to immediately free the json ptr.
         }
 
 
+        private Action<LogMessage> logHandler;
         private object loggerLockObj = new object();
-        private readonly Librdkafka.LogDelegate logCallbackDelegate;
+        private Librdkafka.LogDelegate logCallbackDelegate;
         private void LogCallback(IntPtr rk, SyslogLevel level, string fac, string buf)
         {
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             // Note: kafkaHandle can be null if the callback is during construction (in that case, we want the delegate to run).
             if (ownedKafkaHandle != null && ownedKafkaHandle.IsClosed) { return; }
-            onLog?.Invoke(this, new LogMessage(Util.Marshal.PtrToStringUTF8(Librdkafka.name(rk)), level, fac, buf));
+            logHandler?.Invoke(new LogMessage(Util.Marshal.PtrToStringUTF8(Librdkafka.name(rk)), level, fac, buf));
         }
 
         private Librdkafka.DeliveryReportDelegate DeliveryReportCallback;
@@ -280,93 +291,27 @@ namespace Confluent.Kafka
             }
         }
 
-        private event EventHandler<LogMessage> onLog;
-
-        /// <summary>
-        ///     Refer to <see cref="IClient.OnLog" />.
-        /// </summary>
-        public event EventHandler<LogMessage> OnLog
+        internal void Initialize(Handle handle)
         {
-            add
+            if (!handle.Owner.GetType().Name.Contains("Producer")) // much simpler than checking actual types.
             {
-                if (ownedKafkaHandle != null) { onLog += value; }
-                else { borrowedHandle.Owner.OnLog += value; }
+                throw new Exception("A Producer instance may only be constructed using the handle of another Producer instance.");
             }
-            remove
-            {
-                if (ownedKafkaHandle != null) { onLog -= value; }
-                else { borrowedHandle.Owner.OnLog -= value; }
-            }
-        }
 
-
-        private event EventHandler<Error> onError;
-
-        /// <summary>
-        ///     Refer to <see cref="IClient.OnError" />.
-        /// </summary>
-        public event EventHandler<Error> OnError
-        {
-            add
-            {
-                if (ownedKafkaHandle != null) { onError += value; }
-                else { borrowedHandle.Owner.OnError += value; }
-            }
-            remove
-            {
-                if (ownedKafkaHandle != null) { onError -= value; }
-                else { borrowedHandle.Owner.OnError -= value; }
-            }
-        }
-
-        private event EventHandler<string> onStatistics;
-
-        /// <summary>
-        ///     Refer to <see cref="IClient.OnStatistics" />.
-        /// </summary>
-        public event EventHandler<string> OnStatistics
-        {
-            add
-            {
-                if (ownedKafkaHandle != null) { onStatistics += value; }
-                else { borrowedHandle.Owner.OnStatistics += value; }
-            }
-            remove
-            {
-                if (ownedKafkaHandle != null) { onStatistics -= value; }
-                else { borrowedHandle.Owner.OnStatistics -= value; }
-            }
-        }
-
-        /// <summary>
-        ///     Creates a new <see cref="ProducerBase" /> instance.
-        /// </summary>
-        /// <param name="handle">
-        ///     An existing librdkafka producer handle to use for 
-        ///     communications with Kafka brokers.
-        /// </param>
-        public ProducerBase(Handle handle)
-        {
             this.borrowedHandle = handle;
         }
 
-        /// <summary>
-        ///     Creates a new <see cref="ProducerBase" /> instance.
-        /// </summary>
-        /// <param name="config">
-        ///     A collection of librdkafka configuration parameters 
-        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
-        ///     and parameters specific to this client (refer to: 
-        ///     <see cref="ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' must be specified.
-        /// </param>
-        public ProducerBase(IEnumerable<KeyValuePair<string, string>> config)
+        internal void Initialize(ProducerBase.Config baseConfig)
         {
             // TODO: Make Tasks auto complete when EnableDeliveryReportsPropertyName is set to false.
             // TODO: Hijack the "delivery.report.only.error" configuration parameter and add functionality to enforce that Tasks 
             //       that never complete are never created when this is set to true.
 
-            config = Config.GetCancellationDelayMaxMs(config, out this.cancellationDelayMaxMs);
+            this.statsHandler = baseConfig.statsHandler;
+            this.logHandler = baseConfig.logHandler;
+            this.errorHandler = baseConfig.errorHandler;
+
+            var config = Confluent.Kafka.Config.ExtractCancellationDelayMaxMs(baseConfig.config, out this.cancellationDelayMaxMs);
 
             this.DeliveryReportCallback = DeliveryReportCallbackImpl;
 
@@ -465,6 +410,8 @@ namespace Confluent.Kafka
                 callbackTask = StartPollTask(callbackCts.Token);
             }
         }
+        
+        internal ProducerBase() {}
 
 
         /// <summary>

--- a/src/Confluent.Kafka/ProducerBase.cs
+++ b/src/Confluent.Kafka/ProducerBase.cs
@@ -31,8 +31,8 @@ using Confluent.Kafka.Internal;
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     A high-level Apache Kafka producer, excluding
-    ///     any public methods for producing messages.
+    ///     A high-level Apache Kafka producer, excluding any public methods
+    ///     for producing messages.
     /// </summary>
     public class ProducerBase : IProducerBase
     {

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -25,25 +25,40 @@ namespace Confluent.Kafka
     /// </summary>
     public class ProducerBuilder
     {
-        internal IEnumerable<KeyValuePair<string, string>> config;
-        internal Action<Producer, Error> errorHandler;
-        internal Action<Producer, LogMessage> logHandler;
-        internal Action<Producer, string> statisticsHandler;
+        /// <summary>
+        ///     The config dictionary.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+
+        /// <summary>
+        ///     The configured error handler.
+        /// </summary>
+        public Action<Producer, Error> ErrorHandler { get; set; }
+
+        /// <summary>
+        ///     The configured log handler.
+        /// </summary>
+        public Action<Producer, LogMessage> LogHandler { get; set; }
+
+        /// <summary>
+        ///     The configured statistics handler.
+        /// </summary>
+        public Action<Producer, string> StatisticsHandler { get; set; }
 
         internal ProducerBase.Config ConstructBaseConfig(Producer producer)
         {
             return new ProducerBase.Config
             {
-                config = config,
-                errorHandler = this.errorHandler == null
+                config = Config,
+                errorHandler = this.ErrorHandler == null
                     ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
-                    : error => this.errorHandler(producer, error),
-                logHandler = this.logHandler == null
+                    : error => this.ErrorHandler(producer, error),
+                logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
-                    : logMessage => this.logHandler(producer, logMessage),
-                statsHandler = this.statisticsHandler == null
+                    : logMessage => this.LogHandler(producer, logMessage),
+                statsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
-                    : stats => this.statisticsHandler(producer, stats)
+                    : stats => this.StatisticsHandler(producer, stats)
             };
         }
 
@@ -57,7 +72,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
-            this.config = config;
+            this.Config = config;
         }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder SetStatisticsHandler(Action<Producer, string> statisticsHandler)
         {
-            this.statisticsHandler = statisticsHandler;
+            this.StatisticsHandler = statisticsHandler;
             return this;
         }
 
@@ -74,7 +89,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder SetErrorHandler(Action<Producer, Error> errorHandler)
         {
-            this.errorHandler = errorHandler;
+            this.ErrorHandler = errorHandler;
             return this;
         }
 
@@ -83,14 +98,14 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder SetLogHandler(Action<Producer, LogMessage> logHandler)
         {
-            this.logHandler = logHandler;
+            this.LogHandler = logHandler;
             return this;
         }
 
         /// <summary>
         ///     Refer to <see cref="ProducerBuilder{TKey,TValue}.Build()" />.
         /// </summary>
-        public Producer Build()
+        public virtual Producer Build()
         {
             return new Producer(this);
         }
@@ -102,30 +117,61 @@ namespace Confluent.Kafka
     /// </summary>
     public class ProducerBuilder<TKey, TValue>
     {
-        internal IEnumerable<KeyValuePair<string, string>> config;
-        internal Action<Producer<TKey, TValue>, Error> errorHandler;
-        internal Action<Producer<TKey, TValue>, LogMessage> logHandler;
-        internal Action<Producer<TKey, TValue>, string> statisticsHandler;
+        /// <summary>
+        ///     The config dictionary.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+
+        /// <summary>
+        ///     The configured error handler.
+        /// </summary>
+        public Action<Producer<TKey, TValue>, Error> ErrorHandler { get; set; }
+
+        /// <summary>
+        ///     The configured log handler.
+        /// </summary>
+        public Action<Producer<TKey, TValue>, LogMessage> LogHandler { get; set; }
+
+        /// <summary>
+        ///     The configured statistics handler.
+        /// </summary>
+        public Action<Producer<TKey, TValue>, string> StatisticsHandler { get; set; }
         
-        internal ISerializer<TKey> keySerializer;
-        internal ISerializer<TValue> valueSerializer;
-        internal IAsyncSerializer<TKey> asyncKeySerializer;
-        internal IAsyncSerializer<TValue> asyncValueSerializer;
+
+        /// <summary>
+        ///     The configured key serializer.
+        /// </summary>
+        public ISerializer<TKey> KeySerializer { get; set; }
+
+        /// <summary>
+        ///     The configured value serializer.
+        /// </summary>
+        public ISerializer<TValue> ValueSerializer { get; set; }
+
+        /// <summary>
+        ///     The configured async key serializer.
+        /// </summary>
+        public IAsyncSerializer<TKey> AsyncKeySerializer { get; set; }
+
+        /// <summary>
+        ///     The configured async value serializer.
+        /// </summary>
+        public IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
 
         internal ProducerBase.Config ConstructBaseConfig(Producer<TKey, TValue> producer)
         {
             return new ProducerBase.Config
             {
-                config = config,
-                errorHandler = this.errorHandler == null
+                config = Config,
+                errorHandler = this.ErrorHandler == null
                     ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
-                    : error => this.errorHandler(producer, error),
-                logHandler = this.logHandler == null
+                    : error => this.ErrorHandler(producer, error),
+                logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
-                    : logMessage => this.logHandler(producer, logMessage),
-                statsHandler = this.statisticsHandler == null
+                    : logMessage => this.LogHandler(producer, logMessage),
+                statsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
-                    : stats => this.statisticsHandler(producer, stats)
+                    : stats => this.StatisticsHandler(producer, stats)
             };
         }
 
@@ -139,7 +185,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
-            this.config = config;
+            this.Config = config;
         }
 
         /// <summary>
@@ -156,7 +202,7 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetStatisticsHandler(Action<Producer<TKey, TValue>, string> statisticsHandler)
         {
-            this.statisticsHandler = statisticsHandler;
+            this.StatisticsHandler = statisticsHandler;
             return this;
         }
 
@@ -172,7 +218,7 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetErrorHandler(Action<Producer<TKey, TValue>, Error> errorHandler)
         {
-            this.errorHandler = errorHandler;
+            this.ErrorHandler = errorHandler;
             return this;
         }
 
@@ -197,7 +243,7 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetLogHandler(Action<Producer<TKey, TValue>, LogMessage> logHandler)
         {
-            this.logHandler = logHandler;
+            this.LogHandler = logHandler;
             return this;
         }
 
@@ -206,7 +252,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetKeySerializer(ISerializer<TKey> serializer)
         {
-            this.keySerializer = serializer;
+            this.KeySerializer = serializer;
             return this;
         }
 
@@ -215,7 +261,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
         {
-            this.valueSerializer = serializer;
+            this.ValueSerializer = serializer;
             return this;
         }
 
@@ -224,7 +270,7 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSerializer<TKey> serializer)
         {
-            this.asyncKeySerializer = serializer;
+            this.AsyncKeySerializer = serializer;
             return this;
         }
 
@@ -233,14 +279,14 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
-            this.asyncValueSerializer = serializer;
+            this.AsyncValueSerializer = serializer;
             return this;
         }
 
         /// <summary>
         ///     Build a new Producer instance.
         /// </summary>
-        public Producer<TKey, TValue> Build()
+        public virtual Producer<TKey, TValue> Build()
         {
             return new Producer<TKey, TValue>(this);
         }

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -56,7 +56,7 @@ namespace Confluent.Kafka
                 logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
                     : logMessage => this.LogHandler(producer, logMessage),
-                statsHandler = this.StatisticsHandler == null
+                statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
                     : stats => this.StatisticsHandler(producer, stats)
             };
@@ -67,8 +67,7 @@ namespace Confluent.Kafka
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
         ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
-        ///     specified.
+        ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </summary>
         public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {
@@ -169,7 +168,7 @@ namespace Confluent.Kafka
                 logHandler = this.LogHandler == null
                     ? default(Action<LogMessage>)
                     : logMessage => this.LogHandler(producer, logMessage),
-                statsHandler = this.StatisticsHandler == null
+                statisticsHandler = this.StatisticsHandler == null
                     ? default(Action<string>)
                     : stats => this.StatisticsHandler(producer, stats)
             };
@@ -180,8 +179,7 @@ namespace Confluent.Kafka
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
         ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
-        ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
-        ///     specified.
+        ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </summary>
         public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)
         {

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -1,0 +1,248 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     A builder class for <see cref="Producer" /> instances.
+    /// </summary>
+    public class ProducerBuilder
+    {
+        internal IEnumerable<KeyValuePair<string, string>> config;
+        internal Action<Producer, Error> errorHandler;
+        internal Action<Producer, LogMessage> logHandler;
+        internal Action<Producer, string> statisticsHandler;
+
+        internal ProducerBase.Config ConstructBaseConfig(Producer producer)
+        {
+            return new ProducerBase.Config
+            {
+                config = config,
+                errorHandler = this.errorHandler == null
+                    ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
+                    : error => this.errorHandler(producer, error),
+                logHandler = this.logHandler == null
+                    ? default(Action<LogMessage>)
+                    : logMessage => this.logHandler(producer, logMessage),
+                statsHandler = this.statisticsHandler == null
+                    ? default(Action<string>)
+                    : stats => this.statisticsHandler(producer, stats)
+            };
+        }
+
+        /// <summary>
+        ///     A collection of librdkafka configuration parameters 
+        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
+        ///     and parameters specific to this client (refer to: 
+        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
+        ///     specified.
+        /// </summary>
+        public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)
+        {
+            this.config = config;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ProducerBuilder{TKey,TValue}.SetStatisticsHandler(Action{Producer{TKey, TValue}, string})" />.
+        /// </summary>
+        public ProducerBuilder SetStatisticsHandler(Action<Producer, string> statisticsHandler)
+        {
+            this.statisticsHandler = statisticsHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ProducerBuilder{TKey,TValue}.SetErrorHandler(Action{Producer{TKey, TValue}, Error})" />.
+        /// </summary>
+        public ProducerBuilder SetErrorHandler(Action<Producer, Error> errorHandler)
+        {
+            this.errorHandler = errorHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ProducerBuilder{TKey,TValue}.SetLogHandler(Action{Producer{TKey, TValue}, LogMessage})" />.
+        /// </summary>
+        public ProducerBuilder SetLogHandler(Action<Producer, LogMessage> logHandler)
+        {
+            this.logHandler = logHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Refer to <see cref="ProducerBuilder{TKey,TValue}.Build()" />.
+        /// </summary>
+        public Producer Build()
+        {
+            return new Producer(this);
+        }
+    }
+
+
+    /// <summary>
+    ///     A builder class for <see cref="Producer{TKey, TValue}" /> instances.
+    /// </summary>
+    public class ProducerBuilder<TKey, TValue>
+    {
+        internal IEnumerable<KeyValuePair<string, string>> config;
+        internal Action<Producer<TKey, TValue>, Error> errorHandler;
+        internal Action<Producer<TKey, TValue>, LogMessage> logHandler;
+        internal Action<Producer<TKey, TValue>, string> statisticsHandler;
+        
+        internal ISerializer<TKey> keySerializer;
+        internal ISerializer<TValue> valueSerializer;
+        internal IAsyncSerializer<TKey> asyncKeySerializer;
+        internal IAsyncSerializer<TValue> asyncValueSerializer;
+
+        internal ProducerBase.Config ConstructBaseConfig(Producer<TKey, TValue> producer)
+        {
+            return new ProducerBase.Config
+            {
+                config = config,
+                errorHandler = this.errorHandler == null
+                    ? default(Action<Error>) // using default(...) rather than null (== default(...)) so types can be inferred.
+                    : error => this.errorHandler(producer, error),
+                logHandler = this.logHandler == null
+                    ? default(Action<LogMessage>)
+                    : logMessage => this.logHandler(producer, logMessage),
+                statsHandler = this.statisticsHandler == null
+                    ? default(Action<string>)
+                    : stats => this.statisticsHandler(producer, stats)
+            };
+        }
+
+        /// <summary>
+        ///     A collection of librdkafka configuration parameters 
+        ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
+        ///     and parameters specific to this client (refer to: 
+        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
+        ///     specified.
+        /// </summary>
+        public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)
+        {
+            this.config = config;
+        }
+
+        /// <summary>
+        ///     Set the handler to call on librdkafka statistics events. Statistics are provided as a JSON formatted string as defined here:
+        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
+        /// </summary>
+        /// <remarks>
+        ///     You can enable statistics and set the statistics interval
+        ///     using the statistics.interval.ms configuration parameter
+        ///     (disabled by default).
+        ///
+        ///     Executes on the poll thread (by default, a background thread managed by
+        ///     the producer).
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetStatisticsHandler(Action<Producer<TKey, TValue>, string> statisticsHandler)
+        {
+            this.statisticsHandler = statisticsHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call on error events e.g. connection failures or all
+        ///     brokers down. Note that the client will try to automatically recover from
+        ///     errors that are not marked as fatal - such errors should be interpreted
+        ///     as informational rather than catastrophic.
+        /// </summary>
+        /// <remarks>
+        ///     Executes on the poll thread (by default, a background thread managed by
+        ///     the producer).
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetErrorHandler(Action<Producer<TKey, TValue>, Error> errorHandler)
+        {
+            this.errorHandler = errorHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set the handler to call when there is information available
+        ///     to be logged. If not specified, a default callback that writes
+        ///     to stderr will be used.
+        /// </summary>
+        /// <remarks>
+        ///     By default not many log messages are generated.
+        ///
+        ///     For more verbose logging, specify one or more debug contexts
+        ///     using the 'debug' configuration property. The 'log_level'
+        ///     configuration property is also relevant, however logging is
+        ///     verbose by default given a debug context has been specified,
+        ///     so you typically shouldn't adjust this value.
+        ///
+        ///     Warning: Log handlers are called spontaneously from internal
+        ///     librdkafka threads and the application must not call any
+        ///     Confluent.Kafka APIs from within a log handler or perform any
+        ///     prolonged operations.
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetLogHandler(Action<Producer<TKey, TValue>, LogMessage> logHandler)
+        {
+            this.logHandler = logHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize keys.
+        /// </summary>
+        public ProducerBuilder<TKey, TValue> SetKeySerializer(ISerializer<TKey> serializer)
+        {
+            this.keySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        public ProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
+        {
+            this.valueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize keys.
+        /// </summary>
+        public ProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSerializer<TKey> serializer)
+        {
+            this.asyncKeySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        public ProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
+        {
+            this.asyncValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     Build a new Producer instance.
+        /// </summary>
+        public Producer<TKey, TValue> Build()
+        {
+            return new Producer<TKey, TValue>(this);
+        }
+    }
+}

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -28,22 +28,22 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The config dictionary.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+        internal protected IEnumerable<KeyValuePair<string, string>> Config { get; set; }
 
         /// <summary>
         ///     The configured error handler.
         /// </summary>
-        public Action<Producer, Error> ErrorHandler { get; set; }
+        internal protected Action<Producer, Error> ErrorHandler { get; set; }
 
         /// <summary>
         ///     The configured log handler.
         /// </summary>
-        public Action<Producer, LogMessage> LogHandler { get; set; }
+        internal protected Action<Producer, LogMessage> LogHandler { get; set; }
 
         /// <summary>
         ///     The configured statistics handler.
         /// </summary>
-        public Action<Producer, string> StatisticsHandler { get; set; }
+        internal protected Action<Producer, string> StatisticsHandler { get; set; }
 
         internal ProducerBase.Config ConstructBaseConfig(Producer producer)
         {
@@ -119,43 +119,43 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The config dictionary.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Config { get; set; }
+        internal protected IEnumerable<KeyValuePair<string, string>> Config { get; set; }
 
         /// <summary>
         ///     The configured error handler.
         /// </summary>
-        public Action<Producer<TKey, TValue>, Error> ErrorHandler { get; set; }
+        internal protected Action<Producer<TKey, TValue>, Error> ErrorHandler { get; set; }
 
         /// <summary>
         ///     The configured log handler.
         /// </summary>
-        public Action<Producer<TKey, TValue>, LogMessage> LogHandler { get; set; }
+        internal protected Action<Producer<TKey, TValue>, LogMessage> LogHandler { get; set; }
 
         /// <summary>
         ///     The configured statistics handler.
         /// </summary>
-        public Action<Producer<TKey, TValue>, string> StatisticsHandler { get; set; }
+        internal protected Action<Producer<TKey, TValue>, string> StatisticsHandler { get; set; }
         
 
         /// <summary>
         ///     The configured key serializer.
         /// </summary>
-        public ISerializer<TKey> KeySerializer { get; set; }
+        internal protected ISerializer<TKey> KeySerializer { get; set; }
 
         /// <summary>
         ///     The configured value serializer.
         /// </summary>
-        public ISerializer<TValue> ValueSerializer { get; set; }
+        internal protected ISerializer<TValue> ValueSerializer { get; set; }
 
         /// <summary>
         ///     The configured async key serializer.
         /// </summary>
-        public IAsyncSerializer<TKey> AsyncKeySerializer { get; set; }
+        internal protected IAsyncSerializer<TKey> AsyncKeySerializer { get; set; }
 
         /// <summary>
         ///     The configured async value serializer.
         /// </summary>
-        public IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
+        internal protected IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
 
         internal ProducerBase.Config ConstructBaseConfig(Producer<TKey, TValue> producer)
         {

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -187,8 +187,9 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Set the handler to call on librdkafka statistics events. Statistics are provided as a JSON formatted string as defined here:
-        ///     https://github.com/edenhill/librdkafka/wiki/Statistics
+        ///     Set the handler to call on statistics events. Statistics are provided as
+        ///     a JSON formatted string as defined here:
+        ///     https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
         /// </summary>
         /// <remarks>
         ///     You can enable statistics and set the statistics interval
@@ -200,6 +201,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetStatisticsHandler(Action<Producer<TKey, TValue>, string> statisticsHandler)
         {
+            if (this.StatisticsHandler != null)
+            {
+                throw new ArgumentException("Statistics handler may not be specified more than once.");
+            }
             this.StatisticsHandler = statisticsHandler;
             return this;
         }
@@ -207,7 +212,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Set the handler to call on error events e.g. connection failures or all
         ///     brokers down. Note that the client will try to automatically recover from
-        ///     errors that are not marked as fatal - such errors should be interpreted
+        ///     errors that are not marked as fatal. Non-fatal errors should be interpreted
         ///     as informational rather than catastrophic.
         /// </summary>
         /// <remarks>
@@ -216,6 +221,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetErrorHandler(Action<Producer<TKey, TValue>, Error> errorHandler)
         {
+            if (this.ErrorHandler != null)
+            {
+                throw new ArgumentException("Error handler may not be specified more than once.");
+            }
             this.ErrorHandler = errorHandler;
             return this;
         }
@@ -229,10 +238,7 @@ namespace Confluent.Kafka
         ///     By default not many log messages are generated.
         ///
         ///     For more verbose logging, specify one or more debug contexts
-        ///     using the 'debug' configuration property. The 'log_level'
-        ///     configuration property is also relevant, however logging is
-        ///     verbose by default given a debug context has been specified,
-        ///     so you typically shouldn't adjust this value.
+        ///     using the 'debug' configuration property.
         ///
         ///     Warning: Log handlers are called spontaneously from internal
         ///     librdkafka threads and the application must not call any
@@ -241,6 +247,10 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetLogHandler(Action<Producer<TKey, TValue>, LogMessage> logHandler)
         {
+            if (this.LogHandler != null)
+            {
+                throw new ArgumentException("Log handler may not be specified more than once.");
+            }
             this.LogHandler = logHandler;
             return this;
         }
@@ -250,6 +260,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetKeySerializer(ISerializer<TKey> serializer)
         {
+            if (this.KeySerializer != null || this.AsyncKeySerializer != null)
+            {
+                throw new ArgumentException("Key serializer may not be specified more than once.");
+            }
             this.KeySerializer = serializer;
             return this;
         }
@@ -259,6 +273,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
         {
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
+            {
+                throw new ArgumentException("Value serializer may not be specified more than once.");
+            }
             this.ValueSerializer = serializer;
             return this;
         }
@@ -268,6 +286,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSerializer<TKey> serializer)
         {
+            if (this.KeySerializer != null || this.AsyncKeySerializer != null)
+            {
+                throw new ArgumentException("Key serializer may not be specified more than once.");
+            }
             this.AsyncKeySerializer = serializer;
             return this;
         }
@@ -277,6 +299,10 @@ namespace Confluent.Kafka
         /// </summary>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
+            {
+                throw new ArgumentException("Value serializer may not be specified more than once.");
+            }
             this.AsyncValueSerializer = serializer;
             return this;
         }

--- a/src/Confluent.Kafka/Serializers.cs
+++ b/src/Confluent.Kafka/Serializers.cs
@@ -18,7 +18,7 @@ using System;
 using System.Text;
 
 
-namespace Confluent.Kafka
+namespace Confluent.Kafka.Serdes
 {
     /// <summary>
     ///     Serializers for use with <see cref="Producer{TKey,TValue}" />.

--- a/src/Confluent.SchemaRegistry.Serdes/AvroSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes/AvroSerializer.cs
@@ -126,6 +126,7 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="isKey">
         ///     True if deserializing the message key, false if deserializing the
         ///     message value.
+        /// </param>
         /// <returns>
         ///     A <see cref="System.Threading.Tasks.Task" /> that completes with 
         ///     <paramref name="value" /> serialized as a byte array.

--- a/test/Confluent.Kafka.Benchmark/BenchmarkConsumer.cs
+++ b/test/Confluent.Kafka.Benchmark/BenchmarkConsumer.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.Benchmark
                 ConsumeResultFields = nHeaders == 0 ? "none" : "headers"
             };
 
-            using (var consumer = new Consumer<Ignore, Ignore>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Ignore, Ignore>(consumerConfig).Build())
             {
                 for (var j=0; j<nTests; j += 1)
                 {

--- a/test/Confluent.Kafka.Benchmark/BenchmarkProducer.cs
+++ b/test/Confluent.Kafka.Benchmark/BenchmarkProducer.cs
@@ -56,7 +56,7 @@ namespace Confluent.Kafka.Benchmark
                 }
             }
 
-            using (var producer = new Producer(config))
+            using (var producer = new ProducerBuilder(config).Build())
             {
                 for (var j=0; j<nTests; j += 1)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/TemporaryTopic.cs
+++ b/test/Confluent.Kafka.IntegrationTests/TemporaryTopic.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka
         public TemporaryTopic(string bootstrapServers, int numPartitions)
         {
             Name = Guid.NewGuid().ToString();
-            adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers });
+            adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
             adminClient.CreateTopicsAsync(
                     new List<TopicSpecification> { new TopicSpecification { Name = Name, NumPartitions = numPartitions, ReplicationFactor = 1 } }).Wait();
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterConfigs.cs
@@ -38,7 +38,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             LogToFile("start AdminClient_AlterConfigs");
 
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 // 1. create a new topic to play with.
                 string topicName = Guid.NewGuid().ToString();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreatePartitions.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreatePartitions.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
             var topicName6 = Guid.NewGuid().ToString();
 
             // test creating a new partition works.
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new AdminClient(producer.Handle))
             {
                 adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
@@ -67,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // check validate only works.
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new AdminClient(producer.Handle))
             {
                 adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
@@ -88,7 +88,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // check valid Assignments property value works.
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new AdminClient(producer.Handle))
             {
                 adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName3, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
@@ -102,7 +102,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // check invalid Assignments property value works.
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new AdminClient(producer.Handle))
             {
                 adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName4, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
@@ -128,7 +128,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // more than one.
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 adminClient.CreateTopicsAsync(new TopicSpecification[] 
                     { 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreateTopics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreateTopics.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
             // test 
             //  - construction of admin client from configuration.
             //  - creation of more than one topic.
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 adminClient.CreateTopicsAsync(
                     new TopicSpecification[]
@@ -61,7 +61,7 @@ namespace Confluent.Kafka.IntegrationTests
             //  - construction of admin client from a producer handle
             //  - creation of topic 
             //  - producing to created topics works.
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient2 = new AdminClient(producer.Handle))
             {
                 adminClient2.CreateTopicsAsync(
@@ -79,7 +79,7 @@ namespace Confluent.Kafka.IntegrationTests
             // test
             //  - create topic with same name as existing topic
             //  - as well as another topic that does exist (and for which create should succeed).
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 try
                 {
@@ -108,7 +108,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             // test 
             //  - validate only
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 adminClient.CreateTopicsAsync(
                     new List<TopicSpecification> { new TopicSpecification { Name = topicName5, NumPartitions = 1, ReplicationFactor = 1 } }, 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteTopics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteTopics.cs
@@ -43,7 +43,7 @@ namespace Confluent.Kafka.IntegrationTests
             var topicName3 = Guid.NewGuid().ToString();
             
             // test single delete topic.
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 adminClient.CreateTopicsAsync(
                     new List<TopicSpecification> { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
@@ -56,7 +56,7 @@ namespace Confluent.Kafka.IntegrationTests
             // test
             //  - delete two topics, one that doesn't exist.
             //  - check that explicitly giving options doesn't obviously not work.
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 adminClient.CreateTopicsAsync(
                     new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DescribeConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DescribeConfigs.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             LogToFile("start AdminClient_DescribeConfigs");
 
-            using (var adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers }))
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 // broker configs
                 // ---

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -46,14 +46,14 @@ namespace Confluent.Kafka.IntegrationTests
             var testString2 = "hello world 2";
 
             DeliveryResult<Null, string> dr;
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString }).Result;
                 var dr2 = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString2 }).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            using (var consumer = new Consumer<Null, string>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
                 // Explicitly specify partition offset.
                 consumer.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(dr.TopicPartition, dr.Offset) });

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -20,6 +20,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using Xunit;
+using Confluent.Kafka.Serdes;
 
 
 namespace Confluent.Kafka.IntegrationTests
@@ -46,15 +47,15 @@ namespace Confluent.Kafka.IntegrationTests
             var testString = "hello world";
 
             DeliveryResult dr;
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize(testString, true, null, null) }).Result;
                 Assert.True(dr.Offset >= 0);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            consumerConfig.AutoOffsetReset = AutoOffsetReset.Latest;
-            using (var consumer = new Consumer(consumerConfig))
+            consumerConfig.AutoOffsetReset = AutoOffsetResetType.Latest;
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeResult record;
 
@@ -67,8 +68,8 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(record);
             }
 
-            consumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
-            using (var consumer = new Consumer(consumerConfig))
+            consumerConfig.AutoOffsetReset = AutoOffsetResetType.Earliest;
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeResult record;
                 consumer.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(dr.TopicPartition, dr.Offset+1) });

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -54,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            consumerConfig.AutoOffsetReset = AutoOffsetResetType.Latest;
+            consumerConfig.AutoOffsetReset = AutoOffsetReset.Latest;
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeResult record;
@@ -68,7 +68,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(record);
             }
 
-            consumerConfig.AutoOffsetReset = AutoOffsetResetType.Earliest;
+            consumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeResult record;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -1,0 +1,144 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+#pragma warning disable xUnit1026
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    /// <summary>
+    ///     Create a custom builder for producer / consumer that uses
+    ///     different default serdes for string. This test is primarily
+    ///     to demonstrate the suitability of the API for this purpose.
+    /// </summary>
+    public static partial class Tests
+    {
+        class MyProducerBuilder<K, V> : ProducerBuilder<K, V>
+        {
+            class Utf32Serializer : ISerializer<string>
+            {
+                public byte[] Serialize(string data, bool isKey, MessageMetadata messageMetadata, TopicPartition destination)
+                {
+                    return Encoding.UTF32.GetBytes(data);
+                }
+            }
+
+            public MyProducerBuilder(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
+
+            public override Producer<K, V> Build()
+            {
+                if (typeof(K) == typeof(string))
+                {
+                    if (KeySerializer == null && AsyncKeySerializer == null)
+                    {
+                        this.KeySerializer = (ISerializer<K>)(new Utf32Serializer());
+                    }
+                }
+
+                if (typeof(V) == typeof(string))
+                {
+                    if (ValueSerializer == null && AsyncValueSerializer == null)
+                    {
+                        this.ValueSerializer = (ISerializer<V>)(new Utf32Serializer());
+                    }
+                }
+                
+                return base.Build();
+            }
+        }
+
+        class MyConsumerBuilder<K, V> : ConsumerBuilder<K, V>
+        {
+            class Utf32Deserializer : IDeserializer<string>
+            {
+                public string Deserialize(ReadOnlySpan<byte> data, bool isNull, bool isKey, MessageMetadata messageMetadata, TopicPartition source)
+                {
+                    if (isNull) { return null; }
+                    return Encoding.UTF32.GetString(data);
+                }
+            }
+
+            public MyConsumerBuilder(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
+
+            public override Consumer<K, V> Build()
+            {
+                if (typeof(K) == typeof(string))
+                {
+                    if (KeyDeserializer == null && AsyncKeyDeserializer == null)
+                    {
+                        this.KeyDeserializer = (IDeserializer<K>)new Utf32Deserializer();
+                    }
+                }
+                
+                if (typeof(V) == typeof(string))
+                {
+                    if (ValueDeserializer == null && AsyncValueDeserializer == null)
+                    {
+                        this.ValueDeserializer = (IDeserializer<V>) new Utf32Deserializer();
+                    }
+                }
+
+                return base.Build();
+            }
+        }
+
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public static void ProducerBuilder(string bootstrapServers, string singlePartitionTopic, string partitionedTopic)
+        {
+            LogToFile("start Builder_CustomDefaults");
+
+            var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
+
+            var dr = new DeliveryResult<string, string>();
+            using (var p = new MyProducerBuilder<string, string>(producerConfig).Build())
+            {
+                dr = p.ProduceAsync(singlePartitionTopic, new Message<string, string> { Key = "abc", Value = "123" }).Result;
+            }
+            
+            var consumerConfig = new ConsumerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                GroupId = Guid.NewGuid().ToString()
+            };
+        
+            using (var c = new MyConsumerBuilder<string, string>(consumerConfig).Build())
+            {
+                c.Assign(dr.TopicPartitionOffset);
+                var cr = c.Consume(TimeSpan.FromSeconds(10));
+                Assert.Equal("abc", cr.Key);
+                Assert.Equal("123", cr.Value);
+            }
+
+            using (var c = new ConsumerBuilder(consumerConfig).Build())
+            {
+                c.Assign(dr.TopicPartitionOffset);
+                var cr = c.Consume(TimeSpan.FromSeconds(10));
+                // check that each character is serialized into 4 bytes.
+                Assert.Equal(3*4, cr.Key.Length);
+                Assert.Equal(3*4, cr.Value.Length);
+            }
+
+            Assert.Equal(0, Library.HandleCount);
+            LogToFile("end   Builder_CustomDefaults");
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Confluent Inc.
+// Copyright 2016-2019 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/CancellationDelayMax.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/CancellationDelayMax.cs
@@ -61,9 +61,9 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             using (var topic = new TemporaryTopic(bootstrapServers, 3))
-            using (var consumer = new Consumer(consumerConfig))
-            using (var producer = new Producer(producerConfig))
-            using (var adminClient = new AdminClient(adminClientConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
+            using (var producer = new ProducerBuilder(producerConfig).Build())
+            using (var adminClient = new AdminClientBuilder(adminClientConfig).Build())
             {
                 consumer.Subscribe(topic.Name);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ClosedHandle.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ClosedHandle.cs
@@ -40,7 +40,7 @@ namespace Confluent.Kafka.IntegrationTests
                 BootstrapServers = bootstrapServers,
                 EnableBackgroundPoll = false
             };
-            var producer = new Producer(producerConfig);
+            var producer = new ProducerBuilder(producerConfig).Build();
             producer.Poll(TimeSpan.FromMilliseconds(10));
             producer.Dispose();
             Assert.Throws<ObjectDisposedException>(() => producer.Poll(TimeSpan.FromMilliseconds(10)));
@@ -59,7 +59,7 @@ namespace Confluent.Kafka.IntegrationTests
             LogToFile("start Consumer_ClosedHandle");
 
             var consumerConfig = new ConsumerConfig { GroupId = Guid.NewGuid().ToString(), BootstrapServers = bootstrapServers };
-            var consumer = new Consumer(consumerConfig);
+            var consumer = new ConsumerBuilder(consumerConfig).Build();
             consumer.Consume(TimeSpan.FromSeconds(10));
             consumer.Dispose();
             Assert.Throws<ObjectDisposedException>(() => consumer.Consume(TimeSpan.FromSeconds(10)));
@@ -78,7 +78,7 @@ namespace Confluent.Kafka.IntegrationTests
             LogToFile("start TypedProducer_ClosedHandle");
 
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
-            var producer = new Producer(producerConfig);
+            var producer = new ProducerBuilder(producerConfig).Build();
             producer.Flush(TimeSpan.FromMilliseconds(10));
             producer.Dispose();
             Thread.Sleep(TimeSpan.FromMilliseconds(500)); // kafka handle destroy is done on the poll thread, is not immediate.
@@ -98,7 +98,7 @@ namespace Confluent.Kafka.IntegrationTests
             LogToFile("start TypedConsumer_ClosedHandle");
 
             var consumerConfig = new ConsumerConfig { GroupId = Guid.NewGuid().ToString(), BootstrapServers = bootstrapServers };
-            var consumer = new Consumer(consumerConfig);
+            var consumer = new ConsumerBuilder(consumerConfig).Build();
             consumer.Consume(TimeSpan.FromSeconds(10));
             consumer.Dispose();
             Assert.Throws<ObjectDisposedException>(() => consumer.Consume(TimeSpan.FromSeconds(10)));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Assignment.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Assignment.cs
@@ -46,22 +46,23 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // Test in which both receive and revoke events are specified.
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    // test non-empty case.
-                    Assert.Single(c.Assignment);
-                    Assert.Equal(singlePartitionTopic, c.Assignment[0].Topic);
-                    Assert.Equal(0, (int)c.Assignment[0].Partition);
-                })
-                .SetPartitionsRevokedHandler((c, partitions) => {
-                    Assert.Single(c.Assignment);
-                    c.Unassign();
-                    Assert.Empty(c.Assignment);
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        Assert.Single(partitions);
+                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                        // test non-empty case.
+                        Assert.Single(c.Assignment);
+                        Assert.Equal(singlePartitionTopic, c.Assignment[0].Topic);
+                        Assert.Equal(0, (int)c.Assignment[0].Partition);
+                    })
+                    .SetPartitionsRevokedHandler((c, partitions) => {
+                        Assert.Single(c.Assignment);
+                        c.Unassign();
+                        Assert.Empty(c.Assignment);
+                    })
+                    .Build())
             {
                 Assert.Empty(consumer.Assignment);
                 consumer.Subscribe(singlePartitionTopic);
@@ -70,13 +71,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // test in which only the revoked event handler is specified.
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsRevokedHandler((c, partitions) => {
-                    Assert.Single(c.Assignment);
-                    c.Unassign();
-                    Assert.Empty(c.Assignment);
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsRevokedHandler((c, partitions) => {
+                        Assert.Single(c.Assignment);
+                        c.Unassign();
+                        Assert.Empty(c.Assignment);
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 
@@ -95,13 +97,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // test in which only the receive event handler is specified.
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    Assert.Empty(c.Assignment);
-                    c.Assign(partitions);
-                    Assert.Single(c.Assignment);
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        Assert.Empty(c.Assignment);
+                        c.Assign(partitions);
+                        Assert.Single(c.Assignment);
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
@@ -50,14 +50,13 @@ namespace Confluent.Kafka.IntegrationTests
                 EnablePartitionEof = true
             };
 
-            using (var consumer = new Consumer<Null, string>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
+                .SetPartitionAssignmentHandler((c, tps) => {
+                    Assert.Single(tps);
+                    c.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
+                })
+                .Build())
             {
-                consumer.OnPartitionsAssigned += (_, partitions) =>
-                {
-                    Assert.Single(partitions);
-                    consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
-                };
-
                 consumer.Subscribe(singlePartitionTopic);
 
                 int msgCnt = 0;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
@@ -50,12 +50,13 @@ namespace Confluent.Kafka.IntegrationTests
                 EnablePartitionEof = true
             };
 
-            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionAssignmentHandler((c, tps) => {
-                    Assert.Single(tps);
-                    c.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder<Null, string>(consumerConfig)
+                    .SetPartitionAssignmentHandler((c, tps) => {
+                        Assert.Single(tps);
+                        c.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
@@ -52,7 +52,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var consumer =
                 new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionAssignmentHandler((c, tps) => {
+                    .SetPartitionsAssignedHandler((c, tps) => {
                         Assert.Single(tps);
                         c.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
                     })

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
@@ -50,14 +50,14 @@ namespace Confluent.Kafka.IntegrationTests
                 EnablePartitionEof = true
             };
 
-            using (var consumer =
-                new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, tps) => {
-                        Assert.Single(tps);
-                        c.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
+                consumer.SetPartitionsAssignedHandler((_, tps) =>
+                {
+                    Assert.Single(tps);
+                    consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, firstProduced.Partition, firstProduced.Offset));
+                });
+
                 consumer.Subscribe(singlePartitionTopic);
 
                 int msgCnt = 0;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_CommitAsync_Committed_Position.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_CommitAsync_Committed_Position.cs
@@ -54,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var firstMessage = messages[0];
             var lastMessage = messages[N - 1];
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
                 
@@ -93,13 +93,13 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // Test #3
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Commit(new List<TopicPartitionOffset> { new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset + 5) });
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 5, co[0].Offset);
             }
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
 
@@ -111,14 +111,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // Test #4
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
                 consumer.Commit(new List<TopicPartitionOffset> { new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset + 3) });
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
             }
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
                 var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
@@ -129,7 +129,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // Test #5
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
                 var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
@@ -140,7 +140,7 @@ namespace Confluent.Kafka.IntegrationTests
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
             }
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
                 var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
@@ -150,7 +150,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // Test #6
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
                 var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
@@ -161,7 +161,7 @@ namespace Confluent.Kafka.IntegrationTests
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
             }
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
                 var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_CommitAsync_Committed_Position.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_CommitAsync_Committed_Position.cs
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(new TopicPartition("invalid-topic", 0), ps[0].TopicPartition);
 
                 // Test #1
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var os = consumer.Commit();
                 Assert.Equal(firstMsgOffset + 1, os[0].Offset);
                 ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
@@ -83,7 +83,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(firstMsgOffset + 1, ps[0].Offset);
                 
                 // Test #2
-                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 os = consumer.Commit();
                 Assert.Equal(firstMsgOffset + 2, os[0].Offset);
                 ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
@@ -103,7 +103,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
 
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
                 Assert.Equal(firstMsgOffset + 6, ps[0].Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
@@ -121,7 +121,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
                 Assert.Equal(firstMsgOffset + 4, ps[0].Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
@@ -132,9 +132,9 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 consumer.Commit(record3);
                 var record4 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
@@ -143,7 +143,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 Assert.Equal(firstMsgOffset + 3, record.Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
@@ -153,18 +153,18 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 consumer.Commit(record3);
-                var record4 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record4 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
             }
             using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 Assert.Equal(firstMsgOffset + 3, record.Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Consume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Consume.cs
@@ -46,13 +46,14 @@ namespace Confluent.Kafka.IntegrationTests
                 EnablePartitionEof = true
             };
 
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        Assert.Single(partitions);
+                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Consume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Consume.cs
@@ -46,15 +46,14 @@ namespace Confluent.Kafka.IntegrationTests
                 EnablePartitionEof = true
             };
 
-            using (var consumer = new Consumer(consumerConfig))
-            {
-                consumer.OnPartitionsAssigned += (_, partitions) =>
-                {
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetPartitionsAssignedHandler((c, partitions) => {
                     Assert.Single(partitions);
                     Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                };
-
+                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                })
+                .Build())
+            {
                 consumer.Subscribe(singlePartitionTopic);
 
                 int msgCnt = 0;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             DeliveryResult dr;
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 dr = producer.ProduceAsync(
                     singlePartitionTopic,
@@ -58,11 +59,10 @@ namespace Confluent.Kafka.IntegrationTests
                 ).Result;
             }
 
-            using (var consumer = new Consumer(consumerConfig))
-            {
-                consumer.OnError += (_, e)
-                    => Assert.True(false, e.Reason);
-                    
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                .Build())
+            {                    
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -59,9 +59,10 @@ namespace Confluent.Kafka.IntegrationTests
                 ).Result;
             }
 
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .Build())
             {                    
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             DeliveryResult dr;
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 dr = producer.ProduceAsync(
                     singlePartitionTopic,
@@ -58,11 +59,10 @@ namespace Confluent.Kafka.IntegrationTests
                 ).Result;
             }
 
-            using (var consumer = new Consumer(consumerConfig))
-            {
-                consumer.OnError += (_, e)
-                    => Assert.True(false, e.Reason);
-                    
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                .Build())
+            {                    
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -59,9 +59,10 @@ namespace Confluent.Kafka.IntegrationTests
                 ).Result;
             }
 
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .Build())
             {                    
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Exiting.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Exiting.cs
@@ -49,11 +49,12 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumerConfig.Set("group.id", Guid.NewGuid().ToString());
 
-                using (var consumer = new ConsumerBuilder(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, partitions) 
-                        => c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset))))
-                    .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
-                    .Build())
+                using (var consumer =
+                    new ConsumerBuilder(consumerConfig)
+                        .SetPartitionsAssignedHandler(
+                            (c, partitions) => c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset))))
+                        .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
+                        .Build())
                 {
                     consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Exiting.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Exiting.cs
@@ -49,14 +49,12 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumerConfig.Set("group.id", Guid.NewGuid().ToString());
 
-                using (var consumer = new Consumer(consumerConfig))
+                using (var consumer = new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) 
+                        => c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset))))
+                    .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
+                    .Build())
                 {
-                    consumer.OnPartitionsAssigned += (_, partitions)
-                        => consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-
-                    consumer.OnPartitionsRevoked += (_, partitions)
-                        => consumer.Unassign();
-
                     consumer.Subscribe(singlePartitionTopic);
 
                     int tryCount = 10;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Exiting.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Exiting.cs
@@ -49,13 +49,14 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumerConfig.Set("group.id", Guid.NewGuid().ToString());
 
-                using (var consumer =
-                    new ConsumerBuilder(consumerConfig)
-                        .SetPartitionsAssignedHandler(
-                            (c, partitions) => c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset))))
-                        .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
-                        .Build())
+                using (var consumer = new ConsumerBuilder(consumerConfig).Build())
                 {
+                    consumer.SetPartitionsAssignedHandler((_, partitions)
+                        => consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset))));
+
+                    consumer.SetPartitionsRevokedHandler((_, partitions)
+                        => consumer.Unassign());
+
                     consumer.Subscribe(singlePartitionTopic);
 
                     int tryCount = 10;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var firstMessage = messages[0];
             var lastMessage = messages[N - 1];
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 var timeout = TimeSpan.FromSeconds(10);
 
@@ -103,7 +104,7 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             var messages = new DeliveryResult[count];
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 for (var index = 0; index < count; index++)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
@@ -47,13 +47,14 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // no eof, non generic consumer case.
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        Assert.Single(partitions);
+                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 
@@ -70,13 +71,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // no eof, generic consumer case.
-            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionAssignmentHandler((c, tps) => {
-                    Assert.Single(tps);
-                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder<Null, string>(consumerConfig)
+                    .SetPartitionAssignmentHandler((c, tps) => {
+                        Assert.Single(tps);
+                        Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                        c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 
@@ -100,13 +102,14 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // eof, non-generic consumer case.
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        Assert.Single(partitions);
+                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 
@@ -126,13 +129,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // eof, generic consumer case.
-            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionAssignmentHandler((c, tps) => {
-                    Assert.Single(tps);
-                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder<Null, string>(consumerConfig)
+                    .SetPartitionAssignmentHandler((c, tps) => {
+                        Assert.Single(tps);
+                        Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                        c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    })
+                    .Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
@@ -47,49 +47,49 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // no eof, non generic consumer case.
-            using (var c = new Consumer(consumerConfig))
-            {
-                c.OnPartitionsAssigned += (_, partitions) =>
-                {
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetPartitionsAssignedHandler((c, partitions) => {
                     Assert.Single(partitions);
                     Assert.Equal(firstProduced.TopicPartition, partitions[0]);
                     c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                };
-                c.Subscribe(singlePartitionTopic);
+                })
+                .Build())
+            {
+                consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = c.Consume();
+                var cr1 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = c.Consume();
+                var cr2 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr3 = c.Consume(TimeSpan.FromSeconds(1));
+                var cr3 = consumer.Consume(TimeSpan.FromSeconds(1));
                 Assert.Null(cr3);
 
-                c.Close();
+                consumer.Close();
             }
 
             // no eof, generic consumer case.
-            using (var c = new Consumer<Null, string>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
+                .SetPartitionAssignmentHandler((c, tps) => {
+                    Assert.Single(tps);
+                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                })
+                .Build())
             {
-                c.OnPartitionsAssigned += (_, partitions) =>
-                {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                };
-                c.Subscribe(singlePartitionTopic);
+                consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = c.Consume();
+                var cr1 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = c.Consume();
+                var cr2 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr3 = c.Consume(TimeSpan.FromSeconds(1));
+                var cr3 = consumer.Consume(TimeSpan.FromSeconds(1));
                 Assert.Null(cr3);
 
-                c.Close();
+                consumer.Close();
             }
 
             consumerConfig = new ConsumerConfig
@@ -100,55 +100,55 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // eof, non-generic consumer case.
-            using (var c = new Consumer(consumerConfig))
-            {
-                c.OnPartitionsAssigned += (_, partitions) =>
-                {
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetPartitionsAssignedHandler((c, partitions) => {
                     Assert.Single(partitions);
                     Assert.Equal(firstProduced.TopicPartition, partitions[0]);
                     c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                };
-                c.Subscribe(singlePartitionTopic);
+                })
+                .Build())
+            {
+                consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = c.Consume();
+                var cr1 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = c.Consume();
+                var cr2 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr3 = c.Consume();
+                var cr3 = consumer.Consume();
                 Assert.Null(cr3.Message);
                 Assert.True(cr3.IsPartitionEOF);
-                var cr4 = c.Consume(TimeSpan.FromSeconds(1));
+                var cr4 = consumer.Consume(TimeSpan.FromSeconds(1));
                 Assert.Null(cr4);
 
-                c.Close();
+                consumer.Close();
             }
 
             // eof, generic consumer case.
-            using (var c = new Consumer<Null, string>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
+                .SetPartitionAssignmentHandler((c, tps) => {
+                    Assert.Single(tps);
+                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                })
+                .Build())
             {
-                c.OnPartitionsAssigned += (_, partitions) =>
-                {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                };
-                c.Subscribe(singlePartitionTopic);
+                consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = c.Consume();
+                var cr1 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = c.Consume();
+                var cr2 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr3 = c.Consume();
+                var cr3 = consumer.Consume();
                 Assert.Null(cr3.Message);
                 Assert.True(cr3.IsPartitionEOF);
-                var cr4 = c.Consume(TimeSpan.FromSeconds(1));
+                var cr4 = consumer.Consume(TimeSpan.FromSeconds(1));
                 Assert.Null(cr4);
 
-                c.Close();
+                consumer.Close();
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
@@ -47,15 +47,15 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // no eof, non generic consumer case.
-            using (var consumer =
-                new ConsumerBuilder(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, partitions) => {
-                        Assert.Single(partitions);
-                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
+                consumer.SetPartitionsAssignedHandler((c, partitions) =>
+                {
+                    Assert.Single(partitions);
+                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                });
+
                 consumer.Subscribe(singlePartitionTopic);
 
                 var cr1 = consumer.Consume();
@@ -71,15 +71,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // no eof, generic consumer case.
-            using (var consumer =
-                new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, tps) => {
-                        Assert.Single(tps);
-                        Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                        c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
+                consumer.SetPartitionsAssignedHandler((c, tps) => {
+                    Assert.Single(tps);
+                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                });
+
                 consumer.Subscribe(singlePartitionTopic);
 
                 var cr1 = consumer.Consume();
@@ -102,15 +101,14 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // eof, non-generic consumer case.
-            using (var consumer =
-                new ConsumerBuilder(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, partitions) => {
-                        Assert.Single(partitions);
-                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
+                consumer.SetPartitionsAssignedHandler((c, partitions) => {
+                    Assert.Single(partitions);
+                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                });
+
                 consumer.Subscribe(singlePartitionTopic);
 
                 var cr1 = consumer.Consume();
@@ -129,15 +127,14 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // eof, generic consumer case.
-            using (var consumer =
-                new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, tps) => {
-                        Assert.Single(tps);
-                        Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                        c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
+                consumer.SetPartitionsAssignedHandler((c, tps) => {
+                    Assert.Single(tps);
+                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                });
+
                 consumer.Subscribe(singlePartitionTopic);
 
                 var cr1 = consumer.Consume();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
@@ -73,7 +73,7 @@ namespace Confluent.Kafka.IntegrationTests
             // no eof, generic consumer case.
             using (var consumer =
                 new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionAssignmentHandler((c, tps) => {
+                    .SetPartitionsAssignedHandler((c, tps) => {
                         Assert.Single(tps);
                         Assert.Equal(firstProduced.TopicPartition, tps[0]);
                         c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
@@ -131,7 +131,7 @@ namespace Confluent.Kafka.IntegrationTests
             // eof, generic consumer case.
             using (var consumer =
                 new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionAssignmentHandler((c, tps) => {
+                    .SetPartitionsAssignedHandler((c, tps) => {
                         Assert.Single(tps);
                         Assert.Equal(firstProduced.TopicPartition, tps[0]);
                         c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -49,12 +49,13 @@ namespace Confluent.Kafka.IntegrationTests
             IEnumerable<TopicPartition> assignedPartitions = null;
 
             using (var producer = new ProducerBuilder(producerConfig).Build())
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    c.Assign(partitions);
-                    assignedPartitions = partitions;
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        c.Assign(partitions);
+                        assignedPartitions = partitions;
+                    })
+                    .Build())
             {
                 ConsumeResult record;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -22,6 +22,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
 using Xunit;
+using Confluent.Kafka.Serdes;
+
 
 namespace Confluent.Kafka.IntegrationTests
 {
@@ -44,17 +46,17 @@ namespace Confluent.Kafka.IntegrationTests
 
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
-            using (var producer = new Producer(producerConfig))
-            using (var consumer = new Consumer(consumerConfig))
-            {
-                IEnumerable<TopicPartition> assignedPartitions = null;
-                ConsumeResult record;
+            IEnumerable<TopicPartition> assignedPartitions = null;
 
-                consumer.OnPartitionsAssigned += (_, partitions) =>
-                {
-                    consumer.Assign(partitions);
+            using (var producer = new ProducerBuilder(producerConfig).Build())
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetPartitionsAssignedHandler((c, partitions) => {
+                    c.Assign(partitions);
                     assignedPartitions = partitions;
-                };
+                })
+                .Build())
+            {
+                ConsumeResult record;
 
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -49,15 +49,14 @@ namespace Confluent.Kafka.IntegrationTests
             IEnumerable<TopicPartition> assignedPartitions = null;
 
             using (var producer = new ProducerBuilder(producerConfig).Build())
-            using (var consumer =
-                new ConsumerBuilder(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, partitions) => {
-                        c.Assign(partitions);
-                        assignedPartitions = partitions;
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeResult record;
+
+                consumer.SetPartitionsAssignedHandler((c, partitions) => {
+                    c.Assign(partitions);
+                    assignedPartitions = partitions;
+                });
 
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_Error.cs
@@ -98,16 +98,17 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // test value deserialization error behavior.
-            using (var consumer = new ConsumerBuilder<string, Null>(consumerConfig)
-                .SetPartitionAssignmentHandler((c, tps) => {
-                    Assert.Single(tps);
-                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .SetPartitionAssignmentRevokedHandler((c, _) => {
-                    c.Unassign();
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder<string, Null>(consumerConfig)
+                    .SetPartitionAssignmentHandler((c, tps) => {
+                        Assert.Single(tps);
+                        Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                        c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    })
+                    .SetPartitionAssignmentRevokedHandler((c, _) => {
+                        c.Unassign();
+                    })
+                    .Build())
             {
                 int msgCnt = 0;
                 int errCnt = 0;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_Error.cs
@@ -57,21 +57,21 @@ namespace Confluent.Kafka.IntegrationTests
             };
 
             // test key deserialization error behavior
-            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionsAssignedHandler((c, tps) => {
-                    Assert.Single(tps);
-                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                })
-                .SetPartitionsRevokedHandler((c, _) => {
-                    c.Unassign();
-                })
-                .Build())
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
                 int msgCnt = 0;
                 int errCnt = 0;
                 
                 consumer.Subscribe(singlePartitionTopic);
+
+                consumer.SetPartitionsAssignedHandler((c, tps) => {
+                    Assert.Single(tps);
+                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                });
+
+                consumer.SetPartitionsRevokedHandler((c, _)
+                    => { c.Unassign(); });
 
                 while (true)
                 {
@@ -98,20 +98,20 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // test value deserialization error behavior.
-            using (var consumer =
-                new ConsumerBuilder<string, Null>(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, tps) => {
-                        Assert.Single(tps);
-                        Assert.Equal(firstProduced.TopicPartition, tps[0]);
-                        c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    })
-                    .SetPartitionsRevokedHandler((c, _) => {
-                        c.Unassign();
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder<string, Null>(consumerConfig).Build())
             {
                 int msgCnt = 0;
                 int errCnt = 0;
+
+                consumer.SetPartitionsAssignedHandler((c, tps) => 
+                {
+                    Assert.Single(tps);
+                    Assert.Equal(firstProduced.TopicPartition, tps[0]);
+                    c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                });
+
+                consumer.SetPartitionsRevokedHandler((c, _)
+                    => { c.Unassign(); });
 
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_Error.cs
@@ -58,12 +58,12 @@ namespace Confluent.Kafka.IntegrationTests
 
             // test key deserialization error behavior
             using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionAssignmentHandler((c, tps) => {
+                .SetPartitionsAssignedHandler((c, tps) => {
                     Assert.Single(tps);
                     Assert.Equal(firstProduced.TopicPartition, tps[0]);
                     c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
                 })
-                .SetPartitionAssignmentRevokedHandler((c, _) => {
+                .SetPartitionsRevokedHandler((c, _) => {
                     c.Unassign();
                 })
                 .Build())
@@ -100,12 +100,12 @@ namespace Confluent.Kafka.IntegrationTests
             // test value deserialization error behavior.
             using (var consumer =
                 new ConsumerBuilder<string, Null>(consumerConfig)
-                    .SetPartitionAssignmentHandler((c, tps) => {
+                    .SetPartitionsAssignedHandler((c, tps) => {
                         Assert.Single(tps);
                         Assert.Equal(firstProduced.TopicPartition, tps[0]);
                         c.Assign(tps.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
                     })
-                    .SetPartitionAssignmentRevokedHandler((c, _) => {
+                    .SetPartitionsRevokedHandler((c, _) => {
                         c.Unassign();
                     })
                     .Build())

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,12 +45,11 @@ namespace Confluent.Kafka.IntegrationTests
 
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
-            using (var producer = new Producer(producerConfig))
-            using (var consumer = new Consumer<Null, string>(consumerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
+                .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                .Build())
             {
-                consumer.OnError += (_, e)
-                    => Assert.True(false, e.Reason);
-
                 const string checkValue = "check value";
                 var dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize(checkValue, true, null, null) }).Result;
                 var dr2 = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize("second value", true, null, null) }).Result;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
@@ -46,9 +46,10 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             using (var producer = new ProducerBuilder(producerConfig).Build())
-            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder<Null, string>(consumerConfig)
+                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .Build())
             {
                 const string checkValue = "check value";
                 var dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize(checkValue, true, null, null) }).Result;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
@@ -48,12 +48,13 @@ namespace Confluent.Kafka.IntegrationTests
             IEnumerable<TopicPartition> assignedPartitions = null;
 
             using (var producer = new ProducerBuilder(producerConfig).Build())
-            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionAssignmentHandler((c, tps) => {
-                    c.Assign(tps);
-                    assignedPartitions = tps;
-                })
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder<Null, string>(consumerConfig)
+                    .SetPartitionAssignmentHandler((c, tps) => {
+                        c.Assign(tps);
+                        assignedPartitions = tps;
+                    })
+                    .Build())
             {
                 ConsumeResult<Null, string> record;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
@@ -48,15 +48,15 @@ namespace Confluent.Kafka.IntegrationTests
             IEnumerable<TopicPartition> assignedPartitions = null;
 
             using (var producer = new ProducerBuilder(producerConfig).Build())
-            using (var consumer =
-                new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, tps) => {
-                        c.Assign(tps);
-                        assignedPartitions = tps;
-                    })
-                    .Build())
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
                 ConsumeResult<Null, string> record;
+
+                consumer.SetPartitionsAssignedHandler((c, tps) =>
+                {
+                    c.Assign(tps);
+                    assignedPartitions = tps;
+                });
 
                 consumer.Subscribe(topic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new ProducerBuilder(producerConfig).Build())
             using (var consumer =
                 new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionAssignmentHandler((c, tps) => {
+                    .SetPartitionsAssignedHandler((c, tps) => {
                         c.Assign(tps);
                         assignedPartitions = tps;
                     })

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription.cs
@@ -45,24 +45,20 @@ namespace Confluent.Kafka.IntegrationTests
                 SessionTimeoutMs = 6000
             };
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetPartitionsAssignedHandler((c, partitions) => {
+                    Assert.Single(partitions);
+                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    // test non-empty case.
+                    Assert.Single(c.Subscription);
+                    Assert.Equal(singlePartitionTopic, c.Subscription[0]);
+                })
+                .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
+                .Build())
             {
                 // Test empty case.
                 Assert.Empty(consumer.Subscription);
-
-                consumer.OnPartitionsAssigned += (_, partitions) =>
-                {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-
-                    // test non-empty case.
-                    Assert.Single(consumer.Subscription);
-                    Assert.Equal(singlePartitionTopic, consumer.Subscription[0]);
-                };
-
-                consumer.OnPartitionsRevoked += (_, partitions)
-                    => consumer.Unassign();
 
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription.cs
@@ -45,17 +45,18 @@ namespace Confluent.Kafka.IntegrationTests
                 SessionTimeoutMs = 6000
             };
 
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetPartitionsAssignedHandler((c, partitions) => {
-                    Assert.Single(partitions);
-                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                    c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                    // test non-empty case.
-                    Assert.Single(c.Subscription);
-                    Assert.Equal(singlePartitionTopic, c.Subscription[0]);
-                })
-                .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
-                .Build())
+            using (var consumer =
+                new ConsumerBuilder(consumerConfig)
+                    .SetPartitionsAssignedHandler((c, partitions) => {
+                        Assert.Single(partitions);
+                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                        // test non-empty case.
+                        Assert.Single(c.Subscription);
+                        Assert.Equal(singlePartitionTopic, c.Subscription[0]);
+                    })
+                    .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
+                    .Build())
             {
                 // Test empty case.
                 Assert.Empty(consumer.Subscription);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription.cs
@@ -45,21 +45,23 @@ namespace Confluent.Kafka.IntegrationTests
                 SessionTimeoutMs = 6000
             };
 
-            using (var consumer =
-                new ConsumerBuilder(consumerConfig)
-                    .SetPartitionsAssignedHandler((c, partitions) => {
-                        Assert.Single(partitions);
-                        Assert.Equal(firstProduced.TopicPartition, partitions[0]);
-                        c.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
-                        // test non-empty case.
-                        Assert.Single(c.Subscription);
-                        Assert.Equal(singlePartitionTopic, c.Subscription[0]);
-                    })
-                    .SetPartitionsRevokedHandler((c, partitions) => c.Unassign())
-                    .Build())
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 // Test empty case.
                 Assert.Empty(consumer.Subscription);
+
+                consumer.SetPartitionsAssignedHandler((_, partitions) =>
+                {
+                    Assert.Single(partitions);
+                    Assert.Equal(firstProduced.TopicPartition, partitions[0]);
+                    consumer.Assign(partitions.Select(p => new TopicPartitionOffset(p, firstProduced.Offset)));
+                    // test non-empty case.
+                    Assert.Single(consumer.Subscription);
+                    Assert.Equal(singlePartitionTopic, consumer.Subscription[0]);
+                });
+
+                consumer.SetPartitionsRevokedHandler((_, partitions)
+                    => consumer.Unassign());
 
                 consumer.Subscribe(singlePartitionTopic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -49,15 +50,15 @@ namespace Confluent.Kafka.IntegrationTests
             var testString = "hello world";
 
             DeliveryResult dr;
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize(testString, true, null, null) }).Result;
                 Assert.NotNull(dr);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            using (var consumer1 = new Consumer(consumerConfig))
-            using (var consumer2 = new Consumer(consumerConfig))
+            using (var consumer1 = new ConsumerBuilder(consumerConfig).Build())
+            using (var consumer2 = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer1.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(singlePartitionTopic, dr.Partition, 0) });
                 consumer2.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(singlePartitionTopic, dr.Partition, 0) });

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -40,12 +41,12 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var consumerConfig = new ConsumerConfig { GroupId = Guid.NewGuid().ToString(), BootstrapServers = bootstrapServers };
 
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize("test string", true, null, null) }).Wait();
             }
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
                 consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -126,7 +126,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 producer.Flush(TimeSpan.FromSeconds(10));
 
-                Assert.Empty(drs[0].Message.Headers);
+                Assert.Empty(drs[0].Message.Headers); // TODO: this is intermittently not working.
                 Assert.Equal(2, drs[1].Message.Headers.Count);
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
             var drs = new List<DeliveryReport<Null, string>>();
             DeliveryResult<Null, string> dr_single, dr_empty, dr_null, dr_multiple, dr_duplicate;
             DeliveryResult<Null, string> dr_ol1, dr_ol3;
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
                 // single header value.
                 var headers = new Headers();
@@ -132,7 +132,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             List<DeliveryReport<byte[], byte[]>> drs_2 = new List<DeliveryReport<byte[], byte[]>>();
             DeliveryResult<byte[], byte[]> dr_ol4, dr_ol5, dr_ol6, dr_ol7;
-            using (var producer = new Producer<byte[], byte[]>(producerConfig))
+            using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 var headers = new Headers();
                 headers.Add("hkey", new byte[] { 44 });
@@ -165,7 +165,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Single(drs_2[3].Message.Headers);
             }
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new List<TopicPartitionOffset>() {dr_single.TopicPartitionOffset});
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -282,7 +282,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             // null key
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 var headers = new Headers();
                 var threw = false;
@@ -306,7 +306,7 @@ namespace Confluent.Kafka.IntegrationTests
             // null value
 
             DeliveryResult<Null, string> nulldr;
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
                 var headers = new Headers();
                 headers.Add("my-header", null);
@@ -314,7 +314,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Single(nulldr.Headers);
                 Assert.Null(nulldr.Headers[0].Value);
             }
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, nulldr.Offset));
                 var cr = consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             DeliveryResult<byte[], byte[]> dr;
-            using (var producer = new Producer<byte[], byte[]>(producerConfig))
+            using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 // Assume that all these produce calls succeed.
                 dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }).Result;
@@ -47,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            using (var consumer = new Consumer<Ignore, Ignore>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Ignore, Ignore>(consumerConfig).Build())
             {
                 consumer.Assign(new List<TopicPartitionOffset>() { dr.TopicPartitionOffset });
 
@@ -67,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(record.Message.Value);
             }
 
-            using (var consumer = new Consumer<Ignore, byte[]>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Ignore, byte[]>(consumerConfig).Build())
             {
                 consumer.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(dr.TopicPartition, dr.Offset.Value + 3) });
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -50,11 +50,24 @@ namespace Confluent.Kafka.IntegrationTests
                 Debug = "all"
             };
 
+            var adminConfig = new AdminClientConfig
+            {
+                BootstrapServers = bootstrapServers,
+                Debug = "all"
+            };
+
             DeliveryResult dr;
 
+<<<<<<< HEAD
             using (var producer = new ProducerBuilder(producerConfig)
                 .SetLogHandler((_, m) => logCount += 1)
                 .Build())
+=======
+            using (var producer =
+                Producer.CreateBuilder(producerConfig)
+                    .SetLogHandler((_, m) => logCount += 1)
+                    .Build())
+>>>>>>> f181216... added AdminClient log callback test
             {
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize("test value", true, null, null) }).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
@@ -62,13 +75,29 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.True(logCount > 0);
 
             logCount = 0;
+<<<<<<< HEAD
             using (var consumer = new ConsumerBuilder(consumerConfig)
                 .SetLogHandler((_, m) => logCount += 1)
                 .Build())
+=======
+            using (var consumer =
+                Consumer.CreateBuilder(consumerConfig)
+                    .SetLogHandler((_, m) => logCount += 1)
+                    .Build())
+>>>>>>> f181216... added AdminClient log callback test
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                
                 consumer.Consume(TimeSpan.FromSeconds(10));
+            }
+            Assert.True(logCount > 0);
+
+            logCount = 0;
+            using (var adminClient =
+                AdminClient.CreateBuilder(adminConfig)
+                    .SetLogHandler((_, m) => logCount += 1)
+                    .Build())
+            {
+                adminClient.GetMetadata(TimeSpan.FromSeconds(1));
             }
             Assert.True(logCount > 0);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -51,22 +52,20 @@ namespace Confluent.Kafka.IntegrationTests
 
             DeliveryResult dr;
 
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig)
+                .SetLogHandler((_, m) => logCount += 1)
+                .Build())
             {
-                producer.OnLog += (_, m)
-                    => logCount += 1;
-
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize("test value", true, null, null) }).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);
 
             logCount = 0;
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig)
+                .SetLogHandler((_, m) => logCount += 1)
+                .Build())
             {
-                consumer.OnLog += (_, m)
-                    => logCount += 1;
-
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
                 
                 consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -58,16 +58,10 @@ namespace Confluent.Kafka.IntegrationTests
 
             DeliveryResult dr;
 
-<<<<<<< HEAD
-            using (var producer = new ProducerBuilder(producerConfig)
-                .SetLogHandler((_, m) => logCount += 1)
-                .Build())
-=======
             using (var producer =
-                Producer.CreateBuilder(producerConfig)
+                new ProducerBuilder(producerConfig)
                     .SetLogHandler((_, m) => logCount += 1)
                     .Build())
->>>>>>> f181216... added AdminClient log callback test
             {
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize("test value", true, null, null) }).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
@@ -75,16 +69,10 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.True(logCount > 0);
 
             logCount = 0;
-<<<<<<< HEAD
-            using (var consumer = new ConsumerBuilder(consumerConfig)
-                .SetLogHandler((_, m) => logCount += 1)
-                .Build())
-=======
             using (var consumer =
-                Consumer.CreateBuilder(consumerConfig)
+                new ConsumerBuilder(consumerConfig)
                     .SetLogHandler((_, m) => logCount += 1)
                     .Build())
->>>>>>> f181216... added AdminClient log callback test
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
                 consumer.Consume(TimeSpan.FromSeconds(10));
@@ -93,7 +81,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             logCount = 0;
             using (var adminClient =
-                AdminClient.CreateBuilder(adminConfig)
+                new AdminClientBuilder(adminConfig)
                     .SetLogHandler((_, m) => logCount += 1)
                     .Build())
             {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Metadata.cs
@@ -36,7 +36,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var config = new AdminClientConfig { BootstrapServers = bootstrapServers };
 
-            using (var adminClient = new AdminClient(config))
+            using (var adminClient = new AdminClientBuilder(config).Build())
             {
                 var metadata = adminClient.GetMetadata(TimeSpan.FromSeconds(10));
                 Assert.NotNull(metadata.Brokers);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -43,7 +43,7 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             DeliveryResult dr;
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 // Assume that all these produce calls succeed.
                 dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message { Key = null, Value = null }).Result;
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Assign(new List<TopicPartitionOffset>() { dr.TopicPartitionOffset });
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Text;
 using System.Collections.Generic;
@@ -46,14 +47,14 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
             // Producing onto the topic to make sure it exists.
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 var dr = producer.ProduceAsync(singlePartitionTopic, new Message { Value = Serializers.Utf8.Serialize("test string", true, null, null) }).Result;
                 Assert.NotEqual(Offset.Invalid, dr.Offset);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 consumer.Subscribe(singlePartitionTopic);
                 Assert.Empty(consumer.Assignment);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce.cs
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.IntegrationTests
                 count += 1;
             };
 
-            using (var producer = new Producer<string, string>(producerConfig))
+            using (var producer = new ProducerBuilder<string, string>(producerConfig).Build())
             {
                 producer.BeginProduce(
                     new TopicPartition(singlePartitionTopic, 0), 
@@ -89,7 +89,7 @@ namespace Confluent.Kafka.IntegrationTests
                 count += 1;
             };
 
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 producer.BeginProduce(
                     new TopicPartition(singlePartitionTopic, 0), 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Null.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Null.cs
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                 count += 1;
             };
 
-            using (var producer = new Producer<Null, Null>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, Null>(producerConfig).Build())
             {
                 producer.BeginProduce(new TopicPartition(singlePartitionTopic, 0), new Message<Null, Null> {}, dh);
                 producer.BeginProduce(singlePartitionTopic, new Message<Null, Null> {}, dh);
@@ -79,7 +79,7 @@ namespace Confluent.Kafka.IntegrationTests
                 count += 1;
             };
 
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 producer.BeginProduce(new TopicPartition(singlePartitionTopic, 0), new Message {}, dh2);
                 producer.BeginProduce(singlePartitionTopic, new Message {}, dh2);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_DisableDeliveryReports.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_DisableDeliveryReports.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
             // If delivery reports are disabled:
             //   1. delivery handlers may not be specified.
             //   2. tasks should complete immediately.
-            using (var producer = new Producer<byte[], byte[]>(producerConfig))
+            using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 Assert.Throws<ArgumentException>(() => producer.BeginProduce(
                     singlePartitionTopic,

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_OptimizeDeliveryReports.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_OptimizeDeliveryReports.cs
@@ -45,7 +45,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             // serializing case. 
 
-            using (var producer = new Producer<byte[], byte[]>(producerConfig))
+            using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 var dr = await producer.ProduceAsync(
                     singlePartitionTopic, 
@@ -66,7 +66,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             // byte[] case. 
 
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 var dr = await producer.ProduceAsync(
                     singlePartitionTopic, 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -38,7 +38,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             Func<Task> mthd = async () => 
             {
-                using (var producer = new Producer<Null, string>(new ProducerConfig { BootstrapServers = bootstrapServers }))
+                using (var producer = new ProducerBuilder<Null, string>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
                 {
                     var dr = await producer.ProduceAsync(
                         singlePartitionTopic,
@@ -63,7 +63,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             LogToFile("start Producer_ProduceAsync_Await_NonSerializing");
 
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 var dr = await producer.ProduceAsync(
                     singlePartitionTopic,
@@ -72,6 +72,7 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
             Assert.Equal(0, Library.HandleCount);
+
             LogToFile("end   Producer_ProduceAsync_Await_NonSerializing");
         }
 
@@ -84,7 +85,7 @@ namespace Confluent.Kafka.IntegrationTests
         {
             LogToFile("start Producer_ProduceAsync_Await_Throws");
 
-            using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+            using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 await Assert.ThrowsAsync<ProduceException>(
                     async () => 
@@ -100,7 +101,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             Func<Task> mthd = async () =>
             {
-                using (var producer = new Producer(new ProducerConfig { BootstrapServers = bootstrapServers }))
+                using (var producer = new ProducerBuilder(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
                 {
                     var dr = await producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 1001),

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
@@ -41,7 +41,7 @@ namespace Confluent.Kafka.IntegrationTests
             // serialize case
 
             Task<DeliveryResult<string, string>> drt;
-            using (var producer = new Producer<string, string>(producerConfig))
+            using (var producer = new ProducerBuilder<string, string>(producerConfig).Build())
             {
                 drt = producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 42),
@@ -75,7 +75,7 @@ namespace Confluent.Kafka.IntegrationTests
             // byte[] case
 
             Task<DeliveryResult> drt2;
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 drt2 = producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 42),

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
@@ -42,7 +42,7 @@ namespace Confluent.Kafka.IntegrationTests
             // serialize case
 
             var drs = new List<Task<DeliveryResult<Null, Null>>>();
-            using (var producer = new Producer<Null, Null>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, Null>(producerConfig).Build())
             {
                 drs.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 0), new Message<Null, Null> {}));
@@ -68,7 +68,7 @@ namespace Confluent.Kafka.IntegrationTests
             // byte[] case
         
             var drs2 = new List<Task<DeliveryResult>>();
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 drs2.Add(producer.ProduceAsync(new TopicPartition(partitionedTopic, 1), new Message {}));
                 drs2.Add(producer.ProduceAsync(partitionedTopic, new Message {}));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -42,7 +42,7 @@ namespace Confluent.Kafka.IntegrationTests
             // serialize case
 
             var drs = new List<Task<DeliveryResult<string, string>>>();
-            using (var producer = new Producer<string, string>(producerConfig))
+            using (var producer = new ProducerBuilder<string, string>(producerConfig).Build())
             {
                 drs.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 1),
@@ -71,7 +71,7 @@ namespace Confluent.Kafka.IntegrationTests
             // byte[] case
 
             var drs2 = new List<Task<DeliveryResult>>();
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 drs2.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 1),

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -52,13 +52,13 @@ namespace Confluent.Kafka.IntegrationTests
 
             DeliveryResult<Null, string> produceResult1;
             DeliveryResult<Null, string> produceResult2;
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
                 produceResult1 = ProduceMessage(singlePartitionTopic, producer, testString1);
                 produceResult2 = ProduceMessage(singlePartitionTopic, producer, testString2);
             }
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeMessage(consumer, produceResult1, testString1);
                 ConsumeMessage(consumer, produceResult2, testString2);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
@@ -48,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var drs_beginProduce = new List<DeliveryReport<Null, string>>();
             var drs_task = new List<DeliveryResult<Null, string>>();
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
                 // --- ProduceAsync, serializer case.
 
@@ -141,7 +141,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             var drs2_beginProduce = new List<DeliveryReport>();
             var drs2_task = new List<DeliveryResult>();
-            using (var producer = new Producer(producerConfig))
+            using (var producer = new ProducerBuilder(producerConfig).Build())
             {
                 // --- ProduceAsync, byte[] case.
 
@@ -204,7 +204,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
-            using (var consumer = new Consumer<Null, string>(consumerConfig))
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
             {
                 // serializing async
 
@@ -231,7 +231,7 @@ namespace Confluent.Kafka.IntegrationTests
                 assertCloseToNow(consumer, drs_beginProduce[2].TopicPartitionOffset);
             }
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             {
                 ConsumeResult record;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -40,7 +40,7 @@ namespace Confluent.Kafka.IntegrationTests
             var testString = "hello world";
 
             DeliveryResult<Null, string> dr;
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             using (var adminClient = new AdminClient(producer.Handle))
             {
                 dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString }).Result;
@@ -65,7 +65,7 @@ namespace Confluent.Kafka.IntegrationTests
                 SessionTimeoutMs = 6000
             };
 
-            using (var consumer = new Consumer(consumerConfig))
+            using (var consumer = new ConsumerBuilder(consumerConfig).Build())
             using (var adminClient = new AdminClient(consumer.Handle))
             {
                 consumer.Assign(new List<TopicPartitionOffset>() { dr.TopicPartitionOffset });

--- a/test/Confluent.Kafka.IntegrationTests/Util.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Util.cs
@@ -44,7 +44,7 @@ namespace Confluent.Kafka.IntegrationTests
             var msg = sb.ToString();
 
             DeliveryResult<Null, string> firstDeliveryReport = null;
-            using (var producer = new Producer<Null, string>(producerConfig))
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
                 for (int i=0; i<number; ++i)
                 {

--- a/test/Confluent.Kafka.UnitTests/Consumer.cs
+++ b/test/Confluent.Kafka.UnitTests/Consumer.cs
@@ -30,35 +30,35 @@ namespace Confluent.Kafka.UnitTests
             // Throw exception if 'group.id' is not set in config and ensure that exception
             // mentions 'group.id'.
             var config = new ConsumerConfig();
-            var e = Assert.Throws<ArgumentException>(() => { var c = new Consumer(config); });
+            var e = Assert.Throws<ArgumentException>(() => { var c = new ConsumerBuilder(config).Build(); });
             Assert.Contains("group.id", e.Message);
 
             // Throw exception if a config value is null and ensure that exception mentions the
             // respective config key.
             var configWithNullValue = CreateValidConfiguration();
             configWithNullValue.Set("sasl.password", null);
-            e = Assert.Throws<ArgumentException>(() => { var c = new Consumer(configWithNullValue); });
+            e = Assert.Throws<ArgumentException>(() => { var c = new ConsumerBuilder(configWithNullValue).Build(); });
             Assert.Contains("sasl.password", e.Message);
 
             // Throw an exception if dotnet.cancellation.delay.max.ms is out of range.
             e = Assert.Throws<ArgumentException>(() =>
             {
-                var c = new Consumer(new ConsumerConfig
+                var c = new ConsumerBuilder(new ConsumerConfig
                 {
                     BootstrapServers = "localhost:9092",
                     GroupId = Guid.NewGuid().ToString(),
                     CancellationDelayMaxMs = 0
-                });
+                }).Build();
             });
             Assert.Contains("range", e.Message);
             e = Assert.Throws<ArgumentException>(() =>
             {
-                var c = new Consumer(new ConsumerConfig
+                var c = new ConsumerBuilder(new ConsumerConfig
                 {
                     BootstrapServers = "localhost:9092",
                     GroupId = Guid.NewGuid().ToString(),
                     CancellationDelayMaxMs = 10001
-                });
+                }).Build();
             });
             Assert.Contains("range", e.Message);
         }

--- a/test/Confluent.Kafka.UnitTests/InvalidHandle.cs
+++ b/test/Confluent.Kafka.UnitTests/InvalidHandle.cs
@@ -46,15 +46,15 @@ namespace Confluent.Kafka.UnitTests
                 SslCaLocation = "invalid"
             };
 
-            InvalidOperationException e = Assert.Throws<InvalidOperationException>(() => new Consumer(cConfig));
+            InvalidOperationException e = Assert.Throws<InvalidOperationException>(() => new ConsumerBuilder(cConfig).Build());
             Assert.Contains("ssl.ca.location failed", e.Message);
             // note: if this test fails, it may be because another error is thrown
             // in a new librdkafka version, adapt test in this case
 
-            e = Assert.Throws<InvalidOperationException>(() => new Consumer(cConfig));
+            e = Assert.Throws<InvalidOperationException>(() => new ConsumerBuilder(cConfig).Build());
             Assert.Contains("ssl.ca.location failed", e.Message);
 
-            e = Assert.Throws<InvalidOperationException>(() => new Producer(pConfig));
+            e = Assert.Throws<InvalidOperationException>(() => new ProducerBuilder(pConfig).Build());
             Assert.Contains("ssl.ca.location failed", e.Message);
         }
     }

--- a/test/Confluent.Kafka.UnitTests/Producer.cs
+++ b/test/Confluent.Kafka.UnitTests/Producer.cs
@@ -31,7 +31,7 @@ namespace Confluent.Kafka.UnitTests
             // respective config key.
             var configWithNullValue = new ProducerConfig();
             configWithNullValue.Set("sasl.password", null);
-            var e = Assert.Throws<ArgumentException>(() => { var c = new Producer(configWithNullValue); });
+            var e = Assert.Throws<ArgumentException>(() => { var c = new ProducerBuilder(configWithNullValue).Build(); });
             Assert.Contains("sasl.password", e.Message);
         }
     }

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -1,4 +1,21 @@
-﻿using Xunit;
+﻿// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Confluent.Kafka.Serdes;
+using Xunit;
 
 
 namespace Confluent.Kafka.UnitTests.Serialization

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2017 Confluent Inc.
+﻿// Copyright 2016-2019 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using Confluent.Kafka.Serdes;
 using Xunit;
 using System.Text;
 using System.Collections.Generic;

--- a/test/Confluent.Kafka.VerifiableClient/Program.cs
+++ b/test/Confluent.Kafka.VerifiableClient/Program.cs
@@ -314,11 +314,12 @@ namespace Confluent.Kafka.VerifiableClient
             Config = clientConfig;
             Config.Conf["enable.auto.commit"] = Config.AutoCommit;
             var consumerConfig = new ConsumerConfig(Config.Conf.ToDictionary(a => a.Key, a => a.Value.ToString()));
-            consumer = new ConsumerBuilder<Null, string>(consumerConfig)
-                .SetPartitionAssignmentHandler((_, partitions) => HandleAssign(partitions))
-                .SetPartitionAssignmentRevokedHandler((_, partitions) => HandleRevoke(partitions))
-                .SetOffsetsCommittedHandler((_, offsets) => SendOffsetsCommitted(offsets))
-                .Build();
+            consumer =
+                new ConsumerBuilder<Null, string>(consumerConfig)
+                    .SetPartitionAssignmentHandler((_, partitions) => HandleAssign(partitions))
+                    .SetPartitionAssignmentRevokedHandler((_, partitions) => HandleRevoke(partitions))
+                    .SetOffsetsCommittedHandler((_, offsets) => SendOffsetsCommitted(offsets))
+                    .Build();
             consumedMsgsAtLastCommit = 0;
             Dbg($"Created Consumer {consumer.Name} with AutoCommit={Config.AutoCommit}");
         }

--- a/test/Confluent.Kafka.VerifiableClient/Program.cs
+++ b/test/Confluent.Kafka.VerifiableClient/Program.cs
@@ -158,7 +158,7 @@ namespace Confluent.Kafka.VerifiableClient
         {
             Config = clientConfig;
             var producerConfig = new ProducerConfig(Config.Conf.ToDictionary(a => a.Key, a => a.Value.ToString()));
-            Handle = new Producer(producerConfig);
+            Handle = new ProducerBuilder(producerConfig).Build();
             ProduceLock = new object();
             Dbg("Created producer " + Handle.Name);
         }
@@ -309,13 +309,16 @@ namespace Confluent.Kafka.VerifiableClient
             }
         };
 
-
         public VerifiableConsumer(VerifiableConsumerConfig clientConfig)
         {
             Config = clientConfig;
             Config.Conf["enable.auto.commit"] = Config.AutoCommit;
             var consumerConfig = new ConsumerConfig(Config.Conf.ToDictionary(a => a.Key, a => a.Value.ToString()));
-            consumer = new Consumer<Null, string>(consumerConfig);
+            consumer = new ConsumerBuilder<Null, string>(consumerConfig)
+                .SetPartitionAssignmentHandler((_, partitions) => HandleAssign(partitions))
+                .SetPartitionAssignmentRevokedHandler((_, partitions) => HandleRevoke(partitions))
+                .SetOffsetsCommittedHandler((_, offsets) => SendOffsetsCommitted(offsets))
+                .Build();
             consumedMsgsAtLastCommit = 0;
             Dbg($"Created Consumer {consumer.Name} with AutoCommit={Config.AutoCommit}");
         }
@@ -605,16 +608,6 @@ namespace Confluent.Kafka.VerifiableClient
         public override void Run()
         {
             Send("startup_complete", new Dictionary<string, object>());
-
-            consumer.OnPartitionsAssigned += (_, partitions)
-                => HandleAssign(partitions);
-
-            consumer.OnPartitionsRevoked += (_, partitions)
-                => HandleRevoke(partitions);
-
-            // Only used when auto-commits enabled
-            consumer.OnOffsetsCommitted += (_, offsets)
-                => SendOffsetsCommitted(offsets);
 
             consumer.Subscribe(Config.Topic);
 

--- a/test/Confluent.Kafka.VerifiableClient/Program.cs
+++ b/test/Confluent.Kafka.VerifiableClient/Program.cs
@@ -316,8 +316,8 @@ namespace Confluent.Kafka.VerifiableClient
             var consumerConfig = new ConsumerConfig(Config.Conf.ToDictionary(a => a.Key, a => a.Value.ToString()));
             consumer =
                 new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionAssignmentHandler((_, partitions) => HandleAssign(partitions))
-                    .SetPartitionAssignmentRevokedHandler((_, partitions) => HandleRevoke(partitions))
+                    .SetPartitionsAssignedHandler((_, partitions) => HandleAssign(partitions))
+                    .SetPartitionsRevokedHandler((_, partitions) => HandleRevoke(partitions))
                     .SetOffsetsCommittedHandler((_, offsets) => SendOffsetsCommitted(offsets))
                     .Build();
             consumedMsgsAtLastCommit = 0;

--- a/test/Confluent.Kafka.VerifiableClient/Program.cs
+++ b/test/Confluent.Kafka.VerifiableClient/Program.cs
@@ -314,12 +314,11 @@ namespace Confluent.Kafka.VerifiableClient
             Config = clientConfig;
             Config.Conf["enable.auto.commit"] = Config.AutoCommit;
             var consumerConfig = new ConsumerConfig(Config.Conf.ToDictionary(a => a.Key, a => a.Value.ToString()));
-            consumer =
-                new ConsumerBuilder<Null, string>(consumerConfig)
-                    .SetPartitionsAssignedHandler((_, partitions) => HandleAssign(partitions))
-                    .SetPartitionsRevokedHandler((_, partitions) => HandleRevoke(partitions))
-                    .SetOffsetsCommittedHandler((_, offsets) => SendOffsetsCommitted(offsets))
-                    .Build();
+            consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build();
+            consumer.SetPartitionsAssignedHandler((_, partitions) => HandleAssign(partitions));
+            consumer.SetPartitionsRevokedHandler((_, partitions) => HandleRevoke(partitions));
+            consumer.SetOffsetsCommittedHandler((_, offsets) => SendOffsetsCommitted(offsets));
+
             consumedMsgsAtLastCommit = 0;
             Dbg($"Created Consumer {consumer.Name} with AutoCommit={Config.AutoCommit}");
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/TemporaryTopic.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/TemporaryTopic.cs
@@ -29,7 +29,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         public TemporaryTopic(string bootstrapServers, int numPartitions)
         {
             Name = Guid.NewGuid().ToString();
-            adminClient = new AdminClient(new AdminClientConfig { BootstrapServers = bootstrapServers });
+            adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
             adminClient.CreateTopicsAsync(
                     new List<TopicSpecification> { new TopicSpecification { Name = Name, NumPartitions = numPartitions, ReplicationFactor = 1 } }).Wait();
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
@@ -55,10 +55,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 // first a quick check the value case fails.
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-                using (var producer = new Producer<string, int>(
-                    producerConfig,
-                    new AvroSerializer<string>(schemaRegistry),
-                    new AvroSerializer<int>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false })))
+                using (var producer =
+                    new ProducerBuilder<string, int>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<int>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }))
+                        .Build())
                 {
                     Assert.Throws<SerializationException>(() =>
                     {
@@ -78,10 +79,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 // the following tests all check behavior in the key case.
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-                using (var producer = new Producer<string, int>(
-                    producerConfig,
-                    new AvroSerializer<string>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }),
-                    new AvroSerializer<int>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<string, int>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<string>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }))
+                        .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
+                        .Build())
                 {
                     Assert.Throws<SerializationException>(() =>
                     {
@@ -98,18 +100,22 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 // allow auto register..
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-                using (var producer = new Producer<string, int>(producerConfig,
-                    new AvroSerializer<string>(schemaRegistry), new AvroSerializer<int>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<string, int>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
+                        .Build())
                 {
                     producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
                 }
 
                 // config with avro.serializer.auto.register.schemas == false should work now.
                 using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryServers }))
-                using (var producer = new Producer<string, int>(
-                    producerConfig,
-                    new AvroSerializer<string>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }),
-                    new AvroSerializer<int>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<string, int>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<string>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }))
+                        .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
+                        .Build())
                 {
                     producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
                 }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -14,12 +14,13 @@
 //
 // Refer to LICENSE for more information.
 
-using System;
-using System.Collections.Generic;
 using Confluent.Kafka;
+using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.Kafka.Examples.AvroSpecific;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 
@@ -55,8 +56,10 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 };
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-                using (var producer = new Producer<string, string>(producerConfig,
-                    Serializers.Utf8, new AvroSerializer<string>(schemaRegistry)))
+                using (var producer = new ProducerBuilder<string, string>(producerConfig)
+                    .SetKeySerializer(Serializers.Utf8)
+                    .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
+                    .Build())
                 {
                     // implicit check that this does not fail.
                     producer.ProduceAsync(topic1.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();
@@ -77,8 +80,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 }
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-                using (var producer = new Producer<string, string>(producerConfig,
-                    new AvroSerializer<string>(schemaRegistry), Serializers.Utf8))
+                using (var producer =
+                    new ProducerBuilder<string, string>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                        .SetValueSerializer(Serializers.Utf8)
+                        .Build())
                 {
                     // implicit check that this does not fail.
                     producer.ProduceAsync(topic2.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();
@@ -101,8 +107,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 // check the above can be consumed (using regular / Avro serializers as appropriate)
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
                 {
-                    using (var consumer = new Consumer<string, string>(consumerConfig,
-                        Deserializers.Utf8, new AvroDeserializer<string>(schemaRegistry)))
+                    using (var consumer =
+                        new ConsumerBuilder<string, string>(consumerConfig)
+                            .SetKeyDeserializer(Deserializers.Utf8)
+                            .SetValueDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                            .Build())
                     {
                         consumer.Assign(new TopicPartitionOffset(topic1.Name, 0, 0));
                         var cr = consumer.Consume();
@@ -110,8 +119,10 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         Assert.Equal("world", cr.Value);
                     }
 
-                    using (var consumer = new Consumer<string, string>(consumerConfig,
-                        new AvroDeserializer<string>(schemaRegistry), Deserializers.Utf8))
+                    using (var consumer =
+                        new ConsumerBuilder<string, string>(consumerConfig)
+                            .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                            .SetValueDeserializer(Deserializers.Utf8).Build())
                     {
                         consumer.Assign(new TopicPartitionOffset(topic2.Name, 0, 0));
                         var cr = consumer.Consume();
@@ -119,8 +130,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         Assert.Equal("world", cr.Value);
                     }
 
-                    using (var consumer = new Consumer<string, string>(consumerConfig,
-                        Deserializers.Utf8, new AvroDeserializer<string>(schemaRegistry)))
+                    using (var consumer =
+                        new ConsumerBuilder<string, string>(consumerConfig)
+                            .SetKeyDeserializer(Deserializers.Utf8)
+                            .SetValueDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                            .Build())
                     {
                         consumer.Assign(new TopicPartitionOffset(topic2.Name, 0, 0));
                         Assert.ThrowsAny<DeserializationException>(() => 
@@ -136,8 +150,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             });
                     }
 
-                    using (var consumer = new Consumer<string, string>(consumerConfig,
-                        new AvroDeserializer<string>(schemaRegistry), Deserializers.Utf8))
+                    using (var consumer =
+                        new ConsumerBuilder<string, string>(consumerConfig)
+                            .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                            .SetValueDeserializer(Deserializers.Utf8)
+                            .Build())
                     {
                         consumer.Assign(new TopicPartitionOffset(topic1.Name, 0, 0));
                         Assert.ThrowsAny<DeserializationException>(() =>

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -56,10 +56,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 };
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-                using (var producer = new ProducerBuilder<string, string>(producerConfig)
-                    .SetKeySerializer(Serializers.Utf8)
-                    .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
-                    .Build())
+                using (var producer =
+                    new ProducerBuilder<string, string>(producerConfig)
+                        .SetKeySerializer(Serializers.Utf8)
+                        .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
+                        .Build())
                 {
                     // implicit check that this does not fail.
                     producer.ProduceAsync(topic1.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
@@ -56,8 +56,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             };
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var producer = new Producer<string, User>(producerConfig,
-                new AvroSerializer<string>(schemaRegistry), new AvroSerializer<User>(schemaRegistry)))
+            using (var producer =
+                new ProducerBuilder<string, User>(producerConfig)
+                    .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                    .SetValueSerializer(new AvroSerializer<User>(schemaRegistry))
+                    .Build())
             {
                 var user = new User
                 {
@@ -72,8 +75,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             }
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var consumer = new Consumer<User, User>(consumerConfig,
-                new AvroDeserializer<User>(schemaRegistry), new AvroDeserializer<User>(schemaRegistry)))
+            using (var consumer =
+                new ConsumerBuilder<User, User>(consumerConfig)
+                    .SetKeyDeserializer(new AvroDeserializer<User>(schemaRegistry))
+                    .SetValueDeserializer(new AvroDeserializer<User>(schemaRegistry))
+                    .Build())
             {
                 consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(topic, 0, 0) });
 
@@ -91,8 +97,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             }
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var consumer = new Consumer<string, string>(consumerConfig,
-                new AvroDeserializer<string>(schemaRegistry), new AvroDeserializer<string>(schemaRegistry)))
+            using (var consumer =
+                new ConsumerBuilder<string, string>(consumerConfig)
+                    .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                    .SetValueDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                    .Build())
             {
                 consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(topic, 0, 0) });
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
@@ -69,7 +69,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     new ConsumerBuilder<Null, User>(consumerConfig)
                         .SetKeyDeserializer(Deserializers.Null)
                         .SetValueDeserializer(new AvroDeserializer<User>(schemaRegistry))
-                        .SetPartitionAssignmentHandler((c, tps) => {
+                        .SetPartitionsAssignedHandler((c, tps) => {
                             c.Assign(tps.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning)));
                         })
                         .Build())
@@ -99,7 +99,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     new ConsumerBuilder<Null, User>(consumerConfig)
                         .SetKeyDeserializer(Deserializers.Null)
                         .SetValueDeserializer(new AvroDeserializer<User>(schemaRegistry))
-                        .SetPartitionAssignmentHandler((c, tps) => {
+                        .SetPartitionsAssignedHandler((c, tps) => {
                             c.Assign(tps.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning)));
                         })
                         .Build())

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
@@ -69,11 +69,13 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     new ConsumerBuilder<Null, User>(consumerConfig)
                         .SetKeyDeserializer(Deserializers.Null)
                         .SetValueDeserializer(new AvroDeserializer<User>(schemaRegistry))
-                        .SetPartitionsAssignedHandler((c, tps) => {
-                            c.Assign(tps.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning)));
-                        })
                         .Build())
                 {
+                    consumer.SetPartitionsAssignedHandler((c, tps) =>
+                    {
+                        c.Assign(tps.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning)));
+                    });
+
                     consumer.Subscribe(topic.Name);
 
                     var cr1 = consumer.Consume();
@@ -99,11 +101,13 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     new ConsumerBuilder<Null, User>(consumerConfig)
                         .SetKeyDeserializer(Deserializers.Null)
                         .SetValueDeserializer(new AvroDeserializer<User>(schemaRegistry))
-                        .SetPartitionsAssignedHandler((c, tps) => {
-                            c.Assign(tps.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning)));
-                        })
                         .Build())
                 {
+                    consumer.SetPartitionsAssignedHandler((c, tps) =>
+                    {
+                        c.Assign(tps.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning)));
+                    });
+
                     consumer.Subscribe(topic.Name);
 
                     var cr1 = consumer.Consume();

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
@@ -57,8 +57,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 var doubleTopic = Guid.NewGuid().ToString();
                 var nullTopic = Guid.NewGuid().ToString();
 
-                using (var producer = new Producer<string, string>(
-                    producerConfig, new AvroSerializer<string>(schemaRegistry), new AvroSerializer<string>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<string, string>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(stringTopic, new Message<string, string> { Key = "hello", Value = "world" })
@@ -66,8 +69,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<byte[], byte[]>(
-                    producerConfig, new AvroSerializer<byte[]>(schemaRegistry), new AvroSerializer<byte[]>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<byte[], byte[]>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<byte[]>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<byte[]>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(bytesTopic, new Message<byte[], byte[]> { Key = new byte[] { 1, 4, 11 }, Value = new byte[] {} })
@@ -75,8 +81,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<int, int>(
-                    producerConfig, new AvroSerializer<int>(schemaRegistry), new AvroSerializer<int>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<int, int>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<int>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(intTopic, new Message<int, int> { Key = 42, Value = 43 })
@@ -84,8 +93,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<long, long>(
-                    producerConfig, new AvroSerializer<long>(schemaRegistry), new AvroSerializer<long>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<long, long>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<long>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<long>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(longTopic, new Message<long, long> { Key = -32, Value = -33 })
@@ -93,8 +105,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<bool, bool>(
-                    producerConfig, new AvroSerializer<bool>(schemaRegistry), new AvroSerializer<bool>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<bool, bool>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<bool>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<bool>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(boolTopic, new Message<bool, bool> { Key = true, Value = false })
@@ -102,8 +117,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<float, float>(
-                    producerConfig, new AvroSerializer<float>(schemaRegistry), new AvroSerializer<float>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<float, float>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<float>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<float>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(floatTopic, new Message<float, float> { Key = 44.0f, Value = 45.0f })
@@ -111,8 +129,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<double, double>(
-                    producerConfig, new AvroSerializer<double>(schemaRegistry), new AvroSerializer<double>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<double, double>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<double>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<double>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(doubleTopic, new Message<double, double> { Key = 46.0, Value = 47.0 })
@@ -120,8 +141,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
-                using (var producer = new Producer<Null, Null>(
-                    producerConfig, new AvroSerializer<Null>(schemaRegistry), new AvroSerializer<Null>(schemaRegistry)))
+                using (var producer =
+                    new ProducerBuilder<Null, Null>(producerConfig)
+                        .SetKeySerializer(new AvroSerializer<Null>(schemaRegistry))
+                        .SetValueSerializer(new AvroSerializer<Null>(schemaRegistry))
+                        .Build())
                 {
                     producer
                         .ProduceAsync(nullTopic, new Message<Null,Null>())
@@ -130,8 +154,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 }
 
 
-                using (var consumer = new Consumer<string, string>(
-                    consumerConfig, new AvroDeserializer<string>(schemaRegistry), new AvroDeserializer<string>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<string, string>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<string>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(stringTopic, 0, 0) });
                     var result = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -139,8 +166,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal("world", result.Message.Value);
                 }
 
-                using (var consumer = new Consumer<byte[], byte[]>(
-                    consumerConfig, new AvroDeserializer<byte[]>(schemaRegistry), new AvroDeserializer<byte[]>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<byte[], byte[]>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<byte[]>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<byte[]>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(bytesTopic, 0, 0) });
                     var result2 = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -148,8 +178,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(new byte[] { }, result2.Message.Value);
                 }
 
-                using (var consumer = new Consumer<int, int>(
-                    consumerConfig, new AvroDeserializer<int>(schemaRegistry), new AvroDeserializer<int>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<int, int>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<int>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<int>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(intTopic, 0, 0) });
                     var result3 = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -157,8 +190,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(43, result3.Message.Value);
                 }
 
-                using (var consumer = new Consumer<long, long>(
-                    consumerConfig, new AvroDeserializer<long>(schemaRegistry), new AvroDeserializer<long>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<long, long>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<long>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<long>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(longTopic, 0, 0) });
                     var result4 = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -166,8 +202,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(-33, result4.Message.Value);
                 }
 
-                using (var consumer = new Consumer<bool, bool>(
-                    consumerConfig, new AvroDeserializer<bool>(schemaRegistry), new AvroDeserializer<bool>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<bool, bool>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<bool>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<bool>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(boolTopic, 0, 0) });
                     var result5 = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -175,8 +214,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.False(result5.Message.Value);
                 }
 
-                using (var consumer = new Consumer<float, float>(
-                    consumerConfig, new AvroDeserializer<float>(schemaRegistry), new AvroDeserializer<float>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<float, float>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<float>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<float>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(floatTopic, 0, 0) });
                     var result6 = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -184,8 +226,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(45.0f, result6.Message.Value);
                 }
 
-                using (var consumer = new Consumer<double, double>(
-                    consumerConfig, new AvroDeserializer<double>(schemaRegistry), new AvroDeserializer<double>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<double, double>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<double>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<double>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(doubleTopic, 0, 0) });
                     var result7 = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -193,8 +238,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Equal(47.0, result7.Message.Value);
                 }
 
-                using (var consumer = new Consumer<Null, Null>(
-                    consumerConfig, new AvroDeserializer<Null>(schemaRegistry), new AvroDeserializer<Null>(schemaRegistry)))
+                using (var consumer =
+                    new ConsumerBuilder<Null, Null>(consumerConfig)
+                        .SetKeyDeserializer(new AvroDeserializer<Null>(schemaRegistry))
+                        .SetValueDeserializer(new AvroDeserializer<Null>(schemaRegistry))
+                        .Build())
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(nullTopic, 0, 0) });
                     var result8 = consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceGenericMultipleTopics.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceGenericMultipleTopics.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Confluent.Kafka;
 using Confluent.Kafka.Examples.AvroSpecific;
+using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using Avro;
@@ -42,8 +43,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             DeliveryResult<Null, GenericRecord> dr2;
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var p = new Producer<Null, GenericRecord>(
-                config, Serializers.Null, new AvroSerializer<GenericRecord>(schemaRegistry)))
+            using (var p =
+                new ProducerBuilder<Null, GenericRecord>(config)
+                    .SetKeySerializer(Serializers.Null)
+                    .SetValueSerializer(new AvroSerializer<GenericRecord>(schemaRegistry))
+                    .Build())
             {
                 var record = new GenericRecord(s);
                 record.Add("name", "my name 2");

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceIncompatibleTypes.cs
@@ -51,8 +51,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
             var topic = Guid.NewGuid().ToString();
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var producer = new Producer<string, string>(producerConfig,
-                new AvroSerializer<string>(schemaRegistry), new AvroSerializer<string>(schemaRegistry)))
+            using (var producer =
+                new ProducerBuilder<string, string>(producerConfig)
+                    .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                    .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
+                    .Build())
             {
                 producer
                     .ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" })
@@ -62,8 +65,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             }
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var producer = new Producer<int, string>(producerConfig,
-                new AvroSerializer<int>(schemaRegistry), new AvroSerializer<string>(schemaRegistry)))
+            using (var producer =
+                new ProducerBuilder<int, string>(producerConfig)
+                    .SetKeySerializer(new AvroSerializer<int>(schemaRegistry))
+                    .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
+                    .Build())
             {
                 Assert.Throws<SerializationException>(() =>
                 {
@@ -81,8 +87,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             }
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
-            using (var producer = new Producer<string, int>(producerConfig,
-                new AvroSerializer<string>(schemaRegistry), new AvroSerializer<int>(schemaRegistry)))
+            using (var producer =
+                new ProducerBuilder<string, int>(producerConfig)
+                    .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))
+                    .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
+                    .Build())
             {                
                 Assert.Throws<SerializationException>(() =>
                 {


### PR DESCRIPTION
This PR changes the way Producer/Consumer/AdminClient are constructed to use the builder pattern. This solves many problems:

1. Callback handlers are now available at client construction time. previously, they were specified after construction, but this meant important events may be (were being) missed.
2. Although C# event handlers can be async, if they throw an exception (and are async), this is not bubbled up (due to limitations with the language for historical reasons). In the new implementation, exceptions in async handlers will not be gobbled up.
3. Previously, clients that re-used the underlying handle of another client could set their own event handlers - potentially creating very confusing program flow. Now, dependent clients do not have the capability to set event handlers.
4. The `event` mechanism allowed more than one handler to be specified for a given event. But this is looser semantics than what we require. Now only one handler can be specified, which is better.
5. I have a plan for improving the performance of the serializers. This is a lot of work (involves effectively writing our own GC which is aware of the usage patterns of the producer), which we don't want to do pre-1.0. If implemented, it will require a new serializer interface. The old API would have been very difficult / not ideal to update to accommodate this. In the new interface, it's very easy to do without breaking changes.
6. The API is more future-proof in general - Configuration API changes can be trivially added or depreciated with very little impact on the user.
7. The constructors in the existing implementations are overloaded to be able to handle both the sync and async serde variants. there were some annoying details around type inference which are no longer a problem.
8. Someone who wants to specify their own default set of serdes (cc: @AndyPook) can effectively do this by deriving from the builder classes. This is the only good solution to that problem i've seen.

Neutral / slightly negative aspects to consider:
1. I believe the `DependentProducerBuilder` adds a lot of value (it could have been combined with `ProducerBuilder` + runtime checks). The admin client is inconsistent with this in that the client can be constructed directly from a handle. A `DependentAdminClientBuilder` seemed awkward and going overboard - It's more future proof but I think unlikely to be ever needed.
2. I put the serdes in the `Confluent.Kafka.Serdes` namespace. This will make it easy for people to swap them out when we implement `Confluent.Kafka.Serdes.ReallyReallyVeryEfficient` with the new serializer interface.
3. people will typically create clients in a `using` block and will typically want to specify handlers as lambdas inline. However, they can't reference the client instance because the compiler (stupidly) believes this is referencing an uninitialized variable. To work around this, the client instance is passed to the handler (which is not a compromise - we want this anyway so people have flexibility to specify handlers wherever they like). It's also in line with how standard C# events work. However there is another problem - the same identifier can't be used for both, as they're both in the same scope. I've adopted the convention that the outer client is called the full name. e.g. `consumer` and all parameters to the lambda are abbreviated (e.g. `(c, tps) => c.Assign(tps)`. This feels good to me.
4. I've closed off construction of `ConsumerBase`/`ProducerBase` to users of the library for now, effectively making them an implementation detail (allowing for maximum flexibility for change).
5. There's lots of transfer of information via `internal` state ... possibly not completely ideal, but I don't see any big problem here - the user facing api is good.

Note. the PR got a bit big, though it's not complex... I would have preferred to do the change for each client type in turn in separate PRs, but they're all connected (via IClient), and this would have been ugly and added confusion.

@AndyPook - thanks for planting the seed of the builder pattern in my head - as soon as you said it, i realized it would solve not just the problem under discussion, but heaps of others too. this API is much better for your input.

@edenhill @rnpridgeon 
