### PR TITLE
made ProduceAsync async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Builder classes now return interfaces, not concrete classes.
 - Removed the dependency on `CompilerServices.Unsafe` which was causing `ProduceAsync` to hang in some scenarios.
 - Fixed a deadlock-on-dispose issue in `AdminClient`.
+- Made `Producer.ProduceAsync` async.
 
 
 # 1.0.0-beta3

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -658,7 +658,7 @@ namespace Confluent.Kafka
         ///     A Task which will complete with a delivery report corresponding to
         ///     the produce request, or an exception if an error occured.
         /// </returns>
-        public Task<DeliveryResult<TKey, TValue>> ProduceAsync(
+        public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             TopicPartition topicPartition,
             Message<TKey, TValue> message)
         {
@@ -667,10 +667,7 @@ namespace Confluent.Kafka
             {
                 keyBytes = (keySerializer != null)
                     ? keySerializer.Serialize(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic))
-                    : asyncKeySerializer.SerializeAsync(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic))
-                        .ConfigureAwait(continueOnCapturedContext: false)
-                        .GetAwaiter()
-                        .GetResult();
+                    : await asyncKeySerializer.SerializeAsync(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic));
             }
             catch (Exception exception)
             {
@@ -689,10 +686,7 @@ namespace Confluent.Kafka
             {
                 valBytes = (valueSerializer != null)
                     ? valueSerializer.Serialize(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic))
-                    : asyncValueSerializer.SerializeAsync(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic))
-                        .ConfigureAwait(continueOnCapturedContext: false)
-                        .GetAwaiter()
-                        .GetResult();
+                    : await asyncValueSerializer.SerializeAsync(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic));
             }
             catch (Exception exception)
             {
@@ -722,7 +716,7 @@ namespace Confluent.Kafka
                         message.Timestamp, topicPartition.Partition, message.Headers,
                         handler);
 
-                    return handler.Task;
+                    return await handler.Task;
                 }
                 else
                 {
@@ -739,7 +733,7 @@ namespace Confluent.Kafka
                         Message = message
                     };
 
-                    return Task.FromResult(result);
+                    return result;
                 }
             }
             catch (KafkaException ex)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AddBroker.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AddBroker.cs
@@ -58,7 +58,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(brokersAdded > 0, "Should have added one broker or more (duplicates considered added)");
 
                 var newMetadata = adminClient.GetMetadata(TimeSpan.FromSeconds(3));
-                Assert.True(newMetadata.Brokers.Count == 1);
+                Assert.True(newMetadata.Brokers.Count >= 1);
 
                 brokersAdded = adminClient.AddBrokers("");
                 Assert.True(brokersAdded == 0, "Should not have added brokers");

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreatePartitions.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreatePartitions.cs
@@ -58,9 +58,10 @@ namespace Confluent.Kafka.IntegrationTests
                     producer.ProduceAsync(new TopicPartition(topicName1, 2), new Message<Null, Null>()).Wait();
                     Assert.True(false, "expecting exception");
                 }
-                catch (KafkaException ex)
+                catch (AggregateException ex)
                 {
-                    Assert.True(ex.Error.IsError);
+                    Assert.IsType<ProduceException<Null,Null>>(ex.InnerException);
+                    Assert.True(((ProduceException<Null,Null>)ex.InnerException).Error.IsError);
                 }
             }
 
@@ -79,9 +80,10 @@ namespace Confluent.Kafka.IntegrationTests
                     var dr2 = producer.ProduceAsync(new TopicPartition(topicName2, 1), new Message<Null, Null>()).Result;
                     Assert.True(false, "expecting exception");
                 }
-                catch (KafkaException ex)
+                catch (AggregateException ex)
                 {
-                    Assert.True(ex.Error.IsError);
+                    Assert.IsType<ProduceException<Null,Null>>(ex.InnerException);
+                    Assert.True(((ProduceException<Null,Null>)ex.InnerException).Error.IsError);
                 }
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
@@ -70,7 +70,7 @@ namespace Confluent.Kafka.IntegrationTests
                     new Message<Null, string> { Value = "test-value" }).Result);
 
                 // TimestampType: LogAppendTime
-                Assert.Throws<ArgumentException>(() =>
+                Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 0),
                         new Message<Null, string>
@@ -80,7 +80,7 @@ namespace Confluent.Kafka.IntegrationTests
                         }).Result);
 
                 // TimestampType: NotAvailable
-                Assert.Throws<ArgumentException>(() =>
+                Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 0),
                         new Message<Null, string> 
@@ -159,13 +159,13 @@ namespace Confluent.Kafka.IntegrationTests
                     new Message<byte[], byte[]> { Timestamp = Timestamp.Default }).Result);
 
                 // TimestampType: LogAppendTime
-                Assert.Throws<ArgumentException>(() =>
+                Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         singlePartitionTopic,
                         new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) }).Result);
 
                 // TimestampType: NotAvailable
-                Assert.Throws<ArgumentException>(() =>
+                Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         singlePartitionTopic,
                         new Message<byte[], byte[]> { Timestamp = new Timestamp(10, TimestampType.NotAvailable) }).Result);


### PR DESCRIPTION
Over in #831, @BackTrak points out the `GetResult` call in the `ProduceAsync` call is problematic in some scenarios. This PR resolves that. 

The downside of doing this is that if `ProduceAsync` is used synchronously, an `AggregateException` is thrown with the actual exception exposed via `InnerException`, which is inconvenient. However, that reflects a limitation / annoying trad-off made in .NET, rather than something we should avoid here.

I've retained the `GetResult` in `BeginProduce` for now. We need to think carefully what we want to do there - I think we'll probably want `BeginProduceAsync` in addition to `BeginProduce`.

Also fixed a bug in the `AddBrokers` test (which I found due to now running integration tests against a 3 broker cluster).