### PR TITLE
removed CompilerServices.Unsafe dependency

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="librdkafka.redist" Version="1.0.0-RC7">
         <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -893,7 +893,7 @@ namespace Confluent.Kafka
 
             try
             {
-                var msg = Util.Marshal.PtrToStructureUnsafe<rd_kafka_message>(msgPtr);
+                var msg = Util.Marshal.PtrToStructure<rd_kafka_message>(msgPtr);
 
                 string topic = null;
                 if (this.enableTopicNameMarshaling)

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Text;
 using SystemMarshal = System.Runtime.InteropServices.Marshal;
-using Unsafe = System.Runtime.CompilerServices.Unsafe;
 
 
 namespace Confluent.Kafka.Internal
@@ -48,23 +47,6 @@ namespace Confluent.Kafka.Internal
                 // Avoid unnecessary data copying on NET45+
                 return Encoding.UTF8.GetString((byte*)strPtr.ToPointer(), length);
 #endif
-            }
-
-            /// <summary>
-            ///     Reinterpret_cast without strings marshaling
-            /// </summary>
-            /// <typeparam name="T">
-            ///     Type of struct to cast
-            /// </typeparam>
-            /// <param name="ptr">
-            ///     Raw pointer to use
-            /// </param>
-            /// <returns>
-            ///     A value of type <typeparamref name="T"/>
-            /// </returns>
-            public static unsafe T PtrToStructureUnsafe<T>(IntPtr ptr)
-            {
-                return Unsafe.Read<T>(ptr.ToPointer());
             }
 
             public static T PtrToStructure<T>(IntPtr ptr)

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -133,7 +133,7 @@ namespace Confluent.Kafka
             // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
             if (ownedKafkaHandle.IsClosed) { return; }
 
-            var msg = Util.Marshal.PtrToStructureUnsafe<rd_kafka_message>(rkmessage);
+            var msg = Util.Marshal.PtrToStructure<rd_kafka_message>(rkmessage);
 
             // the msg._private property has dual purpose. Here, it is an opaque pointer set
             // by Topic.Produce to be an IDeliveryHandler. When Consuming, it's for internal


### PR DESCRIPTION
resolves #796 

the `PtrToStructureUnsafe` method is theoretically more efficient, but I'm not seeing a significant regression in performance by reverting to the less performant version (disclaimer: benchmark results are pretty noisy) and loosing the dependency on `System.Runtime.CompilerServices.Unsafe`.
