### PR TITLE
comments: interface <-> class & formatting

### DIFF
--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -322,25 +322,10 @@ namespace Confluent.Kafka
             { Librdkafka.EventType.CreatePartitions_Result, typeof(TaskCompletionSource<List<CreatePartitionsReport>>) }
         };
 
+
         /// <summary>
-        ///     Get the configuration for the specified resources. The returned 
-        ///     configuration includes default values and the IsDefault property
-        ///     can be used to distinguish them from user supplied values. The 
-        ///     value of config entries where IsSensitive is true is always null 
-        ///     so that sensitive information is not disclosed. Config entries where
-        ///     IsReadOnly is true cannot be updated. This operation is supported 
-        ///     by brokers with version 0.11.0.0 or higher.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.DescribeConfigsAsync(IEnumerable{ConfigResource}, DescribeConfigsOptions)" />
         /// </summary>
-        /// <param name="resources">
-        ///     The resources (topic and broker resource types are currently 
-        ///     supported)
-        /// </param>
-        /// <param name="options">
-        ///     The options to use when describing configs.
-        /// </param>
-        /// <returns>
-        ///     Configs for the specified resources.
-        /// </returns>
         public Task<List<DescribeConfigsResult>> DescribeConfigsAsync(IEnumerable<ConfigResource> resources, DescribeConfigsOptions options = null)
         {
             // TODO: To support results that may complete at different times, we may also want to implement:
@@ -354,26 +339,10 @@ namespace Confluent.Kafka
             return completionSource.Task;
         }
 
+
         /// <summary>
-        ///     Update the configuration for the specified resources. Updates are not transactional
-        ///     so they may succeed for some resources while fail for others. The configs for a 
-        ///     particular resource are updated atomically. This operation is supported by brokers 
-        ///     with version 0.11.0.0 or higher. IMPORTANT NOTE: Unspecified configuration properties
-        ///     will be reverted to their default values. Furthermore, if you use DescribeConfigsAsync
-        ///     to obtain the current set of configuration values, modify them, then use 
-        ///     AlterConfigsAsync to set them, you will loose any non-default values that are marked 
-        ///     as sensitive because they are not provided by DescribeConfigsAsync.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.AlterConfigsAsync(Dictionary{ConfigResource, List{ConfigEntry}}, AlterConfigsOptions)" />
         /// </summary>
-        /// <param name="configs">
-        ///     The resources with their configs (topic is the only resource type with configs
-        ///     that can be updated currently).
-        /// </param>
-        /// <param name="options">
-        ///     The options to use when altering configs.
-        /// </param>
-        /// <returns>
-        ///     The results of the alter configs requests.
-        /// </returns>
         public Task AlterConfigsAsync(Dictionary<ConfigResource, List<ConfigEntry>> configs, AlterConfigsOptions options = null)
         {
             // TODO: To support results that may complete at different times, we may also want to implement:
@@ -391,18 +360,10 @@ namespace Confluent.Kafka
             return completionSource.Task;
         }
 
+
         /// <summary>
-        ///     Create a set of new topics.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.CreateTopicsAsync(IEnumerable{TopicSpecification}, CreateTopicsOptions)" />
         /// </summary>
