### PR TITLE
removed Confluent.Kafka.Serdes namespace

### DIFF
--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -16,7 +16,6 @@
 
 using Avro.Generic;
 using Confluent.Kafka;
-using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using System;

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -16,7 +16,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -53,7 +52,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
             const int commitPeriod = 5;
 
             // Note: If a key or value deserializer is not set (as is the case below), the 
-            // deserializer corresponding to the appropriate type from Confluent.Kafka.Serdes
+            // deserializer corresponding to the appropriate type from Confluent.Kafka.Deserializers
             // will be used automatically (where available). The default deserializer for string
             // is UTF8. The default deserializer for Ignore returns null for all input data
             // (including non-null data).

--- a/examples/Protobuf/Program.cs
+++ b/examples/Protobuf/Program.cs
@@ -17,7 +17,6 @@
 // Refer to LICENSE for more information.
 
 using Confluent.Kafka;
-using Confluent.Kafka.Serdes;
 using Google.Protobuf;
 using System;
 using System.Threading;

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -24,7 +24,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka.Impl;
 using Confluent.Kafka.Internal;
-using Confluent.Kafka.Serdes;
 
 
 namespace Confluent.Kafka

--- a/src/Confluent.Kafka/Deserializers.cs
+++ b/src/Confluent.Kafka/Deserializers.cs
@@ -18,7 +18,7 @@ using System;
 using System.Text;
 
 
-namespace Confluent.Kafka.Serdes
+namespace Confluent.Kafka
 {
     /// <summary>
     ///     Deserializers for use with <see cref="Consumer{TKey,TValue}" />.

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -20,7 +20,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Confluent.Kafka.Serdes;
 using Confluent.Kafka.Impl;
 using Confluent.Kafka.Internal;
 

--- a/src/Confluent.Kafka/Serializers.cs
+++ b/src/Confluent.Kafka/Serializers.cs
@@ -18,7 +18,7 @@ using System;
 using System.Text;
 
 
-namespace Confluent.Kafka.Serdes
+namespace Confluent.Kafka
 {
     /// <summary>
     ///     Serializers for use with <see cref="Producer{TKey,TValue}" />.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using Xunit;
-using Confluent.Kafka.Serdes;
 
 
 namespace Confluent.Kafka.IntegrationTests

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -16,11 +16,11 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+
 
 namespace Confluent.Kafka.IntegrationTests
 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using Xunit;
-using Confluent.Kafka.Serdes;
 
 
 namespace Confluent.Kafka.IntegrationTests

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_BeginProduce_Error.cs
@@ -16,7 +16,6 @@
 
 #pragma warning disable xUnit1026
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using Xunit;
 
 

--- a/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using System;
 using Xunit;
 

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -14,7 +14,6 @@
 //
 // Refer to LICENSE for more information.
 
-using Confluent.Kafka.Serdes;
 using Xunit;
 using System.Text;
 using System.Collections.Generic;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -15,7 +15,6 @@
 // Refer to LICENSE for more information.
 
 using Confluent.Kafka;
-using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.Kafka.Examples.AvroSpecific;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Confluent.Kafka;
-using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.Kafka.Examples.AvroSpecific;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsumeGeneric.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsumeGeneric.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Confluent.Kafka;
 using Confluent.Kafka.Examples.AvroSpecific;
-using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using Avro;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceGenericMultipleTopics.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceGenericMultipleTopics.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Confluent.Kafka;
 using Confluent.Kafka.Examples.AvroSpecific;
-using Confluent.Kafka.Serdes;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using Avro;


### PR DESCRIPTION
this is seeming a bit superfluous now everything's housed in the `Serializers` and `Deserializer` static classes.