### PR TITLE
added LogLevelType and conversions

### DIFF
--- a/src/Confluent.Kafka/LogLevelType.cs
+++ b/src/Confluent.Kafka/LogLevelType.cs
@@ -1,0 +1,41 @@
+// Copyright 2019 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Enumerates different log level enumerations.
+    /// </summary>
+    public enum LogLevelType
+    {
+        /// <summary>
+        ///     Confluent.Kafka.SysLogLevel (severity
+        ///     levels correspond to syslog)
+        /// </summary>
+        SysLogLevel = 1,
+
+        /// <summary>
+        ///     Microsoft.Extensions.Logging.LogLevel
+        /// </summary>
+        MicrosoftExtensionsLogging = 2,
+
+        /// <summary>
+        ///     System.Diagnostics.TraceLevel
+        /// </summary>
+        SystemDiagnostics = 3
+    }
+}

--- a/src/Confluent.Kafka/LogMessage.cs
+++ b/src/Confluent.Kafka/LogMessage.cs
@@ -16,6 +16,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 
 namespace Confluent.Kafka
 {
@@ -67,5 +69,57 @@ namespace Confluent.Kafka
         ///     Gets the log message.
         /// </summary>
         public string Message { get; }
+
+        
+        // SysLog levels:
+        // [0] emergency, [1] alert, [2] critical, [3] error, [4] warning, [5] notice, [6] info, [7] debug.
+
+        private static int[] SystemDiagnosticsLevelLookup = new int[]
+        {
+            // System.Diagnostics.TraceLevel: [0] Off, [1] Error, [2] Warning, [3] Info, [4] Verbose
+
+            1, // emergency -> error
+            1, // alert -> error
+            1, // critical -> error
+            1, // error -> error
+            2, // warning -> warning
+            3, // notice -> info
+            3, // info -> info
+            4  // debug -> verbose
+        };
+
+        private static int[] MicrosoftExtensionsLoggingLevelLookup = new int[]
+        {
+            // Microsoft.Extensions.Logging.LogLevel: [0] Trace, [1] Debug, [2] Information, [3] Warning, [4] Error, [5] Critical, [6] None
+
+            5, // emergency -> critical
+            5, // alert -> critical
+            5, // critical -> critical
+            4, // error -> error
+            3, // warning -> warning
+            2, // notice -> information
+            2, // info -> information
+            1, // debug -> debug
+        };
+
+        /// <summary>
+        ///     Convert the syslog message severity
+        ///     level to correspond to the values of
+        //      a different log level enumeration type.
+        /// </summary>
+        public int LevelAs(LogLevelType type)
+        {
+            switch (type)
+            {
+                case LogLevelType.SysLogLevel:
+                    return (int)Level;
+                case LogLevelType.MicrosoftExtensionsLogging:
+                    return MicrosoftExtensionsLoggingLevelLookup[(int)Level];
+                case LogLevelType.SystemDiagnostics:
+                    return SystemDiagnosticsLevelLookup[(int)Level];
+                default:
+                    throw new ArgumentException($"Unexpected log level type: {type}");
+            }
+        }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/LogMessage.cs
+++ b/test/Confluent.Kafka.UnitTests/LogMessage.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Diagnostics;
 
 
 namespace Confluent.Kafka.UnitTests
@@ -30,5 +31,52 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal("myfacility", lm.Facility);
             Assert.Equal("mymessage", lm.Message);
         }
+
+        [Fact]
+        public void SystemDiagnosticsConvert()
+        {
+            var lm = new LogMessage("name", SyslogLevel.Emergency, "facility", "message");
+            Assert.Equal((int)TraceLevel.Error, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Alert, "facility", "message");
+            Assert.Equal((int)TraceLevel.Error, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Critical, "facility", "message");
+            Assert.Equal((int)TraceLevel.Error, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Error, "facility", "message");
+            Assert.Equal((int)TraceLevel.Error, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Warning, "facility", "message");
+            Assert.Equal((int)TraceLevel.Warning, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Notice, "facility", "message");
+            Assert.Equal((int)TraceLevel.Info, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Info, "facility", "message");
+            Assert.Equal((int)TraceLevel.Info, lm.LevelAs(LogLevelType.SystemDiagnostics));
+            lm = new LogMessage("name", SyslogLevel.Debug, "facility", "message");
+            Assert.Equal((int)TraceLevel.Verbose, lm.LevelAs(LogLevelType.SystemDiagnostics));
+        }
+
+        [Fact]
+        public void MicrosoftExtensionsLogging()
+        {
+            // Microsoft.Extensions.Logging.LogLevel: [0] Trace, [1] Debug, [2] Information, [3] Warning, [4] Error, [5] Critical, [6] None
+            // Note: Package containing Microsoft.Extensions.Logging.LogLevel is not referenced
+            //       so as to retain compatibility with net452.
+
+            var lm = new LogMessage("name", SyslogLevel.Emergency, "facility", "message");
+            Assert.Equal(5, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Alert, "facility", "message");
+            Assert.Equal(5, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Critical, "facility", "message");
+            Assert.Equal(5, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Error, "facility", "message");
+            Assert.Equal(4, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Warning, "facility", "message");
+            Assert.Equal(3, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Notice, "facility", "message");
+            Assert.Equal(2, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Info, "facility", "message");
+            Assert.Equal(2, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+            lm = new LogMessage("name", SyslogLevel.Debug, "facility", "message");
+            Assert.Equal(1, lm.LevelAs(LogLevelType.MicrosoftExtensionsLogging));
+        }
+
     }
 }


### PR DESCRIPTION
will need this for the blog post. your choice whether we slip it in before 1.0 (not a breaking api change). if not there will be a 1.0.1 immediately after.