### PR TITLE
fix regression introduced in #760

### DIFF
--- a/src/Confluent.Kafka/IDeliveryHandler.cs
+++ b/src/Confluent.Kafka/IDeliveryHandler.cs
@@ -1,0 +1,24 @@
+// Copyright 2019 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+
+namespace Confluent.Kafka
+{
+    internal interface IDeliveryHandler
+    {
+        void HandleDeliveryReport(DeliveryReport<Null, Null> deliveryReport);
+    }
+}

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -40,11 +40,6 @@ namespace Confluent.Kafka
             public Action<string> statisticsHandler;
         }
 
-        private interface IDeliveryHandler
-        {
-            void HandleDeliveryReport(DeliveryReport<Null, Null> deliveryReport);
-        }
-
         private ISerializer<TKey> keySerializer;
         private ISerializer<TValue> valueSerializer;
         private IAsyncSerializer<TKey> asyncKeySerializer;


### PR DESCRIPTION
the last thing I did before opening #760 was make `IDeliveryHandler` a child class of `Producer<K,V>`. In doing this, I neglected to consider the fact that this generates a new `IDeliveryHandler` type for each producer K,V, breaking an assumption that this is not the case by the dependent producer implementation. didn't realize this at the time because I didn't re-run the integration tests because this was such a simple change it couldn't possibly have gone wrong.