### PR TITLE
PersistenceStatus -> Status + integration tests

### DIFF
--- a/src/Confluent.Kafka/DeliveryResult.cs
+++ b/src/Confluent.Kafka/DeliveryResult.cs
@@ -64,7 +64,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The persistence status of the message
         /// </summary>
-        public PersistenceStatus PersistenceStatus { get; set; }
+        public PersistenceStatus Status { get; set; }
         
         /// <summary>
         ///     The Kafka message.

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -196,7 +196,7 @@ namespace Confluent.Kafka
                     Partition = msg.partition, 
                     Offset = msg.offset, 
                     Error = KafkaHandle.CreatePossiblyFatalError(msg.err, null),
-                    PersistenceStatus = messageStatus,
+                    Status = messageStatus,
                     Message = new Message<Null, Null> { Timestamp = new Timestamp(timestamp, (TimestampType)timestampType), Headers = headers }
                 }
             );
@@ -932,7 +932,7 @@ namespace Confluent.Kafka
                 var dr = new DeliveryResult<K, V>
                 {
                     TopicPartitionOffset = deliveryReport.TopicPartitionOffset,
-                    PersistenceStatus = deliveryReport.PersistenceStatus,
+                    Status = deliveryReport.Status,
                     Message = new Message<K, V>
                     {
                         Key = Key,
@@ -995,7 +995,7 @@ namespace Confluent.Kafka
                 var dr = new DeliveryReport<K, V>
                 {
                     TopicPartitionOffsetError = deliveryReport.TopicPartitionOffsetError,
-                    PersistenceStatus = deliveryReport.PersistenceStatus,
+                    Status = deliveryReport.Status,
                     Message = new Message<K, V> 
                     {
                         Key = Key,

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce.cs
@@ -47,6 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             Action<DeliveryReport<string, string>> dh = (DeliveryReport<string, string> dr) =>
             {
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
+                Assert.Equal(PersistenceStatus.Persisted, dr.Status);
                 Assert.Equal((Partition)0, dr.Partition);
                 Assert.Equal(singlePartitionTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
@@ -79,6 +80,7 @@ namespace Confluent.Kafka.IntegrationTests
             Action<DeliveryReport<byte[], byte[]>> dh2 = (DeliveryReport<byte[], byte[]> dr) =>
             {
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
+                Assert.Equal(PersistenceStatus.Persisted, dr.Status);
                 Assert.Equal((Partition)0, dr.Partition);
                 Assert.Equal(singlePartitionTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Error.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(Offset.Invalid, dr.Offset);
                 Assert.Null(dr.Message.Key);
                 Assert.Equal("test", dr.Message.Value);
-                Assert.Equal(PersistenceStatus.NotPersisted, dr.PersistenceStatus);
+                Assert.Equal(PersistenceStatus.NotPersisted, dr.Status);
                 Assert.Equal(TimestampType.NotAvailable, dr.Message.Timestamp.Type);
                 count += 1;
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Null.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Null.cs
@@ -42,6 +42,7 @@ namespace Confluent.Kafka.IntegrationTests
             Action<DeliveryReport<Null, Null>> dh = (DeliveryReport<Null, Null> dr) => 
             {
                 Assert.Equal(ErrorCode.NoError, dr.Error.Code);
+                Assert.Equal(PersistenceStatus.Persisted, dr.Status);
                 Assert.False(dr.Error.IsFatal);
                 Assert.Equal((Partition)0, dr.Partition);
                 Assert.Equal(singlePartitionTopic, dr.Topic);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
@@ -63,6 +63,7 @@ namespace Confluent.Kafka.IntegrationTests
                 var err = ((ProduceException<string, string>)inner).Error;
                 
                 Assert.True(err.IsError);
+                Assert.Equal(PersistenceStatus.NotPersisted, dr.Status);
                 Assert.False(err.IsFatal);
                 Assert.Equal(partitionedTopic, dr.Topic);
                 Assert.Equal(Offset.Invalid, dr.Offset);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -56,6 +56,7 @@ namespace Confluent.Kafka.IntegrationTests
             for (int i=0; i<2; ++i)
             {
                 var dr = drs[i].Result;
+                Assert.Equal(PersistenceStatus.Persisted, dr.Status);
                 Assert.Equal(partitionedTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
                 Assert.True(dr.Partition == 0 || dr.Partition == 1);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
@@ -82,7 +82,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             Assert.Equal(Offset.Invalid, ((ProduceException<string, int>)e).DeliveryResult.Offset);
                             Assert.Equal(Partition.Any, ((ProduceException<string, int>)e).DeliveryResult.Partition);
                             Assert.Equal(guidTopic, ((ProduceException<string, int>)e).DeliveryResult.Topic);
-                            Assert.Equal(PersistenceStatus.NotPersisted, ((ProduceException<string, int>)e).DeliveryResult.PersistenceStatus);
+                            Assert.Equal(PersistenceStatus.NotPersisted, ((ProduceException<string, int>)e).DeliveryResult.Status);
                             Assert.Equal(Timestamp.Default, ((ProduceException<string, int>)e).DeliveryResult.Timestamp);
                             Assert.Null(((ProduceException<string, int>)e).DeliveryResult.Headers);
 


### PR DESCRIPTION
Following @rnpridgeon in the python client, changed the name of `DeliveryResult.PersistenceStatus` to `DeliveryResult.Status`. I think this is better because:
1. the property and enum will always be used together in practice and it's more verbose than necessary to have the word persistence appear twice.
2. `PersistenceStatus` is a bit awkward sounding.