### PR TITLE
enable idempotence on integration tests where dr order is important

### DIFF
--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig
             {
                 BootstrapServers = bootstrapServers,
-                MaxInFlight = 1
+                EnableIdempotence = true
             };
 
             var consumerConfig = new ConsumerConfig

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce.cs
@@ -36,7 +36,8 @@ namespace Confluent.Kafka.IntegrationTests
 
             var producerConfig = new ProducerConfig
             { 
-                BootstrapServers = bootstrapServers
+                BootstrapServers = bootstrapServers,
+                EnableIdempotence = true
             };
 
 


### PR DESCRIPTION
Integration tests that have checks related to delivery report order following `BeginProduce` calls - where order should be preserved - are intermittently failing. This is a long standing issue. This could be explained by messages delivery failure and retries, though this does seem unlikely in the context of local broker integration tests. Never-the-less, I've enabled idempotence on these tests in this PR, which I believe should ensure delivery report order is the same as produce order in the event of delivery failure [though I wasn't able to find good docs to confirm this - the reviewer should know :-) ]. Alternatively, I could set `message.send.max.retries` to 0, though the tests would still fail in the above scenario due to message failure (but the change would still be an improvement since the reason would be more explicit).

I'm quite sure there's nothing in the C# code that could cause this ordering problem. Alternatively, there could be an issue in librdkafka. 