### PR TITLE
Message<byte[],byt[]> -> Message

### DIFF
--- a/src/Confluent.Kafka/ConsumeResult.cs
+++ b/src/Confluent.Kafka/ConsumeResult.cs
@@ -22,7 +22,95 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Represents a message consumed from a Kafka cluster.
     /// </summary>
-    public class ConsumeResult : ConsumeResult<byte[], byte[]> {}
+    public class ConsumeResult
+    {
+        /// <summary>
+        ///     The topic associated with the message.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        ///     The partition associated with the message.
+        /// </summary>
+        public Partition Partition { get; set; }
+
+        /// <summary>
+        ///     The partition offset associated with the message.
+        /// </summary>
+        public Offset Offset { get; set; }
+
+        /// <summary>
+        ///     The TopicPartition associated with the message.
+        /// </summary>
+        public TopicPartition TopicPartition
+            => new TopicPartition(Topic, Partition);
+
+        /// <summary>
+        ///     The TopicPartitionOffset assoicated with the message.
+        /// </summary>
+        public TopicPartitionOffset TopicPartitionOffset
+        {
+            get
+            {
+                return new TopicPartitionOffset(Topic, Partition, Offset);
+            }
+            set
+            {
+                Topic = value.Topic;
+                Partition = value.Partition;
+                Offset = value.Offset;
+            }
+        }
+
+        /// <summary>
+        ///     The Kafka message, or null if this ConsumeResult
+        ///     instance represents an end of partition event.
+        /// </summary>
+        public Message Message { get; set; }
+
+        /// <summary>
+        ///     The Kafka message Key.
+        /// </summary>
+        public byte[] Key
+        {
+            get { return Message.Key; }
+            set { Message.Key = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message Value.
+        /// </summary>
+        public byte[] Value
+        {
+            get { return Message.Value; }
+            set { Message.Value = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message timestamp.
+        /// </summary>
+        public Timestamp Timestamp
+        {
+            get { return Message.Timestamp; }
+            set { Message.Timestamp = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message headers.
+        /// </summary>
+        public Headers Headers
+        {
+            get { return Message.Headers; }
+            set { Message.Headers = value; }
+        }
+
+        /// <summary>
+        ///     True if this instance represents an end of partition
+        ///     event, false if it represents a message in kafka.
+        /// </summary>
+        public bool IsPartitionEOF { get; set; }
+    }
+
 
     /// <summary>
     ///     Represents a message consumed from a Kafka cluster.

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -314,7 +314,7 @@ namespace Confluent.Kafka
                 return new ConsumeResult
                 {
                     TopicPartitionOffset = result.TopicPartitionOffset,
-                    Message = result.Message,
+                    Message = result.Message == null ? null : new Message(result.Message),
                     IsPartitionEOF = result.IsPartitionEOF
                 };
             }
@@ -342,7 +342,7 @@ namespace Confluent.Kafka
             return new ConsumeResult
             {
                 TopicPartitionOffset = result.TopicPartitionOffset,
-                Message = result.Message,
+                Message = result.Message == null ? null : new Message(result.Message),
                 IsPartitionEOF = result.IsPartitionEOF
             };
         }

--- a/src/Confluent.Kafka/DeliveryReport.cs
+++ b/src/Confluent.Kafka/DeliveryReport.cs
@@ -20,7 +20,31 @@ namespace Confluent.Kafka
     /// <summary>
     ///     The result of a produce request.
     /// </summary>
-    public class DeliveryReport : DeliveryReport<byte[], byte[]> { }
+    public class DeliveryReport : DeliveryResult
+    {
+        /// <summary>
+        ///     An error (or NoError) associated with the message.
+        /// </summary>
+        public Error Error { get; set; }
+
+        /// <summary>
+        ///     The TopicPartitionOffsetError assoicated with the message.
+        /// </summary>
+        public TopicPartitionOffsetError TopicPartitionOffsetError
+        {
+            get
+            {
+                return new TopicPartitionOffsetError(Topic, Partition, Offset, Error);
+            }
+            set
+            {
+                Topic = value.Topic;
+                Partition = value.Partition;
+                Offset = value.Offset;
+                Error = value.Error;
+            }
+        }
+    }
 
     /// <summary>
     ///     The result of a produce request.

--- a/src/Confluent.Kafka/DeliveryResult.cs
+++ b/src/Confluent.Kafka/DeliveryResult.cs
@@ -20,7 +20,94 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Encapsulates the result of a successful produce request.
     /// </summary>
-    public class DeliveryResult : DeliveryResult<byte[], byte[]> { }
+    public class DeliveryResult
+    {
+        /// <summary>
+        ///     The topic associated with the message.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        ///     The partition associated with the message.
+        /// </summary>
+        public Partition Partition { get; set; }
+
+        /// <summary>
+        ///     The partition offset associated with the message.
+        /// </summary>
+        public Offset Offset { get; set; }
+
+        /// <summary>
+        ///     The TopicPartition associated with the message.
+        /// </summary>
+        public TopicPartition TopicPartition
+            => new TopicPartition(Topic, Partition);
+
+
+        /// <summary>
+        ///     The TopicPartitionOffset assoicated with the message.
+        /// </summary>
+        public TopicPartitionOffset TopicPartitionOffset
+        {
+            get
+            {
+                return new TopicPartitionOffset(Topic, Partition, Offset);
+            }
+            set
+            {
+                Topic = value.Topic;
+                Partition = value.Partition;
+                Offset = value.Offset;
+            }
+        }
+
+        /// <summary>
+        ///     The persistence status of the message
+        /// </summary>
+        public PersistenceStatus PersistenceStatus { get; set; }
+        
+        /// <summary>
+        ///     The Kafka message.
+        /// </summary>
+        public Message Message { get; set; }
+
+        /// <summary>
+        ///     The Kafka message Key.
+        /// </summary>
+        public byte[] Key
+        {
+            get { return Message.Key; }
+            set { Message.Key = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message Value.
+        /// </summary>
+        public byte[] Value
+        {
+            get { return Message.Value; }
+            set { Message.Value = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message timestamp.
+        /// </summary>
+        public Timestamp Timestamp
+        {
+            get { return Message.Timestamp; }
+            set { Message.Timestamp = value; }
+        }
+
+        /// <summary>
+        ///     The Kafka message headers.
+        /// </summary>
+        public Headers Headers
+        {
+            get { return Message.Headers; }
+            set { Message.Headers = value; }
+        }
+    }
+
 
     /// <summary>
     ///     Encapsulates the result of a successful produce request.

--- a/src/Confluent.Kafka/Message.cs
+++ b/src/Confluent.Kafka/Message.cs
@@ -38,26 +38,36 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Represents a Kafka message.
     /// </summary>
-    public class Message : Message<byte[], byte[]>
+    public class Message : MessageMetadata
     {
         /// <summary>
-        ///     Create a new instance with default property values.
+        ///     Create a new Message instance with default values.
         /// </summary>
         public Message() {}
 
         /// <summary>
-        ///     Create a new instance that exactly mirrors the state of
-        ///     a <see cref="Message{TKey, TValue}" /> instance.
+        ///     Create a new Message instance that is a copy of
+        ///     <paramref name="message" />.
         /// </summary>
         /// <param name="message">
-        ///     The <see cref="Message{TKey, TValue}" /> instance to copy.
+        ///     The <see cref="Message{TKey,TValue}" /> instance
+        ///     to create a copy of.
         /// </param>
         public Message(Message<byte[], byte[]> message)
+            : base(message)
         {
-            Timestamp = message.Timestamp;
-            Headers = message.Headers;
             Key = message.Key;
             Value = message.Value;
         }
+
+        /// <summary>
+        ///     Gets the message key value (possibly null).
+        /// </summary>
+        public byte[] Key { get; set; }
+
+        /// <summary>
+        ///     Gets the message value (possibly null).
+        /// </summary>
+        public byte[] Value { get; set; }
     }
 }

--- a/src/Confluent.Kafka/MessageMetadata.cs
+++ b/src/Confluent.Kafka/MessageMetadata.cs
@@ -23,6 +23,24 @@ namespace Confluent.Kafka
     public class MessageMetadata
     {
         /// <summary>
+        ///     Create a new MessageMetadata instance with default values.
+        /// </summary>
+        public MessageMetadata() {}
+
+        /// <summary>
+        ///     Create a new MessageMetadata instance that is a copy
+        ///     of <paramref name="messageMetadata" />.
+        /// </summary>
+        /// <param name="messageMetadata">
+        ///     The MessageMetadata instance to create a copy of.
+        /// </param>
+        public MessageMetadata(MessageMetadata messageMetadata)
+        {
+            Timestamp = messageMetadata.Timestamp;
+            Headers = messageMetadata.Headers;
+        }
+
+        /// <summary>
         ///     The message timestamp. The timestamp type must be set to CreateTime. 
         ///     Specify Timestamp.Default to set the message timestamp to the time
         ///     of this function call.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_CommitAsync_Committed_Position.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_CommitAsync_Committed_Position.cs
@@ -74,7 +74,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(new TopicPartition("invalid-topic", 0), ps[0].TopicPartition);
 
                 // Test #1
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var os = consumer.Commit();
                 Assert.Equal(firstMsgOffset + 1, os[0].Offset);
                 ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
@@ -83,7 +83,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(firstMsgOffset + 1, ps[0].Offset);
                 
                 // Test #2
-                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 os = consumer.Commit();
                 Assert.Equal(firstMsgOffset + 2, os[0].Offset);
                 ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
@@ -103,7 +103,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
 
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
                 Assert.Equal(firstMsgOffset + 6, ps[0].Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
@@ -121,7 +121,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new Consumer(consumerConfig))
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var ps = consumer.Position(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) });
                 Assert.Equal(firstMsgOffset + 4, ps[0].Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
@@ -132,18 +132,18 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new Consumer(consumerConfig))
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 consumer.Commit(record3);
-                var record4 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record4 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
             }
             using (var consumer = new Consumer(consumerConfig))
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 Assert.Equal(firstMsgOffset + 3, record.Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
@@ -153,18 +153,18 @@ namespace Confluent.Kafka.IntegrationTests
             using (var consumer = new Consumer(consumerConfig))
             {
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, firstMsgOffset));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
-                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record2 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
+                var record3 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 consumer.Commit(record3);
-                var record4 = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record4 = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);
             }
             using (var consumer = new Consumer(consumerConfig))
             {
                 consumer.Assign(new TopicPartition(singlePartitionTopic, 0));
-                var record = consumer.Consume(TimeSpan.FromMilliseconds(1000));
+                var record = consumer.Consume(TimeSpan.FromMilliseconds(6000));
                 Assert.Equal(firstMsgOffset + 3, record.Offset);
                 var co = consumer.Committed(new List<TopicPartition> { new TopicPartition(singlePartitionTopic, 0) }, TimeSpan.FromSeconds(10));
                 Assert.Equal(firstMsgOffset + 3, co[0].Offset);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Error.cs
@@ -48,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(Offset.Invalid, dr.Offset);
                 Assert.Null(dr.Message.Key);
                 Assert.Equal("test", dr.Message.Value);
-                Assert.Equal(PersistenceStatus.Persisted, dr.PersistenceStatus);
+                Assert.Equal(PersistenceStatus.NotPersisted, dr.PersistenceStatus);
                 Assert.Equal(TimestampType.NotAvailable, dr.Message.Timestamp.Type);
                 count += 1;
             };

--- a/test/Confluent.Kafka.UnitTests/Message.cs
+++ b/test/Confluent.Kafka.UnitTests/Message.cs
@@ -1,0 +1,45 @@
+// Copyright 2019 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Xunit;
+
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class Message
+    {
+        [Fact]
+        public void CopyConstructor()
+        {
+            var testTimestamp = new Timestamp(1003, TimestampType.LogAppendTime);
+            var testHeaders = new Headers { new Header("myheader", new byte[] { 42 }) };
+            var testKey = new byte[] { 4 };
+            var testValue = new byte[] { 7, 5, 2 };
+
+            var m = new Message<byte[], byte[]>();
+            m.Headers = testHeaders;
+            m.Timestamp = testTimestamp;
+            m.Key = testKey;
+            m.Value = testValue;
+
+            var copy = new Confluent.Kafka.Message(m);
+            Assert.Equal(testValue, copy.Value);
+            Assert.Equal(testKey, copy.Key);
+            Assert.Equal(testTimestamp, copy.Timestamp);
+            Assert.Equal(testHeaders, copy.Headers);
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Message.cs
+++ b/test/Confluent.Kafka.UnitTests/Message.cs
@@ -39,7 +39,7 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal(testValue, copy.Value);
             Assert.Equal(testKey, copy.Key);
             Assert.Equal(testTimestamp, copy.Timestamp);
-            Assert.Equal(testHeaders, copy.Headers);
+            Assert.Single(copy.Headers);
         }
     }
 }


### PR DESCRIPTION
resolves #747 

The non-generic `ConsumeResult`, `DeliveryReport` and `DeliveryResult` classes can't derive from the generic `<byte[],byte[]>` equivalents because the `Message` property should have type `Message` not `Message<byte[],byte[]>`. I could have made some base classes to cut down on the code duplication in this PR, but these would increase the complexity of the class hierarchy from a user perspective and so this is not desirable. Also, the amount of duplication is minimal and it's nature won't cause a meaningful maintenance overhead.

The code actually was like this previously, but a contributor made the 'improvement' and i wasn't quick enough at the time to realize the consequences.

As noted in #747, I'm now also quite sure the non-generic producer / consumer are a waste of energy, but they are a little bit useful, harmless, somewhat analogous to the generic/non generic collection classes, and would take quite a number of loc changes to extract from the integration tests, so I think they should stay.

note: unit + integration tests pass.