### PR TITLE
fixed failover connection issue

### DIFF
--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Failover.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Failover.cs
@@ -1,0 +1,73 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Xunit;
+
+
+namespace Confluent.SchemaRegistry.IntegrationTests
+{
+    public static partial class Tests
+    {
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static void Failover(Config config)
+        {
+            var testSchema =
+                "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
+                "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
+                "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
+
+            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = $"{config.Server},http://localhost/65432" }))
+            {
+                var topicName = Guid.NewGuid().ToString();
+                var subject = sr.ConstructKeySubjectName(topicName);
+                var id = sr.RegisterSchemaAsync(subject, testSchema).Result;
+                var id2 = sr.GetSchemaIdAsync(subject, testSchema).Result;
+                Assert.Equal(id, id2);
+            }
+
+            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = $"http://localhost/65432,{config.Server}" }))
+            {
+                var topicName = Guid.NewGuid().ToString();
+                var subject = sr.ConstructKeySubjectName(topicName);
+                var id = sr.RegisterSchemaAsync(subject, testSchema).Result;
+                var id2 = sr.GetSchemaIdAsync(subject, testSchema).Result;
+                Assert.Equal(id, id2);
+            }
+
+            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = $"http://localhost/65432,http://localhost/65431" }))
+            {
+                var topicName = Guid.NewGuid().ToString();
+                var subject = sr.ConstructKeySubjectName(topicName);
+                
+                Assert.Throws<HttpRequestException>(() => 
+                {
+                    try
+                    {
+                        sr.RegisterSchemaAsync(subject, testSchema).Wait();
+                    }
+                    catch (AggregateException e)
+                    {
+                        throw e.InnerException;
+                    }
+                });
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
resolves #711 

verified manually - we should add tests for this case, but that would complicate the dependencies required (an additional SR instance) making it less trivial to start up. we should do this, but after or as part of the task to automate execution of the integration tests. i'll add an issue to track this.

The problem was `HttpClient` doesn't allow the same request instance to be sent more than once. I don't like this behavior TBH. One of a growing number of things I don't like about `HttpClient`. 