-        /// <param name="topics">
-        ///     A collection of specifications for the new topics to create.
-        /// </param>
-        /// <param name="options">
-        ///     The options to use when creating the topics.
-        /// </param>
-        /// <returns>
-        ///     The results of the create topic requests.
-        /// </returns>
         public Task CreateTopicsAsync(IEnumerable<TopicSpecification> topics, CreateTopicsOptions options = null)
         {
             // TODO: To support results that may complete at different times, we may also want to implement:
@@ -417,21 +378,8 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Delete a set of topics. This operation is not transactional so it may succeed for some topics while fail
-        ///     for others. It may take several seconds after the DeleteTopicsResult returns success for all the brokers to
-        ///     become aware that the topics are gone. During this time, topics may continue to be visible via admin 
-        ///     operations. If delete.topic.enable is false on the brokers, DeleteTopicsAsync will mark the topics for
-        ///     deletion, but not actually delete them. The Task will return successfully in this case.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.DeleteTopicsAsync(IEnumerable{string}, DeleteTopicsOptions)" />
         /// </summary>
-        /// <param name="topics">
-        ///     The topic names to delete.
-        /// </param>
-        /// <param name="options">
-        ///     The options to use when deleting topics.
-        /// </param>
-        /// <returns>
-        ///     The results of the delete topic requests.
-        /// </returns>
         public Task DeleteTopicsAsync(IEnumerable<string> topics, DeleteTopicsOptions options = null)
         {
             // TODO: To support results that may complete at different times, we may also want to implement:
@@ -446,18 +394,8 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     Increase the number of partitions for one or more topics as per
-        ///     the supplied PartitionsSpecifications.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.CreatePartitionsAsync(IEnumerable{PartitionsSpecification}, CreatePartitionsOptions)" />
         /// </summary>
-        /// <param name="partitionsSpecifications">
-        ///     A collection of PartitionsSpecifications.
-        /// </param>
-        /// <param name="options">
-        ///     The options to use when creating the partitions.
-        /// </param>
-        /// <returns>
-        ///     The results of the PartitionsSpecification requests.
-        /// </returns>
         public Task CreatePartitionsAsync(
             IEnumerable<PartitionsSpecification> partitionsSpecifications, CreatePartitionsOptions options = null)
         {
@@ -530,51 +468,28 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Get information pertaining to all groups in the Kafka cluster (blocking)
-        ///
-        ///     [API-SUBJECT-TO-CHANGE] - The API associated with this functionality 
-        ///     is subject to change.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.ListGroups(TimeSpan)" />
         /// </summary>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
         public List<GroupInfo> ListGroups(TimeSpan timeout)
             => kafkaHandle.ListGroups(timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Get information pertaining to a particular group in the
-        ///     Kafka cluster (blocking).
-        ///
-        ///     [API-SUBJECT-TO-CHANGE] - The API associated with this functionality is subject to change.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.ListGroup(string, TimeSpan)" />
         /// </summary>
-        /// <param name="group">
-        ///     The group of interest.
-        /// </param>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
-        /// <returns>
-        ///     Returns information pertaining to the specified group
-        ///     or null if this group does not exist.
-        /// </returns>
         public GroupInfo ListGroup(string group, TimeSpan timeout)
             => kafkaHandle.ListGroup(group, timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Query the cluster for metadata.
-        ///
-        ///     [API-SUBJECT-TO-CHANGE] - The API associated with this functionality is subject to change.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.GetMetadata(TimeSpan)" />
         /// </summary>
         public Metadata GetMetadata(TimeSpan timeout)
             => kafkaHandle.GetMetadata(true, null, timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Query the cluster for metadata for a specific topic.
-        /// 
-        ///     [API-SUBJECT-TO-CHANGE] - The API associated with this functionality is subject to change.
+        ///     Refer to <see cref="Confluent.Kafka.IAdminClient.GetMetadata(string, TimeSpan)" />
         /// </summary>
         public Metadata GetMetadata(string topic, TimeSpan timeout)
             => kafkaHandle.GetMetadata(false, kafkaHandle.getKafkaTopicHandle(topic), timeout.TotalMillisecondsAsInt());

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -234,40 +234,22 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Gets the current partition assignment as set by
-        ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(TopicPartition)" />
-        ///     or implicitly.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Assignment" />
         /// </summary>
         public List<TopicPartition> Assignment
             => kafkaHandle.GetAssignment();
 
 
         /// <summary>
-        ///     Gets the current topic subscription as set by
-        ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Subscribe(string)" />.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Subscription" />
         /// </summary>
         public List<string> Subscription
             => kafkaHandle.GetSubscription();
 
 
         /// <summary>
-        ///     Update the topic subscription.
-        ///
-        ///     Any previous subscription will be unassigned and unsubscribed first.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Subscribe(IEnumerable{string})" />
         /// </summary>
-        /// <param name="topics">
-        ///     The topics to subscribe to. A regex can be specified to subscribe to 
-        ///     the set of all matching topics (which is updated as topics are added
-        ///     / removed from the cluster). A regex must be front anchored to be
-        ///     recognized as a regex. e.g. ^myregex
-        /// </param>
-        /// <remarks>
-        ///     The topic subscription set denotes the desired set of topics to consume
-        ///     from. This set is provided to the consumer group leader (one of the group
-        ///     members) which uses the configured partition.assignment.strategy to 
-        ///     allocate partitions of topics in the subscription set to the consumers
-        ///     in the group.
-        /// </remarks>
         public void Subscribe(IEnumerable<string> topics)
         {
             kafkaHandle.Subscribe(topics);
@@ -275,77 +257,36 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Sets the subscription set to a single topic.
-        ///
-        ///     Any previous subscription will be unassigned and unsubscribed first.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Subscribe(string)" />
         /// </summary>
-        /// <param name="topic">
-        ///     The topic to subscribe to. A regex can be specified to subscribe to 
-        ///     the set of all matching topics (which is updated as topics are added
-        ///     / removed from the cluster). A regex must be front anchored to be 
-        ///     recognized as a regex. e.g. ^myregex
-        /// </param>
         public void Subscribe(string topic)
             => Subscribe(new[] { topic });
 
 
         /// <summary>
-        ///     Unsubscribe from the current subscription set.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Unsubscribe" />
         /// </summary>
         public void Unsubscribe()
             => kafkaHandle.Unsubscribe();
 
 
         /// <summary>
-        ///     Sets the current set of assigned partitions (the set of partitions the
-        ///     consumer will consume from) to a single <paramref name="partition" />. 
-        ///
-        ///     Note: The newly specified set is the complete set of partitions to
-        ///     consume from. If the consumer is already assigned to a set of partitions,
-        ///     the previous set will be replaced.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Assign(TopicPartition)" />
         /// </summary>
-        /// <param name="partition">
-        ///     The partition to consume from. Consumption will resume from the last
-        ///     committed offset, or according to the 'auto.offset.reset' configuration
-        ///     parameter if no offsets have been committed yet.
-        /// </param>
         public void Assign(TopicPartition partition)
             => Assign(new List<TopicPartition> { partition });
 
 
         /// <summary>
-        ///     Sets the current set of assigned partitions (the set of partitions the
-        ///     consumer will consume from) to a single <paramref name="partition" />. 
-        ///
-        ///     Note: The newly specified set is the complete set of partitions to
-        ///     consume from. If the consumer is already assigned to a set of partitions,
-        ///     the previous set will be replaced.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Assign(TopicPartitionOffset)" />
         /// </summary>
-        /// <param name="partition">
-        ///     The partition to consume from. If an offset value of Offset.Unset
-        ///     (-1001) is specified, consumption will resume from the last committed
-        ///     offset, or according to the 'auto.offset.reset' configuration parameter
-        ///     if no offsets have been committed yet.
-        /// </param>
         public void Assign(TopicPartitionOffset partition)
             => Assign(new List<TopicPartitionOffset> { partition });
 
 
         /// <summary>
-        ///     Sets the current set of assigned partitions (the set of partitions the
-        ///     consumer will consume from) to <paramref name="partitions" />. 
-        ///
-        ///     Note: The newly specified set is the complete set of partitions to
-        ///     consume from. If the consumer is already assigned to a set of partitions,
-        ///     the previous set will be replaced.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Assign(IEnumerable{TopicPartitionOffset})" />
         /// </summary>
-        /// <param name="partitions">
-        ///     The set of partitions to consume from. If an offset value of
-        ///     Offset.Unset (-1001) is specified for a partition, consumption
-        ///     will resume from the last committed offset on that partition, or
-        ///     according to the 'auto.offset.reset' configuration parameter if
-        ///     no offsets have been committed yet.
-        /// </param>
         public void Assign(IEnumerable<TopicPartitionOffset> partitions)
         {
             lock (assignCallCountLockObj) { assignCallCount += 1; }
@@ -354,19 +295,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Sets the current set of assigned partitions (the set of partitions the
-        ///     consumer will consume from) to <paramref name="partitions" />. 
-        ///
-        ///     Note: The newly specified set is the complete set of partitions to
-        ///     consume from. If the consumer is already assigned to a set of partitions,
-        ///     the previous set will be replaced.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Assign(TopicPartition)" />
         /// </summary>
-        /// <param name="partitions">
-        ///     The set of partitions to consume from. Consumption will resume
-        ///     from the last committed offset on each partition, or according
-        ///     to the 'auto.offset.reset' configuration parameter if no offsets
-        ///     have been committed yet.
-        /// </param>
         public void Assign(IEnumerable<TopicPartition> partitions)
         {
             lock (assignCallCountLockObj) { assignCallCount += 1; }
@@ -375,7 +305,7 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Remove the current set of assigned partitions and stop consumption.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Unassign" />
         /// </summary>
         public void Unassign()
         {
@@ -385,48 +315,15 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Store offsets for a single partition based on the topic/partition/offset
-        ///     of a consume result.
-        /// 
-        ///     The offset will be committed according to `auto.commit.interval.ms`
-        ///     (and `enable.auto.commit`) or manual offset-less commit().
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey, TValue})" />
         /// </summary>
-        /// <remarks>
-        ///     `enable.auto.offset.store` must be set to "false" when using this API.
-        /// </remarks>
-        /// <param name="result">
-        ///     A consume result used to determine the offset to store and topic/partition.
-        /// </param>
-        /// <returns>
-        ///     Current stored offset or a partition specific error.
-        /// </returns>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if result is in error.
-        /// </exception>
         public void StoreOffset(ConsumeResult<TKey, TValue> result)
             => StoreOffset(new TopicPartitionOffset(result.TopicPartition, result.Offset + 1));
 
 
         /// <summary>
-        ///     Store offsets for a single partition.
-        /// 
-        ///     The offset will be committed (written) to the offset store according
-        ///     to `auto.commit.interval.ms` or manual offset-less commit(). Calling
-        ///     this method in itself does not commit offsets, only store them for
-        ///     future commit.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.StoreOffset(TopicPartitionOffset)" />
         /// </summary>
-        /// <remarks>
-        ///     `enable.auto.offset.store` must be set to "false" when using this API.
-        /// </remarks>
-        /// <param name="offset">
-        ///     The offset to be committed.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
         public void StoreOffset(TopicPartitionOffset offset)
         {
             try
@@ -441,59 +338,24 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Commit all offsets for the current assignment.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Commit()" />
         /// </summary>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if any of the constituent results is in error. The entire result
-        ///     (which may contain constituent results that are not in error) is available
-        ///     via the <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
-        ///     property of the exception.
-        /// </exception>
         public List<TopicPartitionOffset> Commit()
             // TODO: use a librdkafka queue for this.
             => kafkaHandle.Commit(null);
 
 
         /// <summary>
-        ///     Commit an explicit list of offsets.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Commit(IEnumerable{TopicPartitionOffset})" />
         /// </summary>
-        /// <param name="offsets">
-        ///     The topic/partition offsets to commit.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if any of the constituent results is in error. The entire result
-        ///     (which may contain constituent results that are not in error) is available
-        ///     via the <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
-        ///     property of the exception.
-        /// </exception>
         public void Commit(IEnumerable<TopicPartitionOffset> offsets)
             // TODO: use a librdkafka queue for this.
             => kafkaHandle.Commit(offsets);
 
 
         /// <summary>
-        ///     Commits an offset based on the topic/partition/offset of a ConsumeResult.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Commit(ConsumeResult{TKey, TValue})" />
         /// </summary>
-        /// <param name="result">
-        ///     The ConsumeResult instance used to determine the committed offset.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if the result is in error.
-        /// </exception>
-        /// <remarks>
-        ///     A consumer at position N has consumed messages with offsets up to N-1 
-        ///     and will next receive the message with offset N. Hence, this method commits an 
-        ///     offset of <paramref name="result" />.Offset + 1.
-        /// </remarks>
         public void Commit(ConsumeResult<TKey, TValue> result)
         {
             if (result.Message == null)
@@ -504,95 +366,39 @@ namespace Confluent.Kafka
             Commit(new [] { new TopicPartitionOffset(result.TopicPartition, result.Offset + 1) });
         }
 
-        
+
         /// <summary>
-        ///     Seek to <parmref name="offset"/> on the specified topic/partition which is either
-        ///     an absolute or logical offset. This must only be done for partitions that are 
-        ///     currently being consumed (i.e., have been Assign()ed). To set the start offset for 
-        ///     not-yet-consumed partitions you should use the 
-        ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(TopicPartitionOffset)" /> 
-        ///     method (or other overload) instead.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Seek(TopicPartitionOffset)" />
         /// </summary>
-        /// <param name="tpo">
-        ///     The topic/partition to seek on and the offset to seek to.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
         public void Seek(TopicPartitionOffset tpo)
             => kafkaHandle.Seek(tpo.Topic, tpo.Partition, tpo.Offset, -1);
 
 
         /// <summary>
-        ///     Pause consumption for the provided list of partitions.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Pause(IEnumerable{TopicPartition})" />
         /// </summary>
-        /// <param name="partitions">
-        ///     The partitions to pause consumption of.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionException">
-        ///     Per partition success or error.
-        /// </exception>
         public void Pause(IEnumerable<TopicPartition> partitions)
             => kafkaHandle.Pause(partitions);
 
 
         /// <summary>
-        ///     Resume consumption for the provided list of partitions.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Resume(IEnumerable{TopicPartition})" />
         /// </summary>
-        /// <param name="partitions">
-        ///     The partitions to resume consumption of.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionException">
-        ///     Per partition success or error.
-        /// </exception>
         public void Resume(IEnumerable<TopicPartition> partitions)
             => kafkaHandle.Resume(partitions);
 
 
         /// <summary>
-        ///     Retrieve current committed offsets for the specified topic partitions.
-        ///
-        ///     The offset field of each requested partition will be set to the offset
-        ///     of the last consumed message, or Offset.Unset in case there was
-        ///     no previous message, or, alternately a partition specific error may also
-        ///     be returned.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Committed(IEnumerable{TopicPartition}, TimeSpan)" />
         /// </summary>
-        /// <param name="partitions">
-        ///     the partitions to get the committed offsets for.
-        /// </param>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if any of the constituent results is in error. The entire result
-        ///     (which may contain constituent results that are not in error) is available
-        ///     via the <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
-        ///     property of the exception.
-        /// </exception>
         public List<TopicPartitionOffset> Committed(IEnumerable<TopicPartition> partitions, TimeSpan timeout)
             // TODO: use a librdkafka queue for this.
             => kafkaHandle.Committed(partitions, (IntPtr)timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Gets the current position (offset) for the specified topic / partition.
-        ///
-        ///     The offset field of each requested partition will be set to the offset
-        ///     of the last consumed message + 1, or Offset.Unset in case there was
-        ///     no previous message consumed by this consumer.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Position(TopicPartition)" />
         /// </summary>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
         public Offset Position(TopicPartition partition)
         {
             try
@@ -605,79 +411,31 @@ namespace Confluent.Kafka
             }
         }
 
+
         /// <summary>
-        ///     Look up the offsets for the given partitions by timestamp. The returned
-        ///     offset for each partition is the earliest offset whose timestamp is greater
-        ///     than or equal to the given timestamp in the corresponding partition.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.OffsetsForTimes(IEnumerable{TopicPartitionTimestamp}, TimeSpan)" />
         /// </summary>
-        /// <remarks>
-        ///     The consumer does not need to be assigned to the requested partitions.
-        /// </remarks>
-        /// <param name="timestampsToSearch">
-        ///     The mapping from partition to the timestamp to look up.
-        /// </param>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
-        /// <returns>
-        ///     A mapping from partition to the timestamp and offset of the first message with
-        ///     timestamp greater than or equal to the target timestamp.
-        /// </returns>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the operation fails.
-        /// </exception>
-        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
-        ///     Thrown if any of the constituent results is in error. The entire result
-        ///     (which may contain constituent results that are not in error) is available
-        ///     via the <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
-        ///     property of the exception.
-        /// </exception>
         public List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestampsToSearch, TimeSpan timeout)
             // TODO: use a librdkafka queue for this.
             => kafkaHandle.OffsetsForTimes(timestampsToSearch, timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Get the last cached low (oldest available/beginning) and high (newest/end)
-        ///     offsets for a topic/partition. Does not block.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.GetWatermarkOffsets(TopicPartition)" />
         /// </summary>
-        /// <remarks>
-        ///     The low offset is updated periodically (if statistics.interval.ms 
-        ///     is set) while the high offset is updated on each fetched message set from
-        ///     the broker. If there is no cached offset (either low or high, or both) then
-        ///     Offset.Unset will be returned for the respective offset.
-        /// </remarks>
-        /// <param name="topicPartition">
-        ///     The topic/partition of interest.
-        /// </param>
-        /// <returns>
-        ///     The requested WatermarkOffsets (see that class for additional documentation).
-        /// </returns>
         public WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition)
             => kafkaHandle.GetWatermarkOffsets(topicPartition.Topic, topicPartition.Partition);
 
 
         /// <summary>
-        ///     Query the Kafka cluster for low (oldest available/beginning) and high (newest/end)
-        ///     offsets for the specified topic/partition. This is a blocking call - always contacts
-        ///     the cluster for the required information.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.QueryWatermarkOffsets(TopicPartition, TimeSpan)" />
         /// </summary>
-        /// <param name="topicPartition">
-        ///     The topic/partition of interest.
-        /// </param>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
-        /// <returns>
-        ///     The requested WatermarkOffsets (see that class for additional documentation).
-        /// </returns>
         public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout)
             => kafkaHandle.QueryWatermarkOffsets(topicPartition.Topic, topicPartition.Partition, timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Gets the (dynamic) group member id of this consumer (as 
-        ///     set by the broker).
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.MemberId" />
         /// </summary>
         public string MemberId
             => kafkaHandle.MemberId;
@@ -707,21 +465,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Commits offsets, alerts the group coodinator that the consumer is
-        ///     exiting the group then releases all resources used by this consumer.
-        ///     You should call <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" />
-        ///     instead of <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Dispose()" />
-        ///     (or just before) to ensure a timely consumer-group rebalance. If you
-        ///     do not call <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" />
-        ///     or <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Unsubscribe" />,
-        ///     the group will rebalance after a timeout specified by the group's 
-        ///     `session.timeout.ms`. Note: the partition asignment and partitions
-        ///     revoked handlers may be called as a side-effect of
-        ///     calling this method.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey,TValue}.Close" />.
         /// </summary>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the operation fails.
-        /// </exception>
         public void Close()
         {
             // commits offsets and unsubscribes.
@@ -1146,28 +891,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Poll for new messages / events. Blocks until a consume result
-        ///     is available or the operation has been cancelled.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey, TValue}.Consume(CancellationToken)" />
         /// </summary>
-        /// <param name="cancellationToken">
-        ///     A cancellation token that can be used to cancel this operation.
-        /// </param>
-        /// <returns>
-        ///     The consume result.
-        /// </returns>
-        /// <remarks>
-        ///     The partitions assigned/revoked and offsets committed handlers may
-        ///     be invoked as a side-effect of calling this method (on the same
-        ///     thread).
-        /// </remarks>
-        /// <exception cref="ConsumeException">
-        ///     Thrown when a call to this method is unsuccessful for any reason
-        ///     (except cancellation by user). Inspect the Error property of the
-        ///     exception for detailed information.
-        /// </exception>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown on cancellation.
-        /// </exception>
         public ConsumeResult<TKey, TValue> Consume(CancellationToken cancellationToken = default(CancellationToken))
         {
             while (true)
@@ -1186,24 +911,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Poll for new messages / events. Blocks until a consume result
-        ///     is available or the timeout period has elapsed.
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey, TValue}.Consume(TimeSpan)" />
         /// </summary>
-        /// <param name="timeout">
-        ///     The maximum period of time the call may block.
-        /// </param>
-        /// <returns>
-        ///     The consume result.
-        /// </returns>
-        /// <remarks>
-        ///     The partitions assigned/revoked and offsets committed handlers may
-        ///     be invoked as a side-effect of calling this method (on the same
-        ///     thread).
-        /// </remarks>
-        /// <exception cref="ConsumeException">
-        ///     Thrown when a call to this method is unsuccessful for any reason.
-        ///     Inspect the Error property of the exception for detailed information.
-        /// </exception>
         public ConsumeResult<TKey, TValue> Consume(TimeSpan timeout)
             => (keyDeserializer != null && valueDeserializer != null)
                 ? ConsumeImpl<TKey, TValue>(timeout.TotalMillisecondsAsInt(), keyDeserializer, valueDeserializer) // fast path for simple case

--- a/src/Confluent.Kafka/DeliveryResult.cs
+++ b/src/Confluent.Kafka/DeliveryResult.cs
@@ -43,7 +43,6 @@ namespace Confluent.Kafka
         public TopicPartition TopicPartition
             => new TopicPartition(Topic, Partition);
 
-
         /// <summary>
         ///     The TopicPartitionOffset assoicated with the message.
         /// </summary>

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -29,59 +29,176 @@ namespace Confluent.Kafka
     public interface IAdminClient : IClient
     {
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.ListGroups(TimeSpan)" />
+        ///     Get information pertaining to all groups in
+        ///     the Kafka cluster (blocking)
+        ///
+        ///     [API-SUBJECT-TO-CHANGE] - The API associated
+        ///     with this functionality is subject to change.
         /// </summary>
+        /// <param name="timeout">
+        ///     The maximum period of time the call may block.
+        /// </param>
         List<GroupInfo> ListGroups(TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.ListGroup(string, TimeSpan)" />
+        ///     Get information pertaining to a particular
+        ///     group in the Kafka cluster (blocking).
+        ///
+        ///     [API-SUBJECT-TO-CHANGE] - The API associated
+        ///     with this functionality is subject to change.
         /// </summary>
+        /// <param name="group">
+        ///     The group of interest.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time the call
+        ///     may block.
+        /// </param>
+        /// <returns>
+        ///     Returns information pertaining to the
+        ///     specified group or null if this group does
+        ///     not exist.
+        /// </returns>
         GroupInfo ListGroup(string group, TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.GetMetadata(string, TimeSpan)" />
+        ///     Query the cluster for metadata for a
+        ///     specific topic.
+        /// 
+        ///     [API-SUBJECT-TO-CHANGE] - The API associated
+        ///     with this functionality is subject to change.
         /// </summary>
+
         Metadata GetMetadata(string topic, TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.GetMetadata(TimeSpan)" />
+        ///     Query the cluster for metadata.
+        ///
+        ///     [API-SUBJECT-TO-CHANGE] - The API associated
+        ///     with this functionality is subject to change.
         /// </summary>
         Metadata GetMetadata(TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.CreatePartitionsAsync(IEnumerable{PartitionsSpecification}, CreatePartitionsOptions)" />
+        ///     Increase the number of partitions for one
+        ///     or more topics as per the supplied
+        ///     PartitionsSpecifications.
         /// </summary>
+        /// <param name="partitionsSpecifications">
+        ///     A collection of PartitionsSpecifications.
+        /// </param>
+        /// <param name="options">
+        ///     The options to use when creating
+        ///     the partitions.
+        /// </param>
+        /// <returns>
+        ///     The results of the
+        ///     PartitionsSpecification requests.
+        /// </returns>
         Task CreatePartitionsAsync(
             IEnumerable<PartitionsSpecification> partitionsSpecifications, CreatePartitionsOptions options = null);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.DeleteTopicsAsync(IEnumerable{string}, DeleteTopicsOptions)" />
+        ///     Delete a set of topics. This operation is not
+        ///     transactional so it may succeed for some
+        ///     topics while fail for others. It may take
+        ///     several seconds after the DeleteTopicsResult
+        ///     returns success for all the brokers to become
+        ///     aware that the topics are gone. During this
+        ///     time, topics may continue to be visible via
+        ///     admin operations. If delete.topic.enable is
+        ///     false on the brokers, DeleteTopicsAsync will
+        ///     mark the topics for deletion, but not
+        ///     actually delete them. The Task will return
+        ///     successfully in this case.
         /// </summary>
+        /// <param name="topics">
+        ///     The topic names to delete.
+        /// </param>
+        /// <param name="options">
+        ///     The options to use when deleting topics.
+        /// </param>
+        /// <returns>
+        ///     The results of the delete topic requests.
+        /// </returns>
         Task DeleteTopicsAsync(IEnumerable<string> topics, DeleteTopicsOptions options = null);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.CreateTopicsAsync(IEnumerable{TopicSpecification}, CreateTopicsOptions)" />
+        ///     Create a set of new topics.
         /// </summary>
+        /// <param name="topics">
+        ///     A collection of specifications for
+        ///     the new topics to create.
+        /// </param>
+        /// <param name="options">
+        ///     The options to use when creating
+        ///     the topics.
+        /// </param>
+        /// <returns>
+        ///     The results of the create topic requests.
+        /// </returns>
         Task CreateTopicsAsync(IEnumerable<TopicSpecification> topics, CreateTopicsOptions options = null);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.AlterConfigsAsync(Dictionary{ConfigResource, List{ConfigEntry}}, AlterConfigsOptions)" />
+        ///     Update the configuration for the specified
+        ///     resources. Updates are not transactional so
+        ///     they may succeed for some resources while fail
+        ///     for others. The configs for a particular
+        ///     resource are updated atomically. This operation
+        ///     is supported by brokers with version 0.11.0
+        ///     or higher. IMPORTANT NOTE: Unspecified
+        ///     configuration properties will be reverted to
+        ///     their default values. Furthermore, if you use
+        ///     DescribeConfigsAsync to obtain the current set
+        ///     of configuration values, modify them, then use 
+        ///     AlterConfigsAsync to set them, you will loose
+        ///     any non-default values that are marked as
+        ///     sensitive because they are not provided by
+        ///     DescribeConfigsAsync.
         /// </summary>
+        /// <param name="configs">
+        ///     The resources with their configs
+        ///     (topic is the only resource type with configs
+        ///     that can be updated currently).
+        /// </param>
+        /// <param name="options">
+        ///     The options to use when altering configs.
+        /// </param>
+        /// <returns>
+        ///     The results of the alter configs requests.
+        /// </returns>
         Task AlterConfigsAsync(Dictionary<ConfigResource, List<ConfigEntry>> configs, AlterConfigsOptions options = null);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.AdminClient.DescribeConfigsAsync(IEnumerable{ConfigResource}, DescribeConfigsOptions)" />
+        ///     Get the configuration for the specified
+        ///     resources. The returned  configuration includes
+        ///     default values and the IsDefault property can be
+        ///     used to distinguish them from user supplied values.
+        ///     The value of config entries where IsSensitive is
+        ///     true is always null so that sensitive information
+        ///     is not disclosed. Config entries where IsReadOnly
+        ///     is true cannot be updated. This operation is
+        ///     supported by brokers with version 0.11.0.0 or higher.
         /// </summary>
+        /// <param name="resources">
+        ///     The resources (topic and broker resource
+        ///     types are currently supported)
+        /// </param>
+        /// <param name="options">
+        ///     The options to use when describing configs.
+        /// </param>
+        /// <returns>
+        ///     Configs for the specified resources.
+        /// </returns>
         Task<List<DescribeConfigsResult>> DescribeConfigsAsync(IEnumerable<ConfigResource> resources, DescribeConfigsOptions options = null);
-
     }
 
 }

--- a/src/Confluent.Kafka/IClient.cs
+++ b/src/Confluent.Kafka/IClient.cs
@@ -25,47 +25,54 @@ namespace Confluent.Kafka
     public interface IClient : IDisposable
     {
         /// <summary>
-        ///     An opaque reference to the underlying librdkafka client instance.
-        ///     This can be used to construct an AdminClient that utilizes the same
-        ///     underlying librdkafka client as this instance.
+        ///     An opaque reference to the underlying
+        ///     librdkafka client instance. This can be used
+        ///     to construct an AdminClient that utilizes the
+        ///     same underlying librdkafka client as this
+        ///     instance.
         /// </summary>
         Handle Handle { get; }
 
 
         /// <summary>
         ///     Gets the name of this client instance.
-        ///     Contains (but is not equal to) the client.id configuration
-        ///     parameter.
+        ///
+        ///     Contains (but is not equal to) the client.id
+        ///     configuration parameter.
         /// </summary>
         /// <remarks>
-        ///     This name will be unique across all client instances
-        ///     in a given application which allows log messages to be
-        ///     associated with the corresponding instance.
+        ///     This name will be unique across all client
+        ///     instances in a given application which allows
+        ///     log messages to be associated with the
+        ///     corresponding instance.
         /// </remarks>
         string Name { get; }
 
 
         /// <summary>
-        ///     Adds one or more brokers to the Client's list of initial
-        ///     bootstrap brokers. 
+        ///     Adds one or more brokers to the Client's list
+        ///     of initial bootstrap brokers. 
         ///
-        ///     Note: Additional brokers are discovered automatically as
-        ///     soon as the Client connects to any broker by querying the
-        ///     broker metadata. Calling this method is only required in
-        ///     some scenarios where the address of all brokers in the
-        ///     cluster changes.
+        ///     Note: Additional brokers are discovered
+        ///     automatically as soon as the Client connects
+        ///     to any broker by querying the broker metadata.
+        ///     Calling this method is only required in some
+        ///     scenarios where the address of all brokers in
+        ///     the cluster changes.
         /// </summary>
         /// <param name="brokers">
-        ///     Comma-separated list of brokers in the same format as 
-        ///     the bootstrap.server configuration parameter.
+        ///     Comma-separated list of brokers in
+        ///     the same format as the bootstrap.server
+        ///     configuration parameter.
         /// </param>
         /// <remarks>
-        ///     There is currently no API to remove existing configured, 
-        ///     added or learnt brokers.
+        ///     There is currently no API to remove existing
+        ///     configured, added or learnt brokers.
         /// </remarks>
         /// <returns>
-        ///     The number of brokers added. This value includes brokers
-        ///     that may have been specified a second time.
+        ///     The number of brokers added. This value
+        ///     includes brokers that may have been specified
+        ///     a second time.
         /// </returns>
         int AddBrokers(string brokers);
     }

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -22,171 +22,549 @@ using System.Threading;
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     Defines a high-level Apache Kafka consumer (with key and 
-    ///     value deserialization).
+    ///     Defines a high-level Apache Kafka consumer
+    ///     (with key and value deserialization).
     /// </summary>
     public interface IConsumer<TKey, TValue> : IClient
     {
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.Consume(CancellationToken)" />
+        ///     Poll for new messages / events. Blocks
+        ///     until a consume result is available or the
+        ///     operation has been cancelled.
         /// </summary>
+        /// <param name="cancellationToken">
+        ///     A cancellation token
+        ///     that can be used to cancel this operation.
+        /// </param>
+        /// <returns>
+        ///     The consume result.
+        /// </returns>
+        /// <remarks>
+        ///     The partitions assigned/revoked and
+        ///     offsets committed handlers may be invoked
+        ///     as a side-effect of calling this method
+        ///     (on the same thread).
+        /// </remarks>
+        /// <exception cref="ConsumeException">
+        ///     Thrown
+        ///     when a call to this method is unsuccessful
+        ///     for any reason (except cancellation by
+        ///     user). Inspect the Error property of the
+        ///     exception for detailed information.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown on cancellation.
+        /// </exception>
         ConsumeResult<TKey, TValue> Consume(CancellationToken cancellationToken = default(CancellationToken));
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey, TValue}.Consume(TimeSpan)" />
+        ///     Poll for new messages / events. Blocks
+        ///     until a consume result is available or the
+        ///     timeout period has elapsed.
         /// </summary>
+        /// <param name="timeout">
+        ///     The maximum period of time
+        ///     the call may block.
+        /// </param>
+        /// <returns>
+        ///     The consume result.
+        /// </returns>
+        /// <remarks>
+        ///     The partitions assigned/revoked and offsets
+        ///     committed handlers may be invoked as a
+        ///     side-effect of calling this method (on the
+        ///     same thread).
+        /// </remarks>
+        /// <exception cref="ConsumeException">
+        ///     Thrown
+        ///     when a call to this method is unsuccessful
+        ///     for any reason. Inspect the Error property
+        ///     of the exception for detailed information.
+        /// </exception>
         ConsumeResult<TKey, TValue> Consume(TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.MemberId" />
+        ///     Gets the (dynamic) group member id of
+        ///     this consumer (as set by the broker).
         /// </summary>
         string MemberId { get; }
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assignment" />
+        ///     Gets the current partition assignment as set by
+        ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(TopicPartition)" />
+        ///     or implicitly.
         /// </summary>
         List<TopicPartition> Assignment { get; }
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Subscription" />
+        ///     Gets the current topic subscription as set by
+        ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Subscribe(string)" />.
         /// </summary>
         List<string> Subscription { get; }
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Subscribe(IEnumerable{string})" />
+        ///     Update the topic subscription.
+        ///
+        ///     Any previous subscription will be
+        ///     unassigned and unsubscribed first.
         /// </summary>
+        /// <param name="topics">
+        ///     The topics to subscribe to.
+        ///     A regex can be specified to subscribe to 
+        ///     the set of all matching topics (which is
+        ///     updated as topics are added / removed from
+        ///     the cluster). A regex must be front
+        ///     anchored to be recognized as a regex.
+        ///     e.g. ^myregex
+        /// </param>
+        /// <remarks>
+        ///     The topic subscription set denotes the
+        ///     desired set of topics to consume from.
+        ///     This set is provided to the consumer
+        ///     group leader (one of the group
+        ///     members) which uses the configured
+        ///     partition.assignment.strategy to 
+        ///     allocate partitions of topics in the
+        ///     subscription set to the consumers in
+        ///     the group.
+        /// </remarks>
         void Subscribe(IEnumerable<string> topics);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Subscribe(string)" />
+        ///     Sets the subscription set to a single
+        ///     topic.
+        ///
+        ///     Any previous subscription will be
+        ///     unassigned and unsubscribed first.
         /// </summary>
-        /// <param name="topic"></param>
+        /// <param name="topic">
+        ///     The topic to subscribe to.
+        ///     A regex can be specified to subscribe to 
+        ///     the set of all matching topics (which is
+        ///     updated as topics are added / removed from
+        ///     the cluster). A regex must be front
+        ///     anchored to be recognized as a regex.
+        ///     e.g. ^myregex
+        /// </param>
         void Subscribe(string topic);
         
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Unsubscribe" />
+        ///     Unsubscribe from the current subscription
+        ///     set.
         /// </summary>
         void Unsubscribe();
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(TopicPartition)" />
+        ///     Sets the current set of assigned partitions
+        ///     (the set of partitions the consumer will consume
+        ///     from) to a single <paramref name="partition" />. 
+        ///
+        ///     Note: The newly specified set is the complete
+        ///     set of partitions to consume from. If the
+        ///     consumer is already assigned to a set of
+        ///     partitions, the previous set will be replaced.
         /// </summary>
+        /// <param name="partition">
+        ///     The partition to consume from.
+        ///     Consumption will resume from the last committed
+        ///     offset, or according to the 'auto.offset.reset'
+        ///     configuration parameter if no offsets have been
+        ///     committed yet.
+        /// </param>
         void Assign(TopicPartition partition);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(TopicPartitionOffset)" />
+        ///     Sets the current set of assigned partitions
+        ///     (the set of partitions the consumer will consume
+        ///     from) to a single <paramref name="partition" />. 
+        ///
+        ///     Note: The newly specified set is the complete
+        ///     set of partitions to consume from. If the
+        ///     consumer is already assigned to a set of
+        ///     partitions, the previous set will be replaced.
         /// </summary>
+        /// <param name="partition">
+        ///     The partition to consume from.
+        ///     If an offset value of Offset.Unset (-1001) is
+        ///     specified, consumption will resume from the last
+        ///     committed offset, or according to the
+        ///     'auto.offset.reset' configuration parameter if
+        ///     no offsets have been committed yet.
+        /// </param>
         void Assign(TopicPartitionOffset partition);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(IEnumerable{TopicPartitionOffset})" />
+        ///     Sets the current set of assigned partitions
+        ///     (the set of partitions the consumer will consume
+        ///     from) to <paramref name="partitions" />. 
+        ///
+        ///     Note: The newly specified set is the complete
+        ///     set of partitions to consume from. If the
+        ///     consumer is already assigned to a set of
+        ///     partitions, the previous set will be replaced.
         /// </summary>
+        /// <param name="partitions">
+        ///     The set of partitions to consume from.
+        ///     If an offset value of Offset.Unset (-1001) is
+        ///     specified for a partition, consumption will
+        ///     resume from the last committed offset on that
+        ///     partition, or according to the
+        ///     'auto.offset.reset' configuration parameter if
+        ///     no offsets have been committed yet.
+        /// </param>
         void Assign(IEnumerable<TopicPartitionOffset> partitions);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Assign(TopicPartition)" />
+        ///     Sets the current set of assigned partitions
+        ///     (the set of partitions the consumer will consume
+        ///     from) to <paramref name="partitions" />. 
+        ///
+        ///     Note: The newly specified set is the complete
+        ///     set of partitions to consume from. If the
+        ///     consumer is already assigned to a set of
+        ///     partitions, the previous set will be replaced.
         /// </summary>
+        /// <param name="partitions">
+        ///     The set of partitions to consume from.
+        ///     Consumption will resume from the last committed
+        ///     offset on each partition, or according to the
+        ///     'auto.offset.reset' configuration parameter if
+        ///     no offsets have been committed yet.
+        /// </param>
         void Assign(IEnumerable<TopicPartition> partitions);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Unassign" />
+        ///     Remove the current set of assigned partitions
+        ///     and stop consumption.
         /// </summary>
         void Unassign();
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey, TValue})" />
+        ///     Store offsets for a single partition based on
+        ///     the topic/partition/offset of a consume result.
+        /// 
+        ///     The offset will be committed according to
+        ///     `auto.commit.interval.ms` (and
+        ///     `enable.auto.commit`) or manual offset-less
+        ///     commit().
         /// </summary>
+        /// <remarks>
+        ///     `enable.auto.offset.store` must be set to
+        ///     "false" when using this API.
+        /// </remarks>
+        /// <param name="result">
+        ///     A consume result used to determine
+        ///     the offset to store and topic/partition.
+        /// </param>
+        /// <returns>
+        ///     Current stored offset or a partition
+        ///     specific error.
+        /// </returns>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if result is in error.
+        /// </exception>
         void StoreOffset(ConsumeResult<TKey, TValue> result);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.StoreOffset(TopicPartitionOffset)" />
+        ///     Store offsets for a single partition.
+        /// 
+        ///     The offset will be committed (written) to the
+        ///     offset store according to `auto.commit.interval.ms`
+        ///     or manual offset-less commit(). Calling
+        ///     this method in itself does not commit offsets,
+        ///     only store them for future commit.
         /// </summary>
+        /// <remarks>
+        ///     `enable.auto.offset.store` must be set to
+        ///     "false" when using this API.
+        /// </remarks>
+        /// <param name="offset">
+        ///     The offset to be committed.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
         void StoreOffset(TopicPartitionOffset offset);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Commit()" />
+        ///     Commit all offsets for the current assignment.
         /// </summary>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if any of the constituent results is in
+        ///     error. The entire result (which may contain
+        ///     constituent results that are not in error) is
+        ///     available via the <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
+        ///     property of the exception.
+        /// </exception>
         List<TopicPartitionOffset> Commit();
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Commit(IEnumerable{TopicPartitionOffset})" />
+        ///     Commit an explicit list of offsets.
         /// </summary>
+        /// <param name="offsets">
+        ///     The topic/partition offsets to commit.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if any of the constituent results is in
+        ///     error. The entire result (which may contain
+        ///     constituent results that are not in error) is
+        ///     available via the <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
+        ///     property of the exception.
+        /// </exception>
         void Commit(IEnumerable<TopicPartitionOffset> offsets);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Commit(ConsumeResult{TKey, TValue})" />
+        ///     Commits an offset based on the
+        ///     topic/partition/offset of a ConsumeResult.
         /// </summary>
+        /// <param name="result">
+        ///     The ConsumeResult instance used
+        ///     to determine the committed offset.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if the result is in error.
+        /// </exception>
+        /// <remarks>
+        ///     A consumer at position N has consumed
+        ///     messages with offsets up to N-1 and will
+        ///     next receive the message with offset N.
+        ///     Hence, this method commits an offset of
+        ///     <paramref name="result" />.Offset + 1.
+        /// </remarks>
         void Commit(ConsumeResult<TKey, TValue> result);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Seek(TopicPartitionOffset)" />
+        ///     Seek to <parmref name="offset"/> on the
+        ///     specified topic partition which is either
+        ///     an absolute or logical offset. This must
+        ///     only be done for partitions that are 
+        ///     currently being consumed (i.e., have been
+        ///     Assign()ed). To set the start offset for 
+        ///     not-yet-consumed partitions you should use the 
+        ///     Assign method instead.
         /// </summary>
+        /// <param name="tpo">
+        ///     The topic partition to seek
+        ///     on and the offset to seek to.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
         void Seek(TopicPartitionOffset tpo);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Pause(IEnumerable{TopicPartition})" />
+        ///     Pause consumption for the provided list
+        ///     of partitions.
         /// </summary>
+        /// <param name="partitions">
+        ///     The partitions to pause consumption of.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionException">
+        ///     Per partition success or error.
+        /// </exception>
         void Pause(IEnumerable<TopicPartition> partitions);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Resume(IEnumerable{TopicPartition})" />
+        ///     Resume consumption for the provided list of partitions.
         /// </summary>
+        /// <param name="partitions">
+        ///     The partitions to resume consumption of.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionException">
+        ///     Per partition success or error.
+        /// </exception>
         void Resume(IEnumerable<TopicPartition> partitions);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Committed(IEnumerable{TopicPartition}, TimeSpan)" />
+        ///     Retrieve current committed offsets for the
+        ///     specified topic partitions.
+        ///
+        ///     The offset field of each requested partition
+        ///     will be set to the offset of the last consumed
+        ///     message, or Offset.Unset in case there was no
+        ///     previous message, or, alternately a partition
+        ///     specific error may also be returned.
         /// </summary>
+        /// <param name="partitions">
+        ///     the partitions to get the committed
+        ///     offsets for.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time the call
+        ///     may block.
+        /// </param>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if any of the constituent results is in
+        ///     error. The entire result (which may contain
+        ///     constituent results that are not in error) is
+        ///     available via the
+        ///     <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
+        ///     property of the exception.
+        /// </exception>
         List<TopicPartitionOffset> Committed(IEnumerable<TopicPartition> partitions, TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Position(TopicPartition)" />
+        ///     Gets the current position (offset) for the
+        ///     specified topic / partition.
+        ///
+        ///     The offset field of each requested partition
+        ///     will be set to the offset of the last consumed
+        ///     message + 1, or Offset.Unset in case there was
+        ///     no previous message consumed by this consumer.
         /// </summary>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
         Offset Position(TopicPartition partition);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.OffsetsForTimes(IEnumerable{TopicPartitionTimestamp}, TimeSpan)" />
+        ///     Look up the offsets for the given partitions
+        ///     by timestamp. The returned offset for each
+        ///     partition is the earliest offset whose
+        ///     timestamp is greater than or equal to the
+        ///     given timestamp in the corresponding partition.
         /// </summary>
+        /// <remarks>
+        ///     The consumer does not need to be assigned to
+        ///     the requested partitions.
+        /// </remarks>
+        /// <param name="timestampsToSearch">
+        ///     The mapping from partition
+        ///     to the timestampto look up.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time the
+        ///     call may block.
+        /// </param>
+        /// <returns>
+        ///     A mapping from partition to the
+        ///     timestamp and offset of the first message with
+        ///     timestamp greater than or equal to the target
+        ///     timestamp.
+        /// </returns>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown
+        ///     if the operation fails.
+        /// </exception>
+        /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
+        ///     Thrown if any of the constituent results is
+        ///     in error. The entire result (which may contain
+        ///     constituent results that are not in error) is
+        ///     available via the
+        ///     <see cref="Confluent.Kafka.TopicPartitionOffsetException.Results" />
+        ///     property of the exception.
+        /// </exception>
         List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestampsToSearch, TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.GetWatermarkOffsets(TopicPartition)" />
+        ///     Get the last cached low (oldest available /
+        ///     beginning) and high (newest/end) offsets for
+        ///     a topic/partition. Does not block.
         /// </summary>
+        /// <remarks>
+        ///     The low offset is updated periodically (if
+        ///     statistics.interval.ms is set) while the
+        ///     high offset is updated on each fetched
+        ///     message set from the broker. If there is no
+        ///     cached offset (either low or high, or both)
+        ///     then Offset.Unset will be returned for the
+        ///     respective offset.
+        /// </remarks>
+        /// <param name="topicPartition">
+        ///     The topic partition of interest.
+        /// </param>
+        /// <returns>
+        ///     The requested WatermarkOffsets
+        ///     (see that class for additional documentation).
+        /// </returns>
         WatermarkOffsets GetWatermarkOffsets(TopicPartition topicPartition);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.QueryWatermarkOffsets(TopicPartition, TimeSpan)" />
+        ///     Query the Kafka cluster for low (oldest
+        ///     available/beginning) and high (newest/end)
+        ///     offsets for the specified topic/partition.
+        ///     This is a blocking call - always contacts
+        ///     the cluster for the required information.
         /// </summary>
+        /// <param name="topicPartition">
+        ///     The topic/partition of interest.
+        /// </param>
+        /// <param name="timeout">
+        ///     The maximum period of time
+        ///     the call may block.
+        /// </param>
+        /// <returns>
+        ///     The requested WatermarkOffsets (see
+        ///     that class for additional documentation).
+        /// </returns>
         WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" />.
+        ///     Commits offsets, alerts the group coodinator
+        ///     that the consumer is exiting the group then
+        ///     releases all resources used by this consumer.
+        ///     You should call <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" />
+        ///     instead of <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Dispose()" />
+        ///     (or just before) to ensure a timely consumer
+        ///     group rebalance. If you do not call
+        ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" />
+        ///     or <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Unsubscribe" />,
+        ///     the group will rebalance after a timeout
+        ///     specified by the group's `session.timeout.ms`.
+        ///     Note: the partition asignment and partitions
+        ///     revoked handlers may be called as a side-effect
+        ///     of calling this method.
         /// </summary>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the operation fails.
+        /// </exception>
         void Close();
     }
 }

--- a/src/Confluent.Kafka/IProducer.cs
+++ b/src/Confluent.Kafka/IProducer.cs
@@ -28,30 +28,110 @@ using System.Collections.Concurrent;
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     Defines a high-level Apache Kafka producer client that provides key
-    ///     and value serialization.
+    ///     Defines a high-level Apache Kafka producer client
+    ///     that provides key and value serialization.
     /// </summary>
     public interface IProducer<TKey, TValue> : IClient
     {
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.ProduceAsync(string, Message{TKey, TValue})" />
+        ///     Asynchronously send a single message to a
+        ///     Kafka topic. The partition the message is
+        ///     sent to is determined by the partitioner
+        ///     defined using the 'partitioner' configuration
+        ///     property.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic to produce the message to.
+        /// </param>
+        /// <param name="message">
+        ///     The message to produce.
+        /// </param>
+        /// <returns>
+        ///     A Task which will complete with a delivery
+        ///     report corresponding to the produce request,
+        ///     or an exception if an error occured.
+        /// </returns>
+        /// <exception cref="ProduceException{TKey,TValue}">
+        ///     Thrown in response to any produce request
+        ///     that was unsuccessful for any reason
+        ///     (excluding user application logic errors).
+        ///     The Error property of the exception provides
+        ///     more detailed information.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown in response to invalid argument values.
+        /// </exception>
         Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             string topic,
             Message<TKey, TValue> message);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.ProduceAsync(TopicPartition, Message{TKey, TValue})" />
+        ///     Asynchronously send a single message to a
+        ///     Kafka topic/partition.
         /// </summary>
+        /// <param name="topicPartition">
+        ///     The topic partition to produce the
+        ///     message to.
+        /// </param>
+        /// <param name="message">
+        ///     The message to produce.
+        /// </param>
+        /// <returns>
+        ///     A Task which will complete with a delivery
+        ///     report corresponding to the produce request,
+        ///     or an exception if an error occured.
+        /// </returns>
+        /// <exception cref="ProduceException{TKey,TValue}">
+        ///     Thrown in response to any produce request
+        ///     that was unsuccessful for any reason
+        ///     (excluding user application logic errors).
+        ///     The Error property of the exception provides
+        ///     more detailed information.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown in response to invalid argument values.
+        /// </exception>
         Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             TopicPartition topicPartition,
             Message<TKey, TValue> message);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.BeginProduce(string, Message{TKey, TValue}, Action{DeliveryReport{TKey, TValue}})" />
+        ///     Asynchronously send a single message to a
+        ///     Kafka topic. The partition the message is sent
+        ///     to is determined by the partitioner defined
+        ///     using the 'partitioner' configuration property.
         /// </summary>
+        /// <param name="topic">
+        ///     The topic to produce the message to.
+        /// </param>
+        /// <param name="message">
+        ///     The message to produce.
+        /// </param>
+        /// <param name="deliveryHandler">
+        ///     A delegate that will be called
+        ///     with a delivery report corresponding to the
+        ///     produce request (if enabled).
+        /// </param>
+        /// <exception cref="ProduceException{TKey,TValue}">
+        ///     Thrown in response to any error that is known
+        ///     immediately (excluding user application logic
+        ///     errors), for example ErrorCode.Local_QueueFull.
+        ///     Asynchronous notification of unsuccessful produce
+        ///     requests is made available via the <paramref name="deliveryHandler" />
+        ///     parameter (if specified). The Error property of
+        ///     the exception / delivery report provides more
+        ///     detailed information.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown in response to invalid argument values.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown in response to error conditions that
+        ///     reflect an error in the application logic of
+        ///     the calling application.
+        /// </exception>
         void BeginProduce(
             string topic,
             Message<TKey, TValue> message,
@@ -59,8 +139,39 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.BeginProduce(TopicPartition, Message{TKey, TValue}, Action{DeliveryReport{TKey, TValue}})" />
+        ///     Asynchronously send a single message to a
+        ///     Kafka topic partition.
         /// </summary>
+        /// <param name="topicPartition">
+        ///     The topic partition to produce
+        ///     the message to.
+        /// </param>
+        /// <param name="message">
+        ///     The message to produce.
+        /// </param>
+        /// <param name="deliveryHandler">
+        ///     A delegate that will be called
+        ///     with a delivery report corresponding to the
+        ///     produce request (if enabled).
+        /// </param>
+        /// <exception cref="ProduceException{TKey,TValue}">
+        ///     Thrown in response to any error that is known
+        ///     immediately (excluding user application logic errors),
+        ///     for example ErrorCode.Local_QueueFull. Asynchronous
+        ///     notification of unsuccessful produce requests is made
+        ///     available via the <paramref name="deliveryHandler" />
+        ///     parameter (if specified). The Error property of the
+        ///     exception / delivery report provides more detailed
+        ///     information.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown in response to invalid argument values.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown in response to error conditions that reflect
+        ///     an error in the application logic of the calling
+        ///     application.
+        /// </exception>
         void BeginProduce(
             TopicPartition topicPartition,
             Message<TKey, TValue> message,
@@ -68,20 +179,97 @@ namespace Confluent.Kafka
 
         
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.Poll(TimeSpan)" />
+        ///     Poll for callback events. Typically, you should not 
+        ///     call this method. Only call on producer instances 
+        ///     where background polling has been disabled.
         /// </summary>
+        /// <param name="timeout">
+        ///     The maximum period of time to block if
+        ///     no callback events are waiting. You should
+        ///     typically use a relatively short timout period
+        ///     because this operation cannot be cancelled.
+        /// </param>
+        /// <returns>
+        ///     Returns the number of events served.
+        /// </returns>
         int Poll(TimeSpan timeout);
 
 
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.Flush(TimeSpan)" />
+        ///     Wait until all outstanding produce requests and
+        ///     delievery report callbacks are completed.
+        ///    
+        ///     [API-SUBJECT-TO-CHANGE] - the semantics and/or
+        ///     type of the return value is subject to change.
         /// </summary>
+        /// <param name="timeout">
+        ///     The maximum length of time to block.
+        ///     You should typically use a relatively short
+        ///     timout period and loop until the return value
+        ///     becomes zero because this operation cannot be
+        ///     cancelled. 
+        /// </param>
+        /// <returns>
+        ///     The current librdkafka out queue length. This
+        ///     should be interpreted as a rough indication of
+        ///     the number of messages waiting to be sent to or
+        ///     acknowledged by the broker. If zero, there are
+        ///     no outstanding messages or callbacks.
+        ///     Specifically, the value is equal to the sum of
+        ///     the number of produced messages for which a
+        ///     delivery report has not yet been handled and a
+        ///     number which is less than or equal to the
+        ///     number of pending delivery report callback
+        ///     events (as determined by the number of
+        ///     outstanding protocol requests).
+        /// </returns>
+        /// <remarks>
+        ///     This method should typically be called prior to
+        ///     destroying a producer instance to make sure all
+        ///     queued and in-flight produce requests are
+        ///     completed before terminating. The wait time is
+        ///     bounded by the timeout parameter.
+        ///    
+        ///     A related configuration parameter is
+        ///     message.timeout.ms which determines the
+        ///     maximum length of time librdkafka attempts
+        ///     to deliver a message before giving up and
+        ///     so also affects the maximum time a call to
+        ///     Flush may block.
+        /// 
+        ///     Where this Producer instance shares a Handle
+        ///     with one or more other producer instances, the
+        ///     Flush method will wait on messages produced by
+        ///     the other producer instances as well.
+        /// </remarks>
         int Flush(TimeSpan timeout);
 
-
+        
         /// <summary>
-        ///     Refer to <see cref="Confluent.Kafka.Producer{TKey,TValue}.Flush(CancellationToken)" />
+        ///     Wait until all outstanding produce requests and
+        ///     delievery report callbacks are completed.
         /// </summary>
+        /// <remarks>
+        ///     This method should typically be called prior to
+        ///     destroying a producer instance to make sure all
+        ///     queued and in-flight produce requests are 
+        ///     completed before terminating. 
+        ///    
+        ///     A related configuration parameter is
+        ///     message.timeout.ms which determines the
+        ///     maximum length of time librdkafka attempts
+        ///     to deliver a message before giving up and
+        ///     so also affects the maximum time a call to
+        ///     Flush may block.
+        /// 
+        ///     Where this Producer instance shares a Handle
+        ///     with one or more other producer instances, the
+        ///     Flush method will wait on messages produced by
+        ///     the other producer instances as well.
+        /// </remarks>
+        /// <exception cref="System.OperationCanceledException">
+        ///     Thrown if the operation is cancelled.
+        /// </exception>
         void Flush(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -265,18 +265,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Poll for callback events. Typically, you should not 
-        ///     call this method. Only call on producer instances 
-        ///     where background polling has been disabled.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.Poll(TimeSpan)" />
         /// </summary>
-        /// <param name="timeout">
-        ///     The maximum period of time to block if no callback events
-        ///     are waiting. You should typically use a relatively short 
-        ///     timout period because this operation cannot be cancelled.
-        /// </param>
-        /// <returns>
-        ///     Returns the number of events served.
-        /// </returns>
         public int Poll(TimeSpan timeout)
         {
             if (!manualPoll)
@@ -289,67 +279,15 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Wait until all outstanding produce requests and delievery report
-        ///     callbacks are completed.
-        ///    
-        ///     [API-SUBJECT-TO-CHANGE] - the semantics and/or type of the return value
-        ///     is subject to change.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.Flush(TimeSpan)" />
         /// </summary>
-        /// <param name="timeout">
-        ///     The maximum length of time to block. You should typically use a
-        ///     relatively short timout period and loop until the return value
-        ///     becomes zero because this operation cannot be cancelled. 
-        /// </param>
-        /// <returns>
-        ///     The current librdkafka out queue length. This should be interpreted
-        ///     as a rough indication of the number of messages waiting to be sent
-        ///     to or acknowledged by the broker. If zero, there are no outstanding
-        ///     messages or callbacks. Specifically, the value is equal to the sum
-        ///     of the number of produced messages for which a delivery report has
-        ///     not yet been handled and a number which is less than or equal to the
-        ///     number of pending delivery report callback events (as determined by
-        ///     the number of outstanding protocol requests).
-        /// </returns>
-        /// <remarks>
-        ///     This method should typically be called prior to destroying a producer
-        ///     instance to make sure all queued and in-flight produce requests are
-        ///     completed before terminating. The wait time is bounded by the
-        ///     timeout parameter.
-        ///    
-        ///     A related configuration parameter is message.timeout.ms which determines
-        ///     the maximum length of time librdkafka attempts to deliver a message 
-        ///     before giving up and so also affects the maximum time a call to Flush 
-        ///     may block.
-        /// 
-        ///     Where this Producer instance shares a Handle with one or more other
-        ///     producer instances, the Flush method will wait on messages produced by
-        ///     the other producer instances as well.
-        /// </remarks>
         public int Flush(TimeSpan timeout)
             => KafkaHandle.Flush(timeout.TotalMillisecondsAsInt());
 
 
         /// <summary>
-        ///     Wait until all outstanding produce requests and delievery report
-        ///     callbacks are completed.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.Flush(CancellationToken)" />
         /// </summary>
-        /// <remarks>
-        ///     This method should typically be called prior to destroying a producer
-        ///     instance to make sure all queued and in-flight produce requests are
-        ///     completed before terminating. 
-        ///    
-        ///     A related configuration parameter is message.timeout.ms which determines
-        ///     the maximum length of time librdkafka attempts to deliver a message 
-        ///     before giving up and so also affects the maximum time a call to Flush 
-        ///     may block.
-        /// 
-        ///     Where this Producer instance shares a Handle with one or more other
-        ///     producer instances, the Flush method will wait on messages produced by
-        ///     the other producer instances as well.
-        /// </remarks>
-        /// <exception cref="System.OperationCanceledException">
-        ///     Thrown if the operation is cancelled.
-        /// </exception>
         public void Flush(CancellationToken cancellationToken)
         {
             while (true)
@@ -646,26 +584,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Asynchronously send a single message to a Kafka topic/partition.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.ProduceAsync(TopicPartition, Message{TKey, TValue})" />
         /// </summary>
-        /// <param name="topicPartition">
-        ///     The topic/partition to produce the message to.
-        /// </param>
-        /// <param name="message">
-        ///     The message to produce.
-        /// </param>
-        /// <returns>
-        ///     A Task which will complete with a delivery report corresponding to
-        ///     the produce request, or an exception if an error occured.
-        /// </returns>
-        /// <exception cref="ProduceException{TKey,TValue}">
-        ///     Thrown in response to any produce request that was unsuccessful for
-        ///     any reason (excluding user application logic errors). The Error
-        ///     property of the exception provides more detailed information.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     Thrown in response to invalid argument values.
-        /// </exception>
         public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             TopicPartition topicPartition,
             Message<TKey, TValue> message)
@@ -758,29 +678,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Asynchronously send a single message to a Kafka topic.
-        ///     The partition the message is sent to is determined by
-        ///     the partitioner defined using the 'partitioner' 
-        ///     configuration property.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.ProduceAsync(string, Message{TKey, TValue})" />
         /// </summary>
-        /// <param name="topic">
-        ///     The topic to produce the message to.
-        /// </param>
-        /// <param name="message">
-        ///     The message to produce.
-        /// </param>
-        /// <returns>
-        ///     A Task which will complete with a delivery report corresponding to
-        ///     the produce request, or an exception if an error occured.
-        /// </returns>
-        /// <exception cref="ProduceException{TKey,TValue}">
-        ///     Thrown in response to any produce request that was unsuccessful for
-        ///     any reason (excluding user application logic errors). The Error
-        ///     property of the exception provides more detailed information.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     Thrown in response to invalid argument values.
-        /// </exception>
         public Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             string topic,
             Message<TKey, TValue> message
@@ -789,36 +688,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Asynchronously send a single message to a Kafka topic.
-        ///     The partition the message is sent to is determined by
-        ///     the partitioner defined using the 'partitioner' 
-        ///     configuration property.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.BeginProduce(string, Message{TKey, TValue}, Action{DeliveryReport{TKey, TValue}})" />
         /// </summary>
-        /// <param name="topic">
-        ///     The topic to produce the message to.
-        /// </param>
-        /// <param name="message">
-        ///     The message to produce.
-        /// </param>
-        /// <param name="deliveryHandler">
-        ///     A delegate that will be called with a delivery report corresponding
-        ///     to the produce request (if enabled).
-        /// </param>
-        /// <exception cref="ProduceException{TKey,TValue}">
-        ///     Thrown in response to any error that is known immediately (excluding
-        ///     user application logic errors), for example ErrorCode.Local_QueueFull.
-        ///     Asynchronous notification of unsuccessful produce requests is made
-        ///     available via the <paramref name="deliveryHandler" /> parameter (if
-        ///     specified). The Error property of the exception / delivery report
-        ///     provides more detailed information.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     Thrown in response to invalid argument values.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown in response to error conditions that reflect an error in
-        ///     the application logic of the calling application.
-        /// </exception>
         public void BeginProduce(
             string topic,
             Message<TKey, TValue> message,
@@ -828,33 +699,8 @@ namespace Confluent.Kafka
 
 
         /// <summary>
-        ///     Asynchronously send a single message to a Kafka topic/partition.
+        ///     Refer to <see cref="Confluent.Kafka.IProducer{TKey,TValue}.BeginProduce(TopicPartition, Message{TKey, TValue}, Action{DeliveryReport{TKey, TValue}})" />
         /// </summary>
-        /// <param name="topicPartition">
-        ///     The topic/partition to produce the message to.
-        /// </param>
-        /// <param name="message">
-        ///     The message to produce.
-        /// </param>
-        /// <param name="deliveryHandler">
-        ///     A delegate that will be called with a delivery report corresponding
-        ///     to the produce request (if enabled).
-        /// </param>
-        /// <exception cref="ProduceException{TKey,TValue}">
-        ///     Thrown in response to any error that is known immediately (excluding
-        ///     user application logic errors), for example ErrorCode.Local_QueueFull.
-        ///     Asynchronous notification of unsuccessful produce requests is made
-        ///     available via the <paramref name="deliveryHandler" /> parameter (if
-        ///     specified). The Error property of the exception / delivery report
-        ///     provides more detailed information.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     Thrown in response to invalid argument values.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown in response to error conditions that reflect an error in
-        ///     the application logic of the calling application.
-        /// </exception>
         public void BeginProduce(
             TopicPartition topicPartition,
             Message<TKey, TValue> message,


### PR DESCRIPTION
1. move API doc comments from Producer / Consumer / AdminClient -> IProducer / IConsumer / IAdminClient . The builder classes return interfaces now, so this change makes intellisense useful again.
2. change line lengths of the comments so they display well in Visual Studio Code intellisense (which has a relatively narrow fixed width hover window, and honors new lines).