### PR TITLE
partital error exception types

### DIFF
--- a/src/Confluent.Kafka/Admin/AlterConfigsException.cs
+++ b/src/Confluent.Kafka/Admin/AlterConfigsException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka.Admin
     /// <summary>
     ///     Represents an error that occured during an alter configs request.
     /// </summary>
-    public class AlterConfigsException : Exception
+    public class AlterConfigsException : KafkaException
     {
         /// <summary>
         ///     Initializes a new instance of AlterConfigsException.
@@ -35,11 +35,11 @@ namespace Confluent.Kafka.Admin
         ///     results will be in error.
         /// </param>
         public AlterConfigsException(List<AlterConfigsReport> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred altering the following resources: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.ConfigResource)) +
                 "]: [" + String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Error)) + 
-                "].")
+                "]."))
         {
             Results = results;
         }

--- a/src/Confluent.Kafka/Admin/CreatePartitionsException.cs
+++ b/src/Confluent.Kafka/Admin/CreatePartitionsException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka.Admin
     /// <summary>
     ///     Represents an error that occured during a create partitions request.
     /// </summary>
-    public class CreatePartitionsException : Exception
+    public class CreatePartitionsException : KafkaException
     {
         /// <summary>
         ///     Initialize a new instance of CreatePartitionsException.
@@ -35,11 +35,11 @@ namespace Confluent.Kafka.Admin
         ///     results will be in error.
         /// </param>
         public CreatePartitionsException(List<CreatePartitionsReport> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred creating partitions for topics: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Topic)) +
                 "]: [" + String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Error)) +
-                "].")
+                "]."))
         {
             Results = results;
         }

--- a/src/Confluent.Kafka/Admin/CreateTopicsException.cs
+++ b/src/Confluent.Kafka/Admin/CreateTopicsException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka.Admin
     /// <summary>
     ///     Represents an error that occured during a create topics request.
     /// </summary>
-    public class CreateTopicsException : Exception
+    public class CreateTopicsException : KafkaException
     {
         /// <summary>
         ///     Initialize a new instance of CreateTopicsException.
@@ -35,11 +35,11 @@ namespace Confluent.Kafka.Admin
         ///     results will be in error.
         /// </param>
         public CreateTopicsException(List<CreateTopicReport> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred creating topics: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Topic)) +
                 "]: [" + String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Error)) +
-                "].")
+                "]."))
         {
             this.Results = results;
         }

--- a/src/Confluent.Kafka/Admin/DeleteTopicsException.cs
+++ b/src/Confluent.Kafka/Admin/DeleteTopicsException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka.Admin
     /// <summary>
     ///     Represents an error that occured during a delete topics request.
     /// </summary>
-    public class DeleteTopicsException : Exception
+    public class DeleteTopicsException : KafkaException
     {
         /// <summary>
         ///     Initializes a new DeleteTopicsException.
@@ -35,11 +35,11 @@ namespace Confluent.Kafka.Admin
         ///     results will be in error.
         /// </param>
         public DeleteTopicsException(List<DeleteTopicReport> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred deleting topics: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Topic)) +
                 "]: [" + String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Error)) +
-                "].")
+                "]."))
         {
             Results = results;
         }

--- a/src/Confluent.Kafka/Admin/DescribeConfigsException.cs
+++ b/src/Confluent.Kafka/Admin/DescribeConfigsException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka.Admin
     /// <summary>
     ///     Represents an error that occured during a describe configs request.
     /// </summary>
-    public class DescribeConfigsException : Exception
+    public class DescribeConfigsException : KafkaException
     {
         /// <summary>
         ///     Initializes a new instance of DescribeConfigsException.
@@ -35,11 +35,11 @@ namespace Confluent.Kafka.Admin
         ///     results will be in error.
         /// </param>
         public DescribeConfigsException(List<DescribeConfigsReport> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred describing the following resources: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.ConfigResource)) +
                 "]: [" + String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.Error)) + 
-                "].")
+                "]."))
         {
             Results = results;
         }

--- a/src/Confluent.Kafka/Exceptions/TopicPartitionException.cs
+++ b/src/Confluent.Kafka/Exceptions/TopicPartitionException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Represents an error that occured during a Consumer.Position request.
     /// </summary>
-    public class TopicPartitionException : Exception
+    public class TopicPartitionException : KafkaException
     {
         /// <summary>
         ///     Initializes a new instance of OffsetsRequestExceptoion.
@@ -35,10 +35,10 @@ namespace Confluent.Kafka
         ///     results will be in error.
         /// </param>
         public TopicPartitionException(List<TopicPartitionError> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred for topic partitions: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.TopicPartition)) +
-                "].")
+                "]."))
         {
             Results = results;
         }

--- a/src/Confluent.Kafka/Exceptions/TopicPartitionOffsetException.cs
+++ b/src/Confluent.Kafka/Exceptions/TopicPartitionOffsetException.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Represents an error that occured during a Consumer.Position request.
     /// </summary>
-    public class TopicPartitionOffsetException : Exception
+    public class TopicPartitionOffsetException : KafkaException
     {
         /// <summary>
         ///     Initializes a new instance of OffsetsRequestExceptoion.
@@ -35,10 +35,10 @@ namespace Confluent.Kafka
         ///     results will be in error.
         /// </param>
         public TopicPartitionOffsetException(List<TopicPartitionOffsetError> results)
-            : base(
+            : base(new Error(ErrorCode.Local_Partial,
                 "An error occurred retrieving offsets for: [" +
                 String.Join(", ", results.Where(r => r.Error.IsError).Select(r => r.TopicPartition)) +
-                "].")
+                "]."))
         {
             Results = results;
         }


### PR DESCRIPTION
it's useful for these exception types to have a base class `KafkaException` since the user may not care about the details of the problem, and this allows these exceptions to be caught in the same handler as other librdkafka generated exceptions.

the `Local_` prefix is a bit misleading, but i think this is ok.

this pr is reverting the revert in #773 (but uses an appropriate error code).