### PR TITLE
move get/query watermark offset methods to consumer

### DIFF
--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -543,52 +543,6 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Get the last cached low (oldest available/beginning) and high (newest/end)
-        ///     offsets for a topic/partition.
-        /// </summary>
-        /// <remarks>
-        ///     This method is only available on instances constructed from a Consumer
-        ///     handle. The low offset is updated periodically (if statistics.interval.ms 
-        ///     is set) while the high offset is updated on each fetched message set from
-        ///     the broker. If there is no cached offset (either low or high, or both) then
-        ///     Offset.Invalid will be returned for the respective offset.
-        /// </remarks>
-        /// <param name="topicPartition">
-        ///     The topic/partition of interest.
-        /// </param>
-        /// <returns>
-        ///     The requested WatermarkOffsets (see that class for additional documentation).
-        /// </returns>
-        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-        {
-            if (!Handle.Owner.GetType().Name.Contains("Consumer"))
-            {
-                throw new InvalidOperationException(
-                    "GetWatermarkOffsets is only available on AdminClient instances constructed from a Consumer handle.");
-            }
-            return kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
-        }
-
-
-        /// <summary>
-        ///     Query the Kafka cluster for low (oldest available/beginning) and high (newest/end)
-        ///     offsets for the specified topic/partition (blocking).
-        /// </summary>
-        /// <param name="topicPartition">
-        ///     The topic/partition of interest.
-        /// </param>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
-        /// <returns>
-        ///     The requested WatermarkOffsets (see that class for additional documentation).
-        /// </returns>
-        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
-            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
-
-
-
-        /// <summary>
         ///     Query the cluster for metadata.
         ///
         ///     [API-SUBJECT-TO-CHANGE] - The API associated with this functionality is subject to change.

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -604,6 +604,48 @@ namespace Confluent.Kafka
 
 
         /// <summary>
+        ///     Get the last cached low (oldest available/beginning) and high (newest/end)
+        ///     offsets for a topic/partition.
+        /// </summary>
+        /// <remarks>
+        ///     The low offset is updated periodically (if statistics.interval.ms 
+        ///     is set) while the high offset is updated on each fetched message set from
+        ///     the broker. If there is no cached offset (either low or high, or both) then
+        ///     Offset.Invalid will be returned for the respective offset.
+        /// </remarks>
+        /// <param name="topicPartition">
+        ///     The topic/partition of interest.
+        /// </param>
+        /// <returns>
+        ///     The requested WatermarkOffsets (see that class for additional documentation).
+        /// </returns>
+        public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
+        {
+            if (!Handle.Owner.GetType().Name.Contains("Consumer"))
+            {
+                throw new InvalidOperationException(
+                    "GetWatermarkOffsets is only available on AdminClient instances constructed from a Consumer handle.");
+            }
+            return kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
+        }
+
+
+        /// <summary>
+        ///     Query the Kafka cluster for low (oldest available/beginning) and high (newest/end)
+        ///     offsets for the specified topic/partition (blocking).
+        /// </summary>
+        /// <param name="topicPartition">
+        ///     The topic/partition of interest.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time the call may block.
+        /// </param>
+        /// <returns>
+        ///     The requested WatermarkOffsets (see that class for additional documentation).
+        /// </returns>
+        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
+            => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
+        /// <summary>
         ///     Gets the (dynamic) group member id of this consumer (as 
         ///     set by the broker).
         /// </summary>

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -620,14 +620,7 @@ namespace Confluent.Kafka
         ///     The requested WatermarkOffsets (see that class for additional documentation).
         /// </returns>
         public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
-        {
-            if (!Handle.Owner.GetType().Name.Contains("Consumer"))
-            {
-                throw new InvalidOperationException(
-                    "GetWatermarkOffsets is only available on AdminClient instances constructed from a Consumer handle.");
-            }
-            return kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
-        }
+            => kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
 
 
         /// <summary>
@@ -645,6 +638,8 @@ namespace Confluent.Kafka
         /// </returns>
         public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
             => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
+
+
         /// <summary>
         ///     Gets the (dynamic) group member id of this consumer (as 
         ///     set by the broker).

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -605,7 +605,7 @@ namespace Confluent.Kafka
 
         /// <summary>
         ///     Get the last cached low (oldest available/beginning) and high (newest/end)
-        ///     offsets for a topic/partition.
+        ///     offsets for a topic/partition. Does not block.
         /// </summary>
         /// <remarks>
         ///     The low offset is updated periodically (if statistics.interval.ms 
@@ -625,7 +625,8 @@ namespace Confluent.Kafka
 
         /// <summary>
         ///     Query the Kafka cluster for low (oldest available/beginning) and high (newest/end)
-        ///     offsets for the specified topic/partition (blocking).
+        ///     offsets for the specified topic/partition. This is a blocking call - always contacts
+        ///     the cluster for the required information.
         /// </summary>
         /// <param name="topicPartition">
         ///     The topic/partition of interest.

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -41,18 +41,6 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.GetWatermarkOffsets(TopicPartition)" />
-        /// </summary>
-        WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition);
-
-
-        /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.QueryWatermarkOffsets(TopicPartition, TimeSpan)" />
-        /// </summary>
-        WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout);
-
-
-        /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.AdminClient.GetMetadata(string, TimeSpan)" />
         /// </summary>
         Metadata GetMetadata(string topic, TimeSpan timeout);

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -173,6 +173,18 @@ namespace Confluent.Kafka
 
 
         /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.GetWatermarkOffsets(TopicPartition)" />
+        /// </summary>
+        WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition);
+
+
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.QueryWatermarkOffsets(TopicPartition, TimeSpan)" />
+        /// </summary>
+        WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout);
+
+
+        /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" />.
         /// </summary>
         void Close();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
@@ -78,10 +78,9 @@ namespace Confluent.Kafka.IntegrationTests
                     Assert.Equal(44.0, r7.Key);
                     Assert.Equal(234.4, r7.Value);
 
-                    var offsets = adminClient.QueryWatermarkOffsets(new TopicPartition(topic.Name, 0), TimeSpan.FromSeconds(10));
-                    Assert.Equal(0, offsets.Low);
-                    Assert.Equal(7, offsets.High);
-                    
+                    var topicMetadata = adminClient.GetMetadata(singlePartitionTopic, TimeSpan.FromSeconds(10));
+                    Assert.Single(topicMetadata.Topics);
+
                     // implicitly check this does not throw.
                 }
 


### PR DESCRIPTION
Follows the java client and puts the query/get watermark functionality on the consumer where it is commonly needed rather than requiring a wrapper admin client. this change takes the query wm offsets capability away from being available on a librdkafka producer instance (via being wrapped by an admin client), but I don't think that's a common requirement. Since I can't think when this would be useful and the java producer doesn't provide similar functionality, I took the view that `QueryWatermarkOffsets` could be added back to `AdminClient` or to the `Producer` later if the need becomes clear (non-breaking change). For `GetWatermarkOffsets`, it was an especially questionable decision to effectively allow this to be called on a producer instance, since it favors runtime over compile enforcement.

It would be good to have `endOffsets` and `beginningOffsets` method functionality as per the java consumer, but that's not easy right yet?