### PR TITLE
various enum related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - Changed the name of `Confluent.Kafka.Avro` to `Confluent.SchemaRegistry.Serdes` (Schema Registry may support other serialization formats in the future).
   - Added a example demonstrating working with protobuf serialized data.
 - Avro serdes no longer make blocking calls to `ICachedSchemaRegistryClient` - everything is `await`ed.
-- References librdkafka.redist [1.0.0-RC4](https://github.com/edenhill/librdkafka/releases/tag/v1.0.0-RC4)
+- References librdkafka.redist [1.0.0-RC5](https://github.com/edenhill/librdkafka/releases/tag/v1.0.0-RC5)
   - Note: End of partition notification is now disabled by default (enable using the `EnablePartitionEof` config property).
 - Removed `Consumer.OnPartitionEOF` in favor of `ConsumeResult.IsPartitionEOF`.
 - Removed `ErrorEvent` class and added `IsFatal` to `Error` class. 

--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -100,7 +100,7 @@ namespace AvroBlogExample
             {
                 GroupId = Guid.NewGuid().ToString(),
                 BootstrapServers = bootstrapServers,
-                AutoOffsetReset = AutoOffsetResetType.Earliest
+                AutoOffsetReset = AutoOffsetReset.Earliest
             };
 
             using (var schemaRegistry = new CachedSchemaRegistryClient( new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryUrl }))

--- a/examples/ConfluentCloud/Program.cs
+++ b/examples/ConfluentCloud/Program.cs
@@ -45,8 +45,8 @@ namespace ConfluentCloudExample
                 BootstrapServers = "<ccloud bootstrap servers>",
                 BrokerVersionFallback = "0.10.0.0",
                 ApiVersionFallbackMs = 0,
-                SaslMechanism = SaslMechanismType.Plain,
-                SecurityProtocol = SecurityProtocolType.Sasl_Ssl,
+                SaslMechanism = SaslMechanism.Plain,
+                SecurityProtocol = SecurityProtocol.SaslSsl,
                 // On Windows, default trusted root CA certificates are stored in the Windows Registry.
                 // They are not automatically discovered by Confluent.Kafka and it's not possible to
                 // reference them using the `ssl.ca.location` property. You will need to obtain these
@@ -76,14 +76,14 @@ namespace ConfluentCloudExample
                 BootstrapServers = "<confluent cloud bootstrap servers>",
                 BrokerVersionFallback = "0.10.0.0",
                 ApiVersionFallbackMs = 0,
-                SaslMechanism = SaslMechanismType.Plain,
-                SecurityProtocol = SecurityProtocolType.Sasl_Ssl,
+                SaslMechanism = SaslMechanism.Plain,
+                SecurityProtocol = SecurityProtocol.SaslSsl,
                 SslCaLocation = "/usr/local/etc/openssl/cert.pem", // suitable configuration for linux, osx.
                 // SslCaLocation = "c:\\path\\to\\cacert.pem",     // windows
                 SaslUsername = "<confluent cloud key>",
                 SaslPassword = "<confluent cloud secret>",
                 GroupId = Guid.NewGuid().ToString(),
-                AutoOffsetReset = AutoOffsetResetType.Earliest
+                AutoOffsetReset = AutoOffsetReset.Earliest
             };
 
             using (var consumer = new Consumer<Null, string>(cConfig))

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -45,7 +45,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 EnableAutoCommit = false,
                 StatisticsIntervalMs = 5000,
                 SessionTimeoutMs = 6000,
-                AutoOffsetReset = AutoOffsetResetType.Earliest,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
                 EnablePartitionEof = true
             };
 

