### PR TITLE
Extensible avro serializer/deserializer 

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes/AvroDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes/AvroDeserializer.cs
@@ -89,7 +89,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     A <see cref="System.Threading.Tasks.Task" /> that completes
         ///     with the deserialized value.
         /// </returns>
-        public async Task<T> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, SerializationContext context)
+        public virtual async Task<T> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, SerializationContext context)
         {
             try
             {

--- a/src/Confluent.SchemaRegistry.Serdes/AvroSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes/AvroSerializer.cs
@@ -122,7 +122,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     A <see cref="System.Threading.Tasks.Task" /> that completes with 
         ///     <paramref name="value" /> serialized as a byte array.
         /// </returns>
-        public async Task<byte[]> SerializeAsync(T value, SerializationContext context)
+        public virtual async Task<byte[]> SerializeAsync(T value, SerializationContext context)
         { 
             try
             {


### PR DESCRIPTION
Updated the SerializeAsync and DeserializeAsync for the Avro serializer/deserializer so that they are extensible. As a use case, now it is possible to add encryption/decryption to the messages sent to and from the topics.