### PR TITLE
run async serdes on thread pool thread

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -1102,14 +1102,14 @@ namespace Confluent.Kafka
 
             TKey key = keyDeserializer != null
                 ? keyDeserializer.Deserialize(rawResult.Key, rawResult.Key == null, new SerializationContext(MessageComponentType.Key, rawResult.Topic))
-                : asyncKeyDeserializer.DeserializeAsync(new ReadOnlyMemory<byte>(rawResult.Key), rawResult.Key == null, new SerializationContext(MessageComponentType.Key, rawResult.Topic))
+                : Task.Run(async () => await asyncKeyDeserializer.DeserializeAsync(new ReadOnlyMemory<byte>(rawResult.Key), rawResult.Key == null, new SerializationContext(MessageComponentType.Key, rawResult.Topic)))
                     .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();
 
             TValue val = valueDeserializer != null
                 ? valueDeserializer.Deserialize(rawResult.Value, rawResult.Value == null, new SerializationContext(MessageComponentType.Value, rawResult.Topic))
-                : asyncValueDeserializer.DeserializeAsync(new ReadOnlyMemory<byte>(rawResult.Value), rawResult == null, new SerializationContext(MessageComponentType.Value, rawResult.Topic))
+                : Task.Run(async () => await asyncValueDeserializer.DeserializeAsync(new ReadOnlyMemory<byte>(rawResult.Value), rawResult == null, new SerializationContext(MessageComponentType.Value, rawResult.Topic)))
                     .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -826,8 +826,8 @@ namespace Confluent.Kafka
             {
                 keyBytes = (keySerializer != null)
                     ? keySerializer.Serialize(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic))
-                    : asyncKeySerializer.SerializeAsync(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic))
-                        .ConfigureAwait(continueOnCapturedContext: false)
+                    : Task.Run(async () => await asyncKeySerializer.SerializeAsync(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic)))
+                        .ConfigureAwait(false)
                         .GetAwaiter()
                         .GetResult();
             }
@@ -848,7 +848,7 @@ namespace Confluent.Kafka
             {
                 valBytes = (valueSerializer != null)
                     ? valueSerializer.Serialize(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic))
-                    : asyncValueSerializer.SerializeAsync(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic))
+                    : Task.Run(async () => await asyncValueSerializer.SerializeAsync(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic)))
                         .ConfigureAwait(continueOnCapturedContext: false)
                         .GetAwaiter()
                         .GetResult();


### PR DESCRIPTION
`Consumer.Consume` and `Producer.BeginProduce` both block on async serdes. There was a deadlock problem with the previous implementation when used in a single threaded context (WinForms, WPF, WebAPI...). This PR forces async serdes to be run on a different thread (my understanding was that the previous implementation was supposed to do this, but it doesn't). All of this is considered an anti-pattern, but it is well considered and i believe appropriate here. Note: there are only performance implications for async serdes (i.e. currently just avro, which is slow anyway), and this is of similar order to doing async 'properly'. Justification of API:

## `BeginProduce`

- There is a fully legit async-all-the-way-down alternative `ProduceAsync`. This is most likely what people actually want when they're writing `async` code.
- The alternative to blocking in `BeginProduce` is to add a `BeginProduceAsync` method in addition to the `BeginProduce` method. We'd want both because making the method `async` has performance implications for the non-async serde case (vanilla `BeginProduce` is much faster than `ProduceAsync`). But:
  - typical usage will be to just block on the `BeginProduceAsync` method anyway (note: it is extremely infrequent that a call will block, as communication with schema registry is very infrequent).
  - so making this sync internally makes the external API simpler for typical usage.
  - `BeginProduceAsync` is going to confuse people, and increases the surface area of the API.
  - We can always add `BeginProduceAsync` later if needed.

## `Consume`

- The alternative is to add a `ConsumeAsync` method in addition to `Consume`.
- But this pointless (consume blocks anyway, and the additional blocking due to communication with SR is extremely infrequent).
- It's also going to confuse users - they'll think `ConsumeAsync` doesn't block.
- In the future, we can add a fully legit `ConsumeAsync` method (though i don't believe this is high priority - i'm not aware of high-priority use cases).