--- a/examples/Protobuf/Program.cs
+++ b/examples/Protobuf/Program.cs
@@ -62,7 +62,7 @@ namespace Confluent.Kafka.Examples.Protobuf
             {
                 BootstrapServers = args[0],
                 GroupId = "protobuf-example",
-                AutoOffsetReset = AutoOffsetResetType.Latest
+                AutoOffsetReset = AutoOffsetReset.Latest
             };
 
             var consumeTask = Task.Run(() =>

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -149,14 +149,14 @@ namespace ConfigGen
     public enum Acks : int
     {
         /// <summary>
-        ///     Zero
+        ///     None
         /// </summary>
-        Zero = 0,
+        None = 0,
 
         /// <summary>
-        ///     One
+        ///     Leader
         /// </summary>
-        One = 1,
+        Leader = 1,
 
         /// <summary>
         ///     All
@@ -184,16 +184,16 @@ namespace ConfigGen
             {
                 var r = Get(""acks"");
                 if (r == null) { return null; }
-                if (r == ""0"") { return Confluent.Kafka.Acks.Zero; }
-                if (r == ""1"") { return Confluent.Kafka.Acks.One; }
+                if (r == ""0"") { return Confluent.Kafka.Acks.None; }
+                if (r == ""1"") { return Confluent.Kafka.Acks.Leader; }
                 if (r == ""-1"" || r == ""all"") { return Confluent.Kafka.Acks.All; }
                 return (Acks)(int.Parse(r));
             }
             set
             {
                 if (value == null) { this.properties.Remove(""acks""); }
-                else if (value == Confluent.Kafka.Acks.Zero) { this.properties[""acks""] = ""0""; }
-                else if (value == Confluent.Kafka.Acks.One) { this.properties[""acks""] = ""1""; }
+                else if (value == Confluent.Kafka.Acks.None) { this.properties[""acks""] = ""0""; }
+                else if (value == Confluent.Kafka.Acks.Leader) { this.properties[""acks""] = ""1""; }
                 else if (value == Confluent.Kafka.Acks.All) { this.properties[""acks""] = ""-1""; }
                 else { this.properties[""acks""] = ((int)value.Value).ToString(); }
             }

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -24,17 +24,21 @@ namespace ConfigGen
         internal static Dictionary<string, List<string>> AdditionalEnums => new Dictionary<string, List<string>>
         {
             { "partition.assignment.strategy", new List<string> { "range", "roundrobin" } },
-            { "partitioner", new List<string> { "random", "consistent", "consistent_random", "murmur2", "murmur2_random" } } 
+            { "partitioner", new List<string> { "random", "consistent", "consistent_random", "murmur2", "murmur2_random" } }
         };
 
         /// <summary>
         ///     A function that filters out properties from the librdkafka list that should
-        ///     not be privided in the 
+        ///     not be automatically extracted.
         /// </summary>
         internal static List<PropertySpecification> RemoveLegacyOrNotRelevant(List<PropertySpecification> props) 
             => props.Where(p => {
-                if (p.Name == "sasl.mechanisms") { return false; } // handled as a special case.
-                if (p.Name == "sasl.mechanism") { return false; } // handled as a special case.
+                // handled as a special case.
+                if (p.Name == "sasl.mechanisms") { return false; }
+                if (p.Name == "sasl.mechanism") { return false; }
+                if (p.Name == "acks") { return false; }
+                if (p.Name == "request.required.acks") { return false; }
+                // legacy
                 if (p.Name == "consume.callback.max.messages") { return false; }
                 if (p.Name == "offset.store.path") { return false; }
                 if (p.Name == "offset.store.sync.interval.ms") { return false; }
@@ -48,6 +52,7 @@ namespace ConfigGen
                 if (p.Name == "enable.auto.commit" && !p.IsGlobal) { return false; }
                 if (p.Name == "auto.commit.enable" && !p.IsGlobal) { return false; }
                 if (p.Name == "queuing.strategy") { return false; }
+                // other
                 if (p.Name.Contains("_")) { return false; }
                 return true;
             }).ToList();
@@ -64,19 +69,18 @@ namespace ConfigGen
                 { "max.partition.fetch.bytes", "fetch.message.max.bytes" },
                 { "linger.ms", "queue.buffering.max.ms" },
                 { "message.send.max.retries", "retries" },
-                { "compression.type", "compression.codec" },
-                { "acks", "request.required.acks" }
+                { "compression.type", "compression.codec" }
             };
 
         /// <summary>
-        ///     SaslMechanismType definition
+        ///     SaslMechanism definition
         /// </summary>
         internal static string SaslMechanismEnumString =>
 @"
     /// <summary>
     ///     SaslMechanism enum values
     /// </summary>
-    public enum SaslMechanismType
+    public enum SaslMechanism
     {
         /// <summary>
         ///     GSSAPI
@@ -108,35 +112,115 @@ namespace ConfigGen
         /// <summary>
         ///     SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism.
         /// </summary>
-        public SaslMechanismType? SaslMechanism
+        public SaslMechanism? SaslMechanism
         {
             get
             {
                 var r = Get(""sasl.mechanism"");
                 if (r == null) { return null; }
-                if (r == ""GSSAPI"") { return  SaslMechanismType.Gssapi; }
-                if (r == ""PLAIN"") { return SaslMechanismType.Plain; }
-                if (r == ""SCRAM-SHA-256"") { return SaslMechanismType.ScramSha256; }
-                if (r == ""SCRAM-SHA-512"") { return SaslMechanismType.ScramSha512; }
+                if (r == ""GSSAPI"") { return Confluent.Kafka.SaslMechanism.Gssapi; }
+                if (r == ""PLAIN"") { return Confluent.Kafka.SaslMechanism.Plain; }
+                if (r == ""SCRAM-SHA-256"") { return Confluent.Kafka.SaslMechanism.ScramSha256; }
+                if (r == ""SCRAM-SHA-512"") { return Confluent.Kafka.SaslMechanism.ScramSha512; }
                 throw new ArgumentException($""Unknown sasl.mechanism value {r}"");
             }
             set
             {
                 if (value == null) { this.properties.Remove(""sasl.mechanism""); }
-                else if (value == SaslMechanismType.Gssapi) { this.properties[""sasl.mechanism""] = ""GSSAPI""; }
-                else if (value == SaslMechanismType.Plain) { this.properties[""sasl.mechanism""] = ""PLAIN""; }
-                else if (value == SaslMechanismType.ScramSha256) { this.properties[""sasl.mechanism""] = ""SCRAM-SHA-256""; }
-                else if (value == SaslMechanismType.ScramSha512) { this.properties[""sasl.mechanism""] = ""SCRAM-SHA-512""; }
+                else if (value == Confluent.Kafka.SaslMechanism.Gssapi) { this.properties[""sasl.mechanism""] = ""GSSAPI""; }
+                else if (value == Confluent.Kafka.SaslMechanism.Plain) { this.properties[""sasl.mechanism""] = ""PLAIN""; }
+                else if (value == Confluent.Kafka.SaslMechanism.ScramSha256) { this.properties[""sasl.mechanism""] = ""SCRAM-SHA-256""; }
+                else if (value == Confluent.Kafka.SaslMechanism.ScramSha512) { this.properties[""sasl.mechanism""] = ""SCRAM-SHA-512""; }
                 else throw new NotImplementedException($""Unknown sasl.mechanism value {value}"");
             }
         }
 
 ";
+
+
+        /// <summary>
+        ///     SaslMechanism definition
+        /// </summary>
+        internal static string AcksEnumString =>
+@"
+    /// <summary>
+    ///     Acks enum values
+    /// </summary>
+    public enum Acks : int
+    {
+        /// <summary>
+        ///     Zero
+        /// </summary>
+        Zero = 0,
+
+        /// <summary>
+        ///     One
+        /// </summary>
+        One = 1,
+
+        /// <summary>
+        ///     All
+        /// </summary>
+        All = -1
+    }
+";
+
+        /// <summary>
+        ///     get/set for Acks.
+        /// </summary>
+        internal static string AcksGetSetString =>
+@"
+        /// <summary>
+        ///     This field indicates the number of acknowledgements the leader broker must receive from ISR brokers
+        ///     before responding to the request: Zero=Broker does not send any response/ack to client, One=The
+        ///     leader will write the record to its local log but will respond without awaiting full acknowledgement
+        ///     from all followers. All=Broker will block until message is committed by all in sync replicas (ISRs).
+        ///     If there are less than min.insync.replicas (broker configuration) in the ISR set the produce request
+        ///     will fail.
+        /// </summary>
+        public Acks? Acks
+        {
+            get
+            {
+                var r = Get(""acks"");
+                if (r == null) { return null; }
+                if (r == ""0"") { return Confluent.Kafka.Acks.Zero; }
+                if (r == ""1"") { return Confluent.Kafka.Acks.One; }
+                if (r == ""-1"" || r == ""all"") { return Confluent.Kafka.Acks.All; }
+                return (Acks)(int.Parse(r));
+            }
+            set
+            {
+                if (value == null) { this.properties.Remove(""acks""); }
+                else if (value == Confluent.Kafka.Acks.Zero) { this.properties[""acks""] = ""0""; }
+                else if (value == Confluent.Kafka.Acks.One) { this.properties[""acks""] = ""1""; }
+                else if (value == Confluent.Kafka.Acks.All) { this.properties[""acks""] = ""-1""; }
+                else { this.properties[""acks""] = ((int)value.Value).ToString(); }
+            }
+        }
+
+";
+
     }
 
     
     class PropertySpecification
     {
+        public PropertySpecification() {}
+
+        public PropertySpecification(PropertySpecification other)
+        {
+            IsGlobal = other.IsGlobal;
+            Name = other.Name;
+            CPorA = other.CPorA;
+            Range = other.Range;
+            Importance = other.Importance;
+            Default = other.Default;
+            Description = other.Description;
+            Type = other.Type;
+            AliasFor = other.AliasFor;
+        }
+
         public bool IsGlobal { get; set; }
         public string Name { get; set; }
         public string CPorA { get; set; }  // Consumer, Producer or All.
@@ -209,11 +293,30 @@ namespace Confluent.Kafka
                 "_[a-z]",
                 m => "_" + m.Value.Substring(1).ToUpper());
 
+        private static Dictionary<string, string> ConfigValueToEnumNameSubstitutes = new Dictionary<string, string>
+        {
+            { "sasl_plaintext", "SaslPlaintext" },
+            { "sasl_ssl", "SaslSsl" },
+            { "consistent_random", "ConsistentRandom" },
+            { "murmur2_random", "Murmur2Random"},
+            { "roundrobin", "RoundRobin" }
+        };
+
         static string EnumNameToDotnetName(string enumName)
-            => Regex.Replace(
-                enumName[0].ToString().ToUpper() + enumName.Substring(1),
-                "_[a-z]",
-                m => "_" + m.Value.Substring(1).ToUpper());
+        {
+            if (ConfigValueToEnumNameSubstitutes.TryGetValue(enumName, out string substitute))
+            {
+                return substitute;
+            }
+
+            var result = enumName[0].ToString().ToUpper() + enumName.Substring(1);
+            if (result.Contains('_'))
+            {
+                Console.WriteLine($"warning: enum value contains underscore (is not consistent with .net naming standards): {enumName}");
+            }
+
+            return result;
+        }
 
         static string createProperties(IEnumerable<PropertySpecification> props)
         {
@@ -221,7 +324,7 @@ namespace Confluent.Kafka
             foreach (var prop in props)
             {
                 if (prop.Type == "pointer") { continue; }
-                var type = (prop.Type == "enum" || MappingConfiguration.AdditionalEnums.Keys.Contains(prop.Name)) ? ConfigNameToDotnetName(prop.Name) + "Type" : prop.Type;
+                var type = (prop.Type == "enum" || MappingConfiguration.AdditionalEnums.Keys.Contains(prop.Name)) ? ConfigNameToDotnetName(prop.Name) : prop.Type;
                 var nullableType = type == "string" ? "string" : type + "?";
 
                 codeText += $"        /// <summary>\n";
@@ -284,7 +387,7 @@ namespace Confluent.Kafka
                 codeText += $"    /// <summary>\n";
                 codeText += $"    ///     {ConfigNameToDotnetName(prop.Name)} enum values\n";
                 codeText += $"    /// </summary>\n";
-                codeText += $"    public enum {ConfigNameToDotnetName(prop.Name)}Type\n";
+                codeText += $"    public enum {ConfigNameToDotnetName(prop.Name)}\n";
                 codeText += $"    {{\n";
                 for (int i=0; i<vs.Count; ++i)
                 {
@@ -551,8 +654,10 @@ namespace Confluent.Kafka
             codeText += createFileHeader(gitBranchName);
             codeText += createEnums(props.Where(p => p.Type == "enum" || MappingConfiguration.AdditionalEnums.Keys.Contains(p.Name)).ToList());
             codeText += MappingConfiguration.SaslMechanismEnumString;
+            codeText += MappingConfiguration.AcksEnumString;
             codeText += createClassHeader("ClientConfig", "Configuration common to all clients", false);
             codeText += MappingConfiguration.SaslMechanismGetSetString;
+            codeText += MappingConfiguration.AcksGetSetString;
             codeText += createProperties(props.Where(p => p.CPorA == "*"));
             codeText += createClassFooter();
             codeText += createClassHeader("AdminClientConfig", "AdminClient configuration properties", true);

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -1,4 +1,4 @@
-// *** Auto-generated from librdkafka branch v1.0.0-RC4 *** - do not modify manually.
+// *** Auto-generated from librdkafka branch v1.0.0-RC5 *** - do not modify manually.
 //
 // Copyright 2018 Confluent Inc.
 //
@@ -27,7 +27,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     BrokerAddressFamily enum values
     /// </summary>
-    public enum BrokerAddressFamilyType
+    public enum BrokerAddressFamily
     {
         /// <summary>
         ///     Any
@@ -48,7 +48,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     SecurityProtocol enum values
     /// </summary>
-    public enum SecurityProtocolType
+    public enum SecurityProtocol
     {
         /// <summary>
         ///     Plaintext
@@ -61,20 +61,20 @@ namespace Confluent.Kafka
         Ssl,
 
         /// <summary>
-        ///     Sasl_Plaintext
+        ///     SaslPlaintext
         /// </summary>
-        Sasl_Plaintext,
+        SaslPlaintext,
 
         /// <summary>
-        ///     Sasl_Ssl
+        ///     SaslSsl
         /// </summary>
-        Sasl_Ssl
+        SaslSsl
     }
 
     /// <summary>
     ///     PartitionAssignmentStrategy enum values
     /// </summary>
-    public enum PartitionAssignmentStrategyType
+    public enum PartitionAssignmentStrategy
     {
         /// <summary>
         ///     Range
@@ -82,15 +82,15 @@ namespace Confluent.Kafka
         Range,
 
         /// <summary>
-        ///     Roundrobin
+        ///     RoundRobin
         /// </summary>
-        Roundrobin
+        RoundRobin
     }
 
     /// <summary>
     ///     Partitioner enum values
     /// </summary>
-    public enum PartitionerType
+    public enum Partitioner
     {
         /// <summary>
         ///     Random
@@ -103,9 +103,9 @@ namespace Confluent.Kafka
         Consistent,
 
         /// <summary>
-        ///     Consistent_Random
+        ///     ConsistentRandom
         /// </summary>
-        Consistent_Random,
+        ConsistentRandom,
 
         /// <summary>
         ///     Murmur2
@@ -113,15 +113,15 @@ namespace Confluent.Kafka
         Murmur2,
 
         /// <summary>
-        ///     Murmur2_Random
+        ///     Murmur2Random
         /// </summary>
-        Murmur2_Random
+        Murmur2Random
     }
 
     /// <summary>
     ///     AutoOffsetReset enum values
     /// </summary>
-    public enum AutoOffsetResetType
+    public enum AutoOffsetReset
     {
         /// <summary>
         ///     Latest
@@ -142,7 +142,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     SaslMechanism enum values
     /// </summary>
-    public enum SaslMechanismType
+    public enum SaslMechanism
     {
         /// <summary>
         ///     GSSAPI
@@ -166,6 +166,27 @@ namespace Confluent.Kafka
     }
 
     /// <summary>
+    ///     Acks enum values
+    /// </summary>
+    public enum Acks : int
+    {
+        /// <summary>
+        ///     Zero
+        /// </summary>
+        Zero = 0,
+
+        /// <summary>
+        ///     One
+        /// </summary>
+        One = 1,
+
+        /// <summary>
+        ///     All
+        /// </summary>
+        All = -1
+    }
+
+    /// <summary>
     ///     Configuration common to all clients
     /// </summary>
     public class ClientConfig : Config
@@ -174,26 +195,56 @@ namespace Confluent.Kafka
         /// <summary>
         ///     SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism.
         /// </summary>
-        public SaslMechanismType? SaslMechanism
+        public SaslMechanism? SaslMechanism
         {
             get
             {
                 var r = Get("sasl.mechanism");
                 if (r == null) { return null; }
-                if (r == "GSSAPI") { return  SaslMechanismType.Gssapi; }
-                if (r == "PLAIN") { return SaslMechanismType.Plain; }
-                if (r == "SCRAM-SHA-256") { return SaslMechanismType.ScramSha256; }
-                if (r == "SCRAM-SHA-512") { return SaslMechanismType.ScramSha512; }
+                if (r == "GSSAPI") { return Confluent.Kafka.SaslMechanism.Gssapi; }
+                if (r == "PLAIN") { return Confluent.Kafka.SaslMechanism.Plain; }
+                if (r == "SCRAM-SHA-256") { return Confluent.Kafka.SaslMechanism.ScramSha256; }
+                if (r == "SCRAM-SHA-512") { return Confluent.Kafka.SaslMechanism.ScramSha512; }
                 throw new ArgumentException($"Unknown sasl.mechanism value {r}");
             }
             set
             {
                 if (value == null) { this.properties.Remove("sasl.mechanism"); }
-                else if (value == SaslMechanismType.Gssapi) { this.properties["sasl.mechanism"] = "GSSAPI"; }
-                else if (value == SaslMechanismType.Plain) { this.properties["sasl.mechanism"] = "PLAIN"; }
-                else if (value == SaslMechanismType.ScramSha256) { this.properties["sasl.mechanism"] = "SCRAM-SHA-256"; }
-                else if (value == SaslMechanismType.ScramSha512) { this.properties["sasl.mechanism"] = "SCRAM-SHA-512"; }
+                else if (value == Confluent.Kafka.SaslMechanism.Gssapi) { this.properties["sasl.mechanism"] = "GSSAPI"; }
+                else if (value == Confluent.Kafka.SaslMechanism.Plain) { this.properties["sasl.mechanism"] = "PLAIN"; }
+                else if (value == Confluent.Kafka.SaslMechanism.ScramSha256) { this.properties["sasl.mechanism"] = "SCRAM-SHA-256"; }
+                else if (value == Confluent.Kafka.SaslMechanism.ScramSha512) { this.properties["sasl.mechanism"] = "SCRAM-SHA-512"; }
                 else throw new NotImplementedException($"Unknown sasl.mechanism value {value}");
+            }
+        }
+
+
+        /// <summary>
+        ///     This field indicates the number of acknowledgements the leader broker must receive from ISR brokers
+        ///     before responding to the request: Zero=Broker does not send any response/ack to client, One=The
+        ///     leader will write the record to its local log but will respond without awaiting full acknowledgement
+        ///     from all followers. All=Broker will block until message is committed by all in sync replicas (ISRs).
+        ///     If there are less than min.insync.replicas (broker configuration) in the ISR set the produce request
+        ///     will fail.
+        /// </summary>
+        public Acks? Acks
+        {
+            get
+            {
+                var r = Get("acks");
+                if (r == null) { return null; }
+                if (r == "0") { return Confluent.Kafka.Acks.Zero; }
+                if (r == "1") { return Confluent.Kafka.Acks.One; }
+                if (r == "-1" || r == "all") { return Confluent.Kafka.Acks.All; }
+                return (Acks)(int.Parse(r));
+            }
+            set
+            {
+                if (value == null) { this.properties.Remove("acks"); }
+                else if (value == Confluent.Kafka.Acks.Zero) { this.properties["acks"] = "0"; }
+                else if (value == Confluent.Kafka.Acks.One) { this.properties["acks"] = "1"; }
+                else if (value == Confluent.Kafka.Acks.All) { this.properties["acks"] = "-1"; }
+                else { this.properties["acks"] = ((int)value.Value).ToString(); }
             }
         }
 
@@ -363,7 +414,7 @@ namespace Confluent.Kafka
         ///     default: any
         ///     importance: low
         /// </summary>
-        public BrokerAddressFamilyType? BrokerAddressFamily { get { return (BrokerAddressFamilyType?)GetEnum(typeof(BrokerAddressFamilyType), "broker.address.family"); } set { this.SetObject("broker.address.family", value); } }
+        public BrokerAddressFamily? BrokerAddressFamily { get { return (BrokerAddressFamily?)GetEnum(typeof(BrokerAddressFamily), "broker.address.family"); } set { this.SetObject("broker.address.family", value); } }
 
         /// <summary>
         ///     When enabled the client will only connect to brokers it needs to communicate with. When disabled the client will maintain connections to all brokers in the cluster.
@@ -448,13 +499,13 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
         ///
-        ///     default: 1200000
+        ///     default: 0
         ///     importance: medium
         /// </summary>
         public int? ApiVersionFallbackMs { get { return GetInt("api.version.fallback.ms"); } set { this.SetObject("api.version.fallback.ms", value); } }
 
         /// <summary>
-        ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value, such as 0.10.2.1, enables ApiVersionRequests.
+        ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
         ///
         ///     default: 0.10.0
         ///     importance: medium
@@ -467,7 +518,7 @@ namespace Confluent.Kafka
         ///     default: plaintext
         ///     importance: high
         /// </summary>
-        public SecurityProtocolType? SecurityProtocol { get { return (SecurityProtocolType?)GetEnum(typeof(SecurityProtocolType), "security.protocol"); } set { this.SetObject("security.protocol", value); } }
+        public SecurityProtocol? SecurityProtocol { get { return (SecurityProtocol?)GetEnum(typeof(SecurityProtocol), "security.protocol"); } set { this.SetObject("security.protocol", value); } }
 
         /// <summary>
         ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
@@ -767,14 +818,6 @@ namespace Confluent.Kafka
         public int? BatchNumMessages { get { return GetInt("batch.num.messages"); } set { this.SetObject("batch.num.messages", value); } }
 
         /// <summary>
-        ///     This field indicates how many acknowledgements the leader broker must receive from ISR brokers before responding to the request: *0*=Broker does not send any response/ack to client, *1*=Only the leader broker will need to ack the message, *-1* or *all*=broker will block until message is committed by all in sync replicas (ISRs) or broker's `min.insync.replicas` setting before sending response.
-        ///
-        ///     default: 1
-        ///     importance: high
-        /// </summary>
-        public int? Acks { get { return GetInt("acks"); } set { this.SetObject("acks", value); } }
-
-        /// <summary>
         ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
         ///
         ///     default: 5000
@@ -796,7 +839,7 @@ namespace Confluent.Kafka
         ///     default: consistent_random
         ///     importance: high
         /// </summary>
-        public PartitionerType? Partitioner { get { return (PartitionerType?)GetEnum(typeof(PartitionerType), "partitioner"); } set { this.SetObject("partitioner", value); } }
+        public Partitioner? Partitioner { get { return (Partitioner?)GetEnum(typeof(Partitioner), "partitioner"); } set { this.SetObject("partitioner", value); } }
 
         /// <summary>
         ///     Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
@@ -859,7 +902,7 @@ namespace Confluent.Kafka
         ///     default: range,roundrobin
         ///     importance: medium
         /// </summary>
-        public PartitionAssignmentStrategyType? PartitionAssignmentStrategy { get { return (PartitionAssignmentStrategyType?)GetEnum(typeof(PartitionAssignmentStrategyType), "partition.assignment.strategy"); } set { this.SetObject("partition.assignment.strategy", value); } }
+        public PartitionAssignmentStrategy? PartitionAssignmentStrategy { get { return (PartitionAssignmentStrategy?)GetEnum(typeof(PartitionAssignmentStrategy), "partition.assignment.strategy"); } set { this.SetObject("partition.assignment.strategy", value); } }
 
         /// <summary>
         ///     Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
@@ -1003,7 +1046,7 @@ namespace Confluent.Kafka
         ///     default: largest
         ///     importance: high
         /// </summary>
-        public AutoOffsetResetType? AutoOffsetReset { get { return (AutoOffsetResetType?)GetEnum(typeof(AutoOffsetResetType), "auto.offset.reset"); } set { this.SetObject("auto.offset.reset", value); } }
+        public AutoOffsetReset? AutoOffsetReset { get { return (AutoOffsetReset?)GetEnum(typeof(AutoOffsetReset), "auto.offset.reset"); } set { this.SetObject("auto.offset.reset", value); } }
 
     }
 

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -171,14 +171,14 @@ namespace Confluent.Kafka
     public enum Acks : int
     {
         /// <summary>
-        ///     Zero
+        ///     None
         /// </summary>
-        Zero = 0,
+        None = 0,
 
         /// <summary>
-        ///     One
+        ///     Leader
         /// </summary>
-        One = 1,
+        Leader = 1,
 
         /// <summary>
         ///     All
@@ -233,16 +233,16 @@ namespace Confluent.Kafka
             {
                 var r = Get("acks");
                 if (r == null) { return null; }
-                if (r == "0") { return Confluent.Kafka.Acks.Zero; }
-                if (r == "1") { return Confluent.Kafka.Acks.One; }
+                if (r == "0") { return Confluent.Kafka.Acks.None; }
+                if (r == "1") { return Confluent.Kafka.Acks.Leader; }
                 if (r == "-1" || r == "all") { return Confluent.Kafka.Acks.All; }
                 return (Acks)(int.Parse(r));
             }
             set
             {
                 if (value == null) { this.properties.Remove("acks"); }
-                else if (value == Confluent.Kafka.Acks.Zero) { this.properties["acks"] = "0"; }
-                else if (value == Confluent.Kafka.Acks.One) { this.properties["acks"] = "1"; }
+                else if (value == Confluent.Kafka.Acks.None) { this.properties["acks"] = "0"; }
+                else if (value == Confluent.Kafka.Acks.Leader) { this.properties["acks"] = "1"; }
                 else if (value == Confluent.Kafka.Acks.All) { this.properties["acks"] = "-1"; }
                 else { this.properties["acks"] = ((int)value.Value).ToString(); }
             }

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>		
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC4" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC5" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.0" />
   </ItemGroup>

--- a/src/Confluent.Kafka/Partition.cs
+++ b/src/Confluent.Kafka/Partition.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Gets the long value corresponding to this partition.
+        ///     Gets the int value corresponding to this partition.
         /// </summary>
         public int Value { get; }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
-            consumerConfig.AutoOffsetReset = AutoOffsetResetType.Latest;
+            consumerConfig.AutoOffsetReset = AutoOffsetReset.Latest;
             using (var consumer = new Consumer(consumerConfig))
             {
                 ConsumeResult record;
@@ -67,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(record);
             }
 
-            consumerConfig.AutoOffsetReset = AutoOffsetResetType.Earliest;
+            consumerConfig.AutoOffsetReset = AutoOffsetReset.Earliest;
             using (var consumer = new Consumer(consumerConfig))
             {
                 ConsumeResult record;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -39,7 +39,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 GroupId = Guid.NewGuid().ToString(),
                 BootstrapServers = bootstrapServers,
-                AutoOffsetReset = AutoOffsetResetType.Latest
+                AutoOffsetReset = AutoOffsetReset.Latest
             };
 
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffsets.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 GroupId = Guid.NewGuid().ToString(),
                 BootstrapServers = bootstrapServers,
-                AutoOffsetReset = AutoOffsetResetType.Latest,
+                AutoOffsetReset = AutoOffsetReset.Latest,
                 EnableAutoCommit = true,
                 EnableAutoOffsetStore = false
             };

--- a/test/Confluent.Kafka.StrongName.UnitTests/Confluent.Kafka.StrongName.UnitTests.csproj
+++ b/test/Confluent.Kafka.StrongName.UnitTests/Confluent.Kafka.StrongName.UnitTests.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC2" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Confluent.Kafka.UnitTests/ConfigEnums.cs
+++ b/test/Confluent.Kafka.UnitTests/ConfigEnums.cs
@@ -32,8 +32,8 @@ namespace Confluent.Kafka.UnitTests
         public void AcksProperty()
         {
             // standard values
-            var config1 = new ProducerConfig { Acks = Acks.Zero };
-            var config2 = new ProducerConfig { Acks = Acks.One };
+            var config1 = new ProducerConfig { Acks = Acks.None };
+            var config2 = new ProducerConfig { Acks = Acks.Leader };
             var config3 = new ProducerConfig { Acks = Acks.All };
 
             // any numerical value is also ok but needs to be cast.
@@ -50,10 +50,10 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal("2", config5.Get("acks"));
             Assert.Equal("-1", config6.Get("acks"));
 
-            Assert.Equal(Acks.Zero, config1.Acks);
-            Assert.Equal(Acks.One, config2.Acks);
+            Assert.Equal(Acks.None, config1.Acks);
+            Assert.Equal(Acks.Leader, config2.Acks);
             Assert.Equal(Acks.All, config3.Acks);
-            Assert.Equal(Acks.One, config4.Acks);
+            Assert.Equal(Acks.Leader, config4.Acks);
             Assert.Equal((Acks)2, config5.Acks);
             Assert.Equal(Acks.All, config6.Acks);
         }

--- a/test/Confluent.Kafka.UnitTests/ConfigEnums.cs
+++ b/test/Confluent.Kafka.UnitTests/ConfigEnums.cs
@@ -9,12 +9,12 @@ namespace Confluent.Kafka.UnitTests
         {
             var config = new ConsumerConfig
             {
-                AutoOffsetReset = AutoOffsetResetType.Earliest
+                AutoOffsetReset = AutoOffsetReset.Earliest
             };
 
             var value = config.AutoOffsetReset;
 
-            Assert.Equal(AutoOffsetResetType.Earliest, value);
+            Assert.Equal(AutoOffsetReset.Earliest, value);
         }
 
         [Fact]
@@ -22,12 +22,62 @@ namespace Confluent.Kafka.UnitTests
         {
             var config = new ProducerConfig
             {
-                QueuingStrategy = QueuingStrategyType.Fifo,
-                Partitioner = PartitionerType.Consistent
+                Partitioner = Partitioner.Consistent
             };
 
-            Assert.Equal(QueuingStrategyType.Fifo, config.QueuingStrategy);
-            Assert.Equal(PartitionerType.Consistent, config.Partitioner);
+            Assert.Equal(Partitioner.Consistent, config.Partitioner);
+        }
+
+        [Fact]
+        public void AcksProperty()
+        {
+            // standard values
+            var config1 = new ProducerConfig { Acks = Acks.Zero };
+            var config2 = new ProducerConfig { Acks = Acks.One };
+            var config3 = new ProducerConfig { Acks = Acks.All };
+
+            // any numerical value is also ok but needs to be cast.
+            // note: values are not range checked by the config class
+            // (but are by librdkafka)
+            var config4 = new ProducerConfig { Acks = (Acks)1 };
+            var config5 = new ProducerConfig { Acks = (Acks)2 };  // this is fine so future proof - enums have exactly the semantics we want.
+            var config6 = new ProducerConfig { Acks = (Acks)(-1) };
+
+            Assert.Equal("0", config1.Get("acks"));
+            Assert.Equal("1", config2.Get("acks"));
+            Assert.Equal("-1", config3.Get("acks"));
+            Assert.Equal("1", config4.Get("acks"));
+            Assert.Equal("2", config5.Get("acks"));
+            Assert.Equal("-1", config6.Get("acks"));
+
+            Assert.Equal(Acks.Zero, config1.Acks);
+            Assert.Equal(Acks.One, config2.Acks);
+            Assert.Equal(Acks.All, config3.Acks);
+            Assert.Equal(Acks.One, config4.Acks);
+            Assert.Equal((Acks)2, config5.Acks);
+            Assert.Equal(Acks.All, config6.Acks);
+        }
+
+        [Fact]
+        public void Substituted()
+        {
+            var config1 = new ProducerConfig { SecurityProtocol = SecurityProtocol.SaslPlaintext };
+            var config2 = new ProducerConfig { SecurityProtocol = SecurityProtocol.SaslSsl };
+            var config3 = new ProducerConfig { Partitioner = Partitioner.ConsistentRandom };
+            var config4 = new ProducerConfig { Partitioner = Partitioner.Murmur2Random };
+            var config5 = new ConsumerConfig { PartitionAssignmentStrategy = PartitionAssignmentStrategy.RoundRobin };
+
+            Assert.Equal("sasl_plaintext", config1.Get("security.protocol"));
+            Assert.Equal("sasl_ssl", config2.Get("security.protocol"));
+            Assert.Equal("consistent_random", config3.Get("partitioner"));
+            Assert.Equal("murmur2_random", config4.Get("partitioner"));
+            Assert.Equal("roundrobin", config5.Get("partition.assignment.strategy"));
+
+            Assert.Equal(SecurityProtocol.SaslPlaintext, config1.SecurityProtocol);
+            Assert.Equal(SecurityProtocol.SaslSsl, config2.SecurityProtocol);
+            Assert.Equal(Partitioner.ConsistentRandom, config3.Partitioner);
+            Assert.Equal(Partitioner.Murmur2Random, config4.Partitioner);
+            Assert.Equal(PartitionAssignmentStrategy.RoundRobin, config5.PartitionAssignmentStrategy);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/InvalidHandle.cs
+++ b/test/Confluent.Kafka.UnitTests/InvalidHandle.cs
@@ -34,15 +34,15 @@ namespace Confluent.Kafka.UnitTests
             var cConfig = new ConsumerConfig
             {
                 GroupId = "test",
-                SaslMechanism = SaslMechanismType.Plain,
-                SecurityProtocol = SecurityProtocolType.Ssl,
+                SaslMechanism = SaslMechanism.Plain,
+                SecurityProtocol = SecurityProtocol.Ssl,
                 SslCaLocation = "invalid"
             };
             
             var pConfig = new ProducerConfig
             {
-                SaslMechanism = SaslMechanismType.Plain,
-                SecurityProtocol = SecurityProtocolType.Ssl,
+                SaslMechanism = SaslMechanism.Plain,
+                SecurityProtocol = SecurityProtocol.Ssl,
                 SslCaLocation = "invalid"
             };
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
@@ -44,7 +44,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     BootstrapServers = bootstrapServers,
                     GroupId = Guid.NewGuid().ToString(),
                     SessionTimeoutMs = 6000,
-                    AutoOffsetReset = AutoOffsetResetType.Earliest
+                    AutoOffsetReset = AutoOffsetReset.Earliest
                 };
 
                 var schemaRegistryConfig = new SchemaRegistryConfig

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -46,7 +46,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     BootstrapServers = bootstrapServers,
                     GroupId = Guid.NewGuid().ToString(),
                     SessionTimeoutMs = 6000,
-                    AutoOffsetReset = AutoOffsetResetType.Earliest
+                    AutoOffsetReset = AutoOffsetReset.Earliest
                 };
 
                 var schemaRegistryConfig = new SchemaRegistryConfig

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
@@ -47,7 +47,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 BootstrapServers = bootstrapServers,
                 GroupId = Guid.NewGuid().ToString(),
                 SessionTimeoutMs = 6000,
-                AutoOffsetReset = AutoOffsetResetType.Earliest
+                AutoOffsetReset = AutoOffsetReset.Earliest
             };
             
             var schemaRegistryConfig = new SchemaRegistryConfig

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
@@ -56,7 +56,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     BootstrapServers = bootstrapServers,
                     GroupId = Guid.NewGuid().ToString(),
                     SessionTimeoutMs = 6000,
-                    AutoOffsetReset = AutoOffsetResetType.Earliest,
+                    AutoOffsetReset = AutoOffsetReset.Earliest,
                     EnablePartitionEof = true
                 };
 
@@ -82,7 +82,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     BootstrapServers = bootstrapServers,
                     GroupId = Guid.NewGuid().ToString(),
                     SessionTimeoutMs = 6000,
-                    AutoOffsetReset = AutoOffsetResetType.Earliest,
+                    AutoOffsetReset = AutoOffsetReset.Earliest,
                     EnablePartitionEof = false
                 };
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
@@ -45,7 +45,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     BootstrapServers = bootstrapServers,
                     GroupId = Guid.NewGuid().ToString(),
                     SessionTimeoutMs = 6000,
-                    AutoOffsetReset = AutoOffsetResetType.Earliest
+                    AutoOffsetReset = AutoOffsetReset.Earliest
                 };
 
                 var stringTopic = Guid.NewGuid().ToString();

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsume.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsume.cs
@@ -45,7 +45,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 BootstrapServers = bootstrapServers,
                 GroupId = Guid.NewGuid().ToString(),
                 SessionTimeoutMs = 6000,
-                AutoOffsetReset = AutoOffsetResetType.Earliest,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
                 EnablePartitionEof = true
             };
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceIncompatibleTypes.cs
@@ -41,7 +41,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 BootstrapServers = bootstrapServers,
                 GroupId = Guid.NewGuid().ToString(),
                 SessionTimeoutMs = 6000,
-                AutoOffsetReset = AutoOffsetResetType.Earliest,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
             };
 
             var schemaRegistryConfig = new SchemaRegistryConfig


### PR DESCRIPTION
- Audited all the enum types in Confluent.Kafka for compliance with .net naming standards and made appropriate changes.
- Changed the `acks` configuration parameter to an enum (of type int32). Note that it's valid in C# to set an enum type to a value that isn't one of it's discrete names (e.g. Acks = 2), so i think this has precisely the semantics we want, also when considering possible future requirements.

@edenhill @rnpridgeon