### PR TITLE
Moved ConsumeResult Commit methods to correct place

### DIFF
--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -104,8 +104,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                             // consuming messages. A high performance application will typically
                             // commit offsets relatively infrequently and be designed handle
                             // duplicate messages in the event of failure.
-                            var committedOffsets = consumer.Commit(consumeResult);
-                            Console.WriteLine($"Committed offset: {committedOffsets}");
+                            consumer.Commit(consumeResult);
                         }
                     }
                     catch (ConsumeException e)

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -266,6 +266,38 @@ namespace Confluent.Kafka
             => (keyDeserializer != null && valueDeserializer != null)
                 ? Consume<TKey, TValue>(timeout.TotalMillisecondsAsInt(), keyDeserializer, valueDeserializer) // fast path for simple case
                 : Consume(timeout.TotalMillisecondsAsInt());
+
+
+        /// <summary>
+        ///     Commits an offset based on the topic/partition/offset of a ConsumeResult.
+        /// </summary>
+        /// <param name="result">
+        ///     The ConsumeResult instance used to determine the committed offset.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used to cancel this operation
+        ///     (currently ignored).
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if the result is in error.
+        /// </exception>
+        /// <remarks>
+        ///     A consumer which has position N has consumed messages with offsets up to N-1 
+        ///     and will next receive the message with offset N. Hence, this method commits an 
+        ///     offset of <paramref name="result" />.Offset + 1.
+        /// </remarks>
+        public void Commit(ConsumeResult<TKey, TValue> result, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (result.Message == null)
+            {
+                throw new InvalidOperationException("Attempt was made to commit offset corresponding to an empty consume result");
+            }
+
+            Commit(new [] { new TopicPartitionOffset(result.TopicPartition, result.Offset + 1) });
+        }
     }
 
 
@@ -286,6 +318,7 @@ namespace Confluent.Kafka
         ///     specified.
         /// </param>
         public Consumer(IEnumerable<KeyValuePair<string, string>> config) : base(config) {}
+
 
         /// <summary>
         ///     Poll for new messages / events. Blocks until a consume result
@@ -320,6 +353,7 @@ namespace Confluent.Kafka
             }
         }
 
+
         /// <summary>
         ///     Poll for new messages / events. Blocks until a consume result
         ///     is available or the timeout period has elapsed.
@@ -346,5 +380,20 @@ namespace Confluent.Kafka
                 IsPartitionEOF = result.IsPartitionEOF
             };
         }
+
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Commit(ConsumeResult{TKey, TValue}, CancellationToken)" />
+        /// </summary>
+        public void Commit(ConsumeResult result, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (result.Message == null)
+            {
+                throw new InvalidOperationException("Attempt was made to commit offset corresponding to an empty consume result");
+            }
+
+            Commit(new [] { new TopicPartitionOffset(result.TopicPartition, result.Offset + 1) });
+        }
+
     }
 }

--- a/src/Confluent.Kafka/ConsumerBase.cs
+++ b/src/Confluent.Kafka/ConsumerBase.cs
@@ -744,54 +744,6 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Commits an offset based on the topic/partition/offset of a ConsumeResult.
-        /// </summary>
-        /// <param name="result">
-        ///     The ConsumeResult instance used to determine the committed offset.
-        /// </param>
-        /// <remarks>
-        ///     A consumer which has position N has consumed messages with offsets up to N-1 
-        ///     and will next receive the message with offset N. Hence, this method commits an 
-        ///     offset of <paramref name="result" />.Offset + 1.
-        /// </remarks>
-        /// <param name="cancellationToken">
-        ///     A cancellation token that can be used to cancel this operation
-        ///     (currently ignored).
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if the result is in error.
-        /// </exception>
-        public TopicPartitionOffset Commit<TKey, TValue>(
-            ConsumeResult<TKey, TValue> result, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (result.Message == null)
-            {
-                throw new InvalidOperationException("Attempt was made to commit offset corresponding to an empty consume result");
-            }
-
-            return kafkaHandle.Commit(new [] { new TopicPartitionOffset(result.TopicPartition, result.Offset + 1) })[0];
-        }
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.Commit{TKey, TValue}(ConsumeResult{TKey, TValue}, CancellationToken)" />
-        /// </summary>
-        public TopicPartitionOffset Commit(
-            ConsumeResult result, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (result.Message == null)
-            {
-                throw new InvalidOperationException("Attempt was made to commit offset corresponding to an empty consume result");
-            }
-
-            return kafkaHandle.Commit(new [] { new TopicPartitionOffset(result.TopicPartition, result.Offset + 1) })[0];
-        }
-
-
-        /// <summary>
         ///     Commit an explicit list of offsets.
         /// </summary>
         /// <param name="offsets">

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -37,6 +37,11 @@ namespace Confluent.Kafka
         /// </summary>
         ConsumeResult Consume(TimeSpan timeout);
 
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer.Commit(ConsumeResult, CancellationToken)" />
+        /// </summary>
+        void Commit(ConsumeResult result, CancellationToken cancellationToken = default(CancellationToken));
     }
 
 
@@ -56,5 +61,11 @@ namespace Confluent.Kafka
         ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.Consume(TimeSpan)" />
         /// </summary>
         ConsumeResult<TKey, TValue> Consume(TimeSpan timeout);
+
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Commit(ConsumeResult{TKey, TValue}, CancellationToken)" />
+        /// </summary>
+        void Commit(ConsumeResult<TKey, TValue> result, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Confluent.Kafka/IConsumerBase.cs
+++ b/src/Confluent.Kafka/IConsumerBase.cs
@@ -137,18 +137,6 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.Commit{TKey, TValue}(ConsumeResult{TKey, TValue}, CancellationToken)" />
-        /// </summary>
-        TopicPartitionOffset Commit<TKey, TValue>(ConsumeResult<TKey, TValue> result, CancellationToken cancellationToken = default(CancellationToken));
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.Commit(ConsumeResult, CancellationToken)" />
-        /// </summary>
-        TopicPartitionOffset Commit(ConsumeResult result, CancellationToken cancellationToken = default(CancellationToken));
-
-
-        /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.ConsumerBase.Commit(IEnumerable{TopicPartitionOffset}, CancellationToken)" />
         /// </summary>
         void Commit(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default(CancellationToken));


### PR DESCRIPTION
also changed the return types to `void`, as returning something effectively provided by the user was pretty pointless and for consistency with the base method used to implement.