### PR TITLE
rework ctors for Config classes

### DIFF
--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -420,11 +420,19 @@ namespace Confluent.Kafka
 
         static string createClassConstructors(string name)
         {
-            var codeText = "\n";
-            codeText += $@"        /// <summary>
+            var codeText = $@"
+        /// <summary>
+        /// Creates a new {name} class by taking a copy of the provided <paramref name=""configSource""/>.
+        /// The <paramref name=""configSource""/> can be any of: IEnumerable; Dictonary; any of the Config types.
+        /// </summary>
+        /// <param name=""configSource""></param>
+        /// <returns></returns>
+        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+
+        /// <summary>
         ///     Initialize a new empty <see cref=""{name}"" /> instance.
         /// </summary>
-        public {name}() {{ }}
+        public {name}() : base() {{ }}
 
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping
@@ -439,13 +447,6 @@ namespace Confluent.Kafka
         ///     This will change the values ""in-place"" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public {name}(IDictionary<string, string> config) : base(config) {{ }}
-
-        /// <summary>
-        ///     Initialize a new <see cref=""{name}"" /> instance copying
-        ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
-        /// </summary>
-        public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
 ";
             return codeText;
         }

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -427,22 +427,33 @@ namespace Confluent.Kafka
         public {name}() {{ }}
 
         /// <summary>
-        ///     Initialize a new <see cref=""{name}"" /> instance based on
+        ///     Initialize a new <see cref=""{name}"" /> instance wrapping
         ///     an existing <see cref=""ClientConfig"" /> instance.
+        /// </summary>
+        /// <summary>
+        ///     <para>
+        ///     This will change the values ""in-place"" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public {name}(ClientConfig config) : base(config) {{ }}
 
         /// <summary>
-        ///     Initialize a new <see cref=""{name}"" /> instance based on
+        ///     Initialize a new <see cref=""{name}"" /> instance wrapping
         ///     an existing key/value pair collection.
-        /// </summary>
-        public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
-
-        /// <summary>
-        ///     Initialize a new <see cref=""{name}"" /> wrapping
-        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will change the values ""in-place"" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public {name}(IDictionary<string, string> config) : base(config) {{ }}
+
+        /// <summary>
+        ///     Initialize a new <see cref=""{name}"" /> instance copying
+        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     </para>
+        /// </summary>
+        public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
 ";
             return codeText;
         }

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -326,13 +326,6 @@ namespace Confluent.Kafka
         static string createConfigPropertyNames(IEnumerable<PropertySpecification> props)
         {
             var codeText = "\n";
-            codeText += $"    public partial class Config\n";
-            codeText += $"    {{\n";
-            codeText += $"        /// <summary>\n";
-            codeText += $"        ///     A reference to the configuration key names\n";
-            codeText += $"        /// </summary>\n";
-            codeText += $"        public static partial class PropertyNames\n";
-            codeText += $"        {{\n";
 
             var codeTextC = string.Empty;
             var codeTextP = string.Empty;
@@ -366,32 +359,38 @@ namespace Confluent.Kafka
             codeText += CreateClass("Producer", codeTextP) + "\n";
             codeText += CreateClass("Admin", codeTextA);
 
-            codeText += $"        }}\n";
-            codeText += $"    }}\n";
+            //codeText += $"        }}\n";
+            //codeText += $"    }}\n";
             return codeText;
 
             string CreateClass(string name, string code)
             {
                 return
-                    $"            /// <summary>\n" +
-                    $"            ///     A reference to the key names for {name} specific configuration properties.\n" +
-                    $"            /// </summary>\n" +
-                    $"            public static partial class {name}\n" +
-                    $"            {{\n" +
+                    $"    /// <summary>\n" +
+                    $"    ///     A reference to the key names for {name} specific configuration properties.\n" +
+                    $"    /// </summary>\n" +
+                    $"    public partial class {name}Config\n" +
+                    $"    {{\n" +
+                    $"        /// <summary>\n"+
+                    $"        ///     A reference to the configuration key names\n"+
+                    $"        /// </summary>\n"+
+                    $"        public static partial class PropertyNames\n"+
+                    $"        {{\n"+
                     code +
-                    $"            }}\n";
+                    $"        }}\n"+
+                    $"    }}\n";
             }
 
             string CreateProperty(PropertySpecification prop)
             {
                 return
-                    $"                /// <summary>\n" +
-                    $"                ///     {prop.Description}\n" +
-                    $"                ///\n" +
-                    $"                ///     default: {(prop.Default == "" ? "''" : prop.Default)}\n" +
-                    $"                ///     importance: {prop.Importance}\n" +
-                    $"                /// </summary>\n" +
-                    $"                public const string {ConfigNameToDotnetName(prop.Name)} = \"{prop.Name}\";\n\n";
+                    $"            /// <summary>\n" +
+                    $"            ///     {prop.Description}\n" +
+                    $"            ///\n" +
+                    $"            ///     default: {(prop.Default == "" ? "''" : prop.Default)}\n" +
+                    $"            ///     importance: {prop.Importance}\n" +
+                    $"            /// </summary>\n" +
+                    $"            public const string {ConfigNameToDotnetName(prop.Name)} = \"{prop.Name}\";\n\n";
             }
         }
 
@@ -486,7 +485,7 @@ namespace Confluent.Kafka
             codeText += $"    /// <summary>\n";
             codeText += $"    ///     {docs}\n";
             codeText += $"    /// </summary>\n";
-            codeText += $"    public class {name}{(derive ? " : ClientConfig" : " : Config")}\n";
+            codeText += $"    public partial class {name}{(derive ? " : ClientConfig" : " : Config")}\n";
             codeText += $"    {{";
             return codeText;
         }

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -443,7 +443,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
         /// </summary>
         public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
 ";

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -322,6 +322,33 @@ namespace Confluent.Kafka
             return result;
         }
 
+        static string createConfigKeys(IEnumerable<PropertySpecification> props)
+        {
+            var codeText = "\n";
+            codeText += $"    public partial class Config\n";
+            codeText += $"    {{\n";
+            codeText += $"        /// <summary>\n";
+            codeText += $"        ///     A reference to the configuration key names\n";
+            codeText += $"        /// </summary>\n";
+            codeText += $"        public static class KeyNames\n";
+            codeText += $"        {{\n";
+
+            foreach (var prop in props)
+            {
+                codeText += $"            /// <summary>\n";
+                codeText += $"            ///     {prop.Description}\n";
+                codeText += $"            ///\n";
+                codeText += $"            ///     default: {(prop.Default == "" ? "''" : prop.Default)}\n";
+                codeText += $"            ///     importance: {prop.Importance}\n";
+                codeText += $"            /// </summary>\n";
+                codeText += $"            public const string {ConfigNameToDotnetName(prop.Name)} = \"{prop.Name}\";\n\n";
+            }
+
+            codeText += $"        }}\n";
+            codeText += $"    }}\n";
+            return codeText;
+        }
+
         static string createProperties(IEnumerable<PropertySpecification> props)
         {
             var codeText = "";
@@ -651,6 +678,7 @@ namespace Confluent.Kafka
             codeText += createEnums(props.Where(p => p.Type == "enum" || MappingConfiguration.AdditionalEnums.Keys.Contains(p.Name)).ToList());
             codeText += MappingConfiguration.SaslMechanismEnumString;
             codeText += MappingConfiguration.AcksEnumString;
+            codeText += createConfigKeys(props);
             codeText += createClassHeader("ClientConfig", "Configuration common to all clients", false);
             codeText += createClassConstructors("ClientConfig");
             codeText += MappingConfiguration.SaslMechanismGetSetString;

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -331,7 +331,7 @@ namespace Confluent.Kafka
             codeText += $"        /// <summary>\n";
             codeText += $"        ///     A reference to the configuration key names\n";
             codeText += $"        /// </summary>\n";
-            codeText += $"        public static class PropertyNames\n";
+            codeText += $"        public static partial class PropertyNames\n";
             codeText += $"        {{\n";
 
             var codeTextC = string.Empty;
@@ -376,7 +376,7 @@ namespace Confluent.Kafka
                     $"            /// <summary>\n" +
                     $"            ///     A reference to the key names for {name} specific configuration properties.\n" +
                     $"            /// </summary>\n" +
-                    $"            public static class {name}\n" +
+                    $"            public static partial class {name}\n" +
                     $"            {{\n" +
                     code +
                     $"            }}\n";

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -427,7 +427,7 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name=""configSource""></param>
         /// <returns></returns>
-        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+        public static new {name} CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new {name}(configSource.ToDictionary(a => a.Key, a => a.Value));
 
         /// <summary>
         ///     Initialize a new empty <see cref=""{name}"" /> instance.

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -441,7 +441,7 @@ namespace Confluent.Kafka
             codeText += $"    ///     {docs}\n";
             codeText += $"    /// </summary>\n";
             codeText += $"    public class {name}{(derive ? " : ClientConfig" : " : Config")}\n";
-            codeText += $"    {{\n";
+            codeText += $"    {{";
             return codeText;
         }
 
@@ -449,24 +449,24 @@ namespace Confluent.Kafka
         {
             var codeText = $@"
         /// <summary>
-        /// Creates a new {name} class by taking a copy of the provided <paramref name=""configSource""/>.
-        /// The <paramref name=""configSource""/> can be any of: IEnumerable; Dictonary; any of the Config types.
-        /// </summary>
-        /// <param name=""configSource""></param>
-        /// <returns></returns>
-        public static new {name} CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new {name}(configSource.ToDictionary(a => a.Key, a => a.Value));
-
-        /// <summary>
         ///     Initialize a new empty <see cref=""{name}"" /> instance.
         /// </summary>
         public {name}() : base() {{ }}
 
         /// <summary>
+        ///     Initialize a new <see cref=""{name}"" /> instance copying
+        ///     an existing key/value collection.
+        ///     This will create a copy of the <paramref name=""configSource""/> i.e. operations on this class WILL NOT modify the provided collection
+        /// </summary>
+        /// <param name=""configSource""></param>
+        public {name}(IEnumerable<KeyValuePair<string, string>> configSource) : base(configSource) {{ }}
+
+        /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping
-        ///     an existing <see cref=""ClientConfig"" /> instance.
+        ///     an existing <see cref=""Config"" /> instance.
         ///     This will change the values ""in-place"" i.e. operations on this class WILL modify the provided collection
         /// </summary>
-        public {name}(ClientConfig config) : base(config) {{ }}
+        public {name}(Config config) : base(config) {{ }}
 
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -374,7 +374,7 @@ namespace Confluent.Kafka
             {
                 return
                     $"            /// <summary>\n" +
-                    $"            ///     A reference to the configuration key names for {name}\n" +
+                    $"            ///     A reference to the key names for {name} specific configuration properties.\n" +
                     $"            /// </summary>\n" +
                     $"            public static class {name}\n" +
                     $"            {{\n" +

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -254,7 +254,7 @@ namespace ConfigGen
         static string createFileHeader(string branch)
         {
             return
-@"// *** Auto-generated from librdkafka " + branch + @" *** - do not modify manually.
+@"// *** Auto-generated from librdkafka branch " + branch + @" *** - do not modify manually.
 //
 // Copyright 2018 Confluent Inc.
 //
@@ -418,26 +418,40 @@ namespace Confluent.Kafka
             return codeText;
         }
 
+        static string createClassConstructors(string name)
+        {
+            var codeText = "\n";
+            codeText += $@"        /// <summary>
+        ///     Initialize a new empty <see cref=""{name}"" /> instance.
+        /// </summary>
+        public {name}() {{ }}
+
+        /// <summary>
+        ///     Initialize a new <see cref=""{name}"" /> instance based on
+        ///     an existing <see cref=""ClientConfig"" /> instance.
+        /// </summary>
+        public {name}(ClientConfig config) : base(config) {{ }}
+
+        /// <summary>
+        ///     Initialize a new <see cref=""{name}"" /> instance based on
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
+
+        /// <summary>
+        ///     Initialize a new <see cref=""{name}"" /> wrapping
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public {name}(IDictionary<string, string> config) : base(config) {{ }}
+";
+            return codeText;
+        }
+
         static string createConsumerSpecific()
         {
             return
-@"        /// <summary>
-        ///     Initialize a new empty <see cref=""ConsumerConfig"" /> instance.
-        /// </summary>
-        public ConsumerConfig() {}
-
-        /// <summary>
-        ///     Initialize a new <see cref=""ConsumerConfig"" /> instance based on
-        ///     an existing <see cref=""ClientConfig"" /> instance.
-        /// </summary>
-        public ConsumerConfig(ClientConfig config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
-
-        /// <summary>
-        ///     Initialize a new <see cref=""ConsumerConfig"" /> instance based on
-        ///     an existing key/value pair collection.
-        /// </summary>
-        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
-
+                createClassConstructors("ConsumerConfig") +
+@"
         /// <summary>
         ///     A comma separated list of fields that may be optionally set
         ///     in <see cref=""Confluent.Kafka.ConsumeResult{TKey,TValue}"" />
@@ -458,23 +472,8 @@ namespace Confluent.Kafka
         static string createProducerSpecific()
         {
             return
-@"        /// <summary>
-        ///     Initialize a new empty <see cref=""ProducerConfig"" /> instance.
-        /// </summary>
-        public ProducerConfig() {}
-
-        /// <summary>
-        ///     Initialize a new <see cref=""ProducerConfig"" /> instance based on
-        ///     an existing <see cref=""ClientConfig"" /> instance.
-        /// </summary>
-        public ProducerConfig(ClientConfig config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
-
-        /// <summary>
-        ///     Initialize a new <see cref=""ProducerConfig"" /> instance based on
-        ///     an existing key/value pair collection.
-        /// </summary>
-        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
-
+                createClassConstructors("ProducerConfig") +
+@"
         /// <summary>
         ///     Specifies whether or not the producer should start a background poll 
         ///     thread to receive delivery reports and event notifications. Generally,
@@ -512,24 +511,7 @@ namespace Confluent.Kafka
 
         static string createAdminClientSpecific()
         {
-            return 
-@"        /// <summary>
-        ///     Initialize a new empty <see cref=""AdminClientConfig"" /> instance.
-        /// </summary>
-        public AdminClientConfig() {}
-
-        /// <summary>
-        ///     Initialize a new <see cref=""AdminClientConfig"" /> instance based on
-        ///     an existing <see cref=""ClientConfig"" /> instance.
-        /// </summary>
-        public AdminClientConfig(ClientConfig config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
-
-        /// <summary>
-        ///     Initialize a new <see cref=""AdminClientConfig"" /> instance based on
-        ///     an existing key/value pair collection.
-        /// </summary>
-        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
-";
+            return createClassConstructors("AdminClientConfig");
         }
 
         static List<PropertySpecification> extractAll(string configDoc)
@@ -666,6 +648,7 @@ namespace Confluent.Kafka
             codeText += MappingConfiguration.SaslMechanismEnumString;
             codeText += MappingConfiguration.AcksEnumString;
             codeText += createClassHeader("ClientConfig", "Configuration common to all clients", false);
+            codeText += createClassConstructors("ClientConfig");
             codeText += MappingConfiguration.SaslMechanismGetSetString;
             codeText += MappingConfiguration.AcksGetSetString;
             codeText += createProperties(props.Where(p => p.CPorA == "*"));

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -429,29 +429,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping
         ///     an existing <see cref=""ClientConfig"" /> instance.
-        /// </summary>
-        /// <summary>
-        ///     <para>
         ///     This will change the values ""in-place"" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public {name}(ClientConfig config) : base(config) {{ }}
 
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will change the values ""in-place"" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public {name}(IDictionary<string, string> config) : base(config) {{ }}
 
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance copying
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will make a copy of the provided values i.e. the original will be NOT modified
-        ///     </para>
         /// </summary>
         public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
 ";

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -254,7 +254,7 @@ namespace ConfigGen
         static string createFileHeader(string branch)
         {
             return
-@"// *** Auto-generated from librdkafka branch " + branch + @" *** - do not modify manually.
+@"// *** Auto-generated from librdkafka " + branch + @" *** - do not modify manually.
 //
 // Copyright 2018 Confluent Inc.
 //

--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -429,21 +429,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping
         ///     an existing <see cref=""ClientConfig"" /> instance.
-        ///     This will change the values ""in-place"" i.e. the original will be modified
+        ///     This will change the values ""in-place"" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public {name}(ClientConfig config) : base(config) {{ }}
 
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     This will change the values ""in-place"" i.e. the original will be modified
+        ///     This will change the values ""in-place"" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public {name}(IDictionary<string, string> config) : base(config) {{ }}
 
         /// <summary>
         ///     Initialize a new <see cref=""{name}"" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
+        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
         /// </summary>
         public {name}(IEnumerable<KeyValuePair<string, string>> config) : base(config) {{ }}
 ";

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -52,7 +52,7 @@ namespace Confluent.Kafka
         ///     A collection of librdkafka configuration parameters 
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     <see cref="Confluent.Kafka.Config.PropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </param>
         public AdminClientBuilder(IEnumerable<KeyValuePair<string, string>> config)

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -52,7 +52,7 @@ namespace Confluent.Kafka
         ///     A collection of librdkafka configuration parameters 
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.Config.PropertyNames" />).
+        ///     <see cref="AdminConfig.PropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </param>
         public AdminClientBuilder(IEnumerable<KeyValuePair<string, string>> config)

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -57,7 +57,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
         /// </summary>
         public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -42,7 +42,7 @@ namespace Confluent.Kafka
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> wrapping
-        ///     an existing key/value dictionary.
+        ///     an existing key/value colection.
         ///     This will create a copy of the <paramref name="configSource"/> i.e. operations on this class WILL NOT modify the provided collection
         /// </summary>
         /// <param name="configSource"></param>

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -213,7 +213,7 @@ namespace Confluent.Kafka
         ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
         ///     importance: low
         /// </summary>
-        public int CancellationDelayMaxMs { set { this.SetObject(ConsumerConfig.PropertyNames.CancellationDelayMaxMs, value); } }
+        public int CancellationDelayMaxMs { set { this.SetObject(ClientConfig.PropertyNames.CancellationDelayMaxMs, value); } }
 
         private const int DefaultCancellationDelayMaxMs = 100;
 
@@ -221,7 +221,7 @@ namespace Confluent.Kafka
             IEnumerable<KeyValuePair<string, string>> config, out int cancellationDelayMaxMs)
         {
             var cancellationDelayMaxString = config
-                .Where(prop => prop.Key == ConsumerConfig.PropertyNames.CancellationDelayMaxMs)
+                .Where(prop => prop.Key == ClientConfig.PropertyNames.CancellationDelayMaxMs)
                 .Select(a => a.Value)
                 .FirstOrDefault();
 
@@ -230,12 +230,12 @@ namespace Confluent.Kafka
                 if (!int.TryParse(cancellationDelayMaxString, out cancellationDelayMaxMs))
                 {
                     throw new ArgumentException(
-                        $"{ConsumerConfig.PropertyNames.CancellationDelayMaxMs} must be a valid integer value.");
+                        $"{ClientConfig.PropertyNames.CancellationDelayMaxMs} must be a valid integer value.");
                 }
                 if (cancellationDelayMaxMs < 1 || cancellationDelayMaxMs > 10000)
                 {
                     throw new ArgumentOutOfRangeException(
-                        $"{ConsumerConfig.PropertyNames.CancellationDelayMaxMs} must be in the range 1 <= {ConsumerConfig.PropertyNames.CancellationDelayMaxMs} <= 10000");
+                        $"{ClientConfig.PropertyNames.CancellationDelayMaxMs} must be in the range 1 <= {ClientConfig.PropertyNames.CancellationDelayMaxMs} <= 10000");
                 }
             }
             else
@@ -243,7 +243,7 @@ namespace Confluent.Kafka
                 cancellationDelayMaxMs = DefaultCancellationDelayMaxMs;
             }
 
-            return config.Where(prop => prop.Key != ConsumerConfig.PropertyNames.CancellationDelayMaxMs);
+            return config.Where(prop => prop.Key != ClientConfig.PropertyNames.CancellationDelayMaxMs);
         }
     }
 }

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -43,27 +43,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing <see cref="Config" /> instance.
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public Config(Config config) { this.properties = config.properties; }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> wrapping
         ///     an existing key/value dictionary.
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public Config(IDictionary<string, string> config) { this.properties = config; }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will make a copy of the provided values i.e. the original will be NOT modified
-        ///     </para>
         /// </summary>
         public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -213,7 +213,7 @@ namespace Confluent.Kafka
         ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
         ///     importance: low
         /// </summary>
-        public int CancellationDelayMaxMs { set { this.SetObject(Config.PropertyNames.CancellationDelayMaxMs, value); } }
+        public int CancellationDelayMaxMs { set { this.SetObject(ConsumerConfig.PropertyNames.CancellationDelayMaxMs, value); } }
 
         private const int DefaultCancellationDelayMaxMs = 100;
 
@@ -221,7 +221,7 @@ namespace Confluent.Kafka
             IEnumerable<KeyValuePair<string, string>> config, out int cancellationDelayMaxMs)
         {
             var cancellationDelayMaxString = config
-                .Where(prop => prop.Key == PropertyNames.CancellationDelayMaxMs)
+                .Where(prop => prop.Key == ConsumerConfig.PropertyNames.CancellationDelayMaxMs)
                 .Select(a => a.Value)
                 .FirstOrDefault();
 
@@ -230,12 +230,12 @@ namespace Confluent.Kafka
                 if (!int.TryParse(cancellationDelayMaxString, out cancellationDelayMaxMs))
                 {
                     throw new ArgumentException(
-                        $"{PropertyNames.CancellationDelayMaxMs} must be a valid integer value.");
+                        $"{ConsumerConfig.PropertyNames.CancellationDelayMaxMs} must be a valid integer value.");
                 }
                 if (cancellationDelayMaxMs < 1 || cancellationDelayMaxMs > 10000)
                 {
                     throw new ArgumentOutOfRangeException(
-                        $"{PropertyNames.CancellationDelayMaxMs} must be in the range 1 <= {PropertyNames.CancellationDelayMaxMs} <= 10000");
+                        $"{ConsumerConfig.PropertyNames.CancellationDelayMaxMs} must be in the range 1 <= {ConsumerConfig.PropertyNames.CancellationDelayMaxMs} <= 10000");
                 }
             }
             else
@@ -243,7 +243,7 @@ namespace Confluent.Kafka
                 cancellationDelayMaxMs = DefaultCancellationDelayMaxMs;
             }
 
-            return config.Where(prop => prop.Key != PropertyNames.CancellationDelayMaxMs);
+            return config.Where(prop => prop.Key != ConsumerConfig.PropertyNames.CancellationDelayMaxMs);
         }
     }
 }

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -36,17 +36,17 @@ namespace Confluent.Kafka
         };
 
         /// <summary>
-        /// Creates a new Config class by taking a copy of the provided <paramref name="configSource"/>.
-        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types
-        /// </summary>
-        /// <param name="configSource"></param>
-        /// <returns></returns>
-        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
-
-        /// <summary>
         ///     Initialize a new empty <see cref="Config" /> instance.
         /// </summary>
         public Config() { this.properties = new Dictionary<string, string>(); }
+
+        /// <summary>
+        ///     Initialize a new <see cref="Config" /> wrapping
+        ///     an existing key/value dictionary.
+        ///     This will create a copy of the <paramref name="configSource"/> i.e. operations on this class WILL NOT modify the provided collection
+        /// </summary>
+        /// <param name="configSource"></param>
+        public Config(IEnumerable<KeyValuePair<string, string>> configSource) : this(configSource.ToDictionary(a => a.Key, a => a.Value)) { }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -43,21 +43,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing <see cref="Config" /> instance.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public Config(Config config) { this.properties = config.properties; }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> wrapping
         ///     an existing key/value dictionary.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public Config(IDictionary<string, string> config) { this.properties = config; }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
+        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the original
         /// </summary>
         public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -44,13 +44,19 @@ namespace Confluent.Kafka
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing <see cref="Config" /> instance.
         /// </summary>
-        public Config(Config config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public Config(Config config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing key/value pair collection.
         /// </summary>
-        public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
+
+        /// <summary>
+        ///     Initialize a new <see cref="Config" /> wrapping
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public Config(IDictionary<string, string> config) { this.properties = config; }
 
         /// <summary>
         ///     Set a configuration property using a string key / value pair.
@@ -178,7 +184,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The configuration properties.
         /// </summary>
-        protected Dictionary<string, string> properties = new Dictionary<string, string>();
+        protected IDictionary<string, string> properties = new Dictionary<string, string>();
 
         /// <summary>
         ///     	Returns an enumerator that iterates through the property collection.

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -62,12 +62,6 @@ namespace Confluent.Kafka
         public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 
         /// <summary>
-        /// Creates a copy of this instance.
-        /// </summary>
-        /// <returns>A new instance of this config with a copy of the values from this instance.</returns>
-        public Config Clone() => new Config(properties.ToDictionary(c => c.Key, c => c.Value));
-
-        /// <summary>
         ///     Set a configuration property using a string key / value pair.
         /// </summary>
         /// <remarks>

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -25,7 +25,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Base functionality common to all configuration classes.
     /// </summary>
-    public class Config : IEnumerable<KeyValuePair<string, string>>
+    public partial class Config : IEnumerable<KeyValuePair<string, string>>
     {
         private static Dictionary<string, string> EnumNameToConfigValueSubstitutes = new Dictionary<string, string>
         {

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -19,7 +19,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-
 namespace Confluent.Kafka
 {
     /// <summary>
@@ -214,7 +213,7 @@ namespace Confluent.Kafka
         ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
         ///     importance: low
         /// </summary>
-        public int CancellationDelayMaxMs { set { this.SetObject(ConfigPropertyNames.CancellationDelayMaxMs, value); } }
+        public int CancellationDelayMaxMs { set { this.SetObject(Config.PropertyNames.CancellationDelayMaxMs, value); } }
 
         private const int DefaultCancellationDelayMaxMs = 100;
 
@@ -222,7 +221,7 @@ namespace Confluent.Kafka
             IEnumerable<KeyValuePair<string, string>> config, out int cancellationDelayMaxMs)
         {
             var cancellationDelayMaxString = config
-                .Where(prop => prop.Key == ConfigPropertyNames.CancellationDelayMaxMs)
+                .Where(prop => prop.Key == PropertyNames.CancellationDelayMaxMs)
                 .Select(a => a.Value)
                 .FirstOrDefault();
 
@@ -231,12 +230,12 @@ namespace Confluent.Kafka
                 if (!int.TryParse(cancellationDelayMaxString, out cancellationDelayMaxMs))
                 {
                     throw new ArgumentException(
-                        $"{ConfigPropertyNames.CancellationDelayMaxMs} must be a valid integer value.");
+                        $"{PropertyNames.CancellationDelayMaxMs} must be a valid integer value.");
                 }
                 if (cancellationDelayMaxMs < 1 || cancellationDelayMaxMs > 10000)
                 {
                     throw new ArgumentOutOfRangeException(
-                        $"{ConfigPropertyNames.CancellationDelayMaxMs} must be in the range 1 <= {ConfigPropertyNames.CancellationDelayMaxMs} <= 10000");
+                        $"{PropertyNames.CancellationDelayMaxMs} must be in the range 1 <= {PropertyNames.CancellationDelayMaxMs} <= 10000");
                 }
             }
             else
@@ -244,7 +243,7 @@ namespace Confluent.Kafka
                 cancellationDelayMaxMs = DefaultCancellationDelayMaxMs;
             }
 
-            return config.Where(prop => prop.Key != ConfigPropertyNames.CancellationDelayMaxMs);
+            return config.Where(prop => prop.Key != PropertyNames.CancellationDelayMaxMs);
         }
     }
 }

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -43,20 +43,35 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing <see cref="Config" /> instance.
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
-        public Config(Config config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
+        public Config(Config config) { this.properties = config.properties; }
+
+        /// <summary>
+        ///     Initialize a new <see cref="Config" /> wrapping
+        ///     an existing key/value dictionary.
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
+        /// </summary>
+        public Config(IDictionary<string, string> config) { this.properties = config; }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
         ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     </para>
         /// </summary>
         public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 
         /// <summary>
-        ///     Initialize a new <see cref="Config" /> wrapping
-        ///     an existing key/value pair collection.
+        /// Creates a copy of this instance.
         /// </summary>
-        public Config(IDictionary<string, string> config) { this.properties = config; }
+        /// <returns>A new instance of this config with a copy of the values from this instance.</returns>
+        public Config Clone() => new Config(properties.ToDictionary(c => c.Key, c => c.Value));
 
         /// <summary>
         ///     Set a configuration property using a string key / value pair.

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -36,9 +36,17 @@ namespace Confluent.Kafka
         };
 
         /// <summary>
+        /// Creates a new Config class by taking a copy of the provided <paramref name="configSource"/>.
+        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types
+        /// </summary>
+        /// <param name="configSource"></param>
+        /// <returns></returns>
+        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+
+        /// <summary>
         ///     Initialize a new empty <see cref="Config" /> instance.
         /// </summary>
-        public Config() {}
+        public Config() { this.properties = new Dictionary<string, string>(); }
 
         /// <summary>
         ///     Initialize a new <see cref="Config" /> instance based on
@@ -53,13 +61,6 @@ namespace Confluent.Kafka
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public Config(IDictionary<string, string> config) { this.properties = config; }
-
-        /// <summary>
-        ///     Initialize a new <see cref="Config" /> instance based on
-        ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the original
-        /// </summary>
-        public Config(IEnumerable<KeyValuePair<string, string>> config) { this.properties = config.ToDictionary(a => a.Key, a => a.Value); }
 
         /// <summary>
         ///     Set a configuration property using a string key / value pair.
@@ -115,7 +116,7 @@ namespace Confluent.Kafka
             if (result == null) { return null; }
             return int.Parse(result);
         }
-        
+
         /// <summary>
         ///     Gets a configuration property bool? value given a key.
         /// </summary>
@@ -187,7 +188,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The configuration properties.
         /// </summary>
-        protected IDictionary<string, string> properties = new Dictionary<string, string>();
+        protected IDictionary<string, string> properties;
 
         /// <summary>
         ///     	Returns an enumerator that iterates through the property collection.

--- a/src/Confluent.Kafka/ConfigPropertyNames.cs
+++ b/src/Confluent.Kafka/ConfigPropertyNames.cs
@@ -15,12 +15,15 @@
 // Refer to LICENSE for more information.
 
 
+using System;
+
 namespace Confluent.Kafka
 {
     /// <summary>
     ///     Names of all configuration properties specific to the
     ///     .NET Client.
     /// </summary>
+    [Obsolete("Please use Config.PropertyNames instead")]
     public static class ConfigPropertyNames
     {
         /// <summary>

--- a/src/Confluent.Kafka/ConfigPropertyNames.cs
+++ b/src/Confluent.Kafka/ConfigPropertyNames.cs
@@ -39,7 +39,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: true
             /// </summary>
-            public const string EnableBackgroundPoll = Config.PropertyNames.Producer.EnableBackgroundPoll;
+            public const string EnableBackgroundPoll = ProducerConfig.PropertyNames.EnableBackgroundPoll;
 
             /// <summary>
             ///     Specifies whether to enable notification of delivery reports. Typically
@@ -48,7 +48,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: true
             /// </summary>
-            public const string EnableDeliveryReports = Config.PropertyNames.Producer.EnableDeliveryReports;
+            public const string EnableDeliveryReports = ProducerConfig.PropertyNames.EnableDeliveryReports;
 
             /// <summary>
             ///     A comma separated list of fields that may be optionally set in delivery
@@ -58,7 +58,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: all
             /// </summary>
-            public const string DeliveryReportFields = Config.PropertyNames.Producer.DeliveryReportFields;
+            public const string DeliveryReportFields = ProducerConfig.PropertyNames.DeliveryReportFields;
         }
         
 
@@ -78,7 +78,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: all
             /// </summary>
-            public const string ConsumeResultFields = Config.PropertyNames.Consumer.ConsumeResultFields;
+            public const string ConsumeResultFields = ConsumerConfig.PropertyNames.ConsumeResultFields;
         }
 
         /// <summary>
@@ -88,7 +88,6 @@ namespace Confluent.Kafka
         ///     default: 100
         ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
         /// </summary>
-        public const string CancellationDelayMaxMs = Config.PropertyNames.CancellationDelayMaxMs;
-        
+        public const string CancellationDelayMaxMs = ConsumerConfig.PropertyNames.CancellationDelayMaxMs;
     }
 }

--- a/src/Confluent.Kafka/ConfigPropertyNames.cs
+++ b/src/Confluent.Kafka/ConfigPropertyNames.cs
@@ -23,7 +23,6 @@ namespace Confluent.Kafka
     ///     Names of all configuration properties specific to the
     ///     .NET Client.
     /// </summary>
-    [Obsolete("Please use Config.PropertyNames instead")]
     public static class ConfigPropertyNames
     {
         /// <summary>

--- a/src/Confluent.Kafka/ConfigPropertyNames.cs
+++ b/src/Confluent.Kafka/ConfigPropertyNames.cs
@@ -88,6 +88,6 @@ namespace Confluent.Kafka
         ///     default: 100
         ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
         /// </summary>
-        public const string CancellationDelayMaxMs = ConsumerConfig.PropertyNames.CancellationDelayMaxMs;
+        public const string CancellationDelayMaxMs = ClientConfig.PropertyNames.CancellationDelayMaxMs;
     }
 }

--- a/src/Confluent.Kafka/ConfigPropertyNames.cs
+++ b/src/Confluent.Kafka/ConfigPropertyNames.cs
@@ -23,6 +23,7 @@ namespace Confluent.Kafka
     ///     Names of all configuration properties specific to the
     ///     .NET Client.
     /// </summary>
+    [Obsolete("Please use Config.PropertyNames instead")]
     public static class ConfigPropertyNames
     {
         /// <summary>
@@ -38,7 +39,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: true
             /// </summary>
-            public const string EnableBackgroundPoll = "dotnet.producer.enable.background.poll";
+            public const string EnableBackgroundPoll = Config.PropertyNames.Producer.EnableBackgroundPoll;
 
             /// <summary>
             ///     Specifies whether to enable notification of delivery reports. Typically
@@ -47,7 +48,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: true
             /// </summary>
-            public const string EnableDeliveryReports = "dotnet.producer.enable.delivery.reports";
+            public const string EnableDeliveryReports = Config.PropertyNames.Producer.EnableDeliveryReports;
 
             /// <summary>
             ///     A comma separated list of fields that may be optionally set in delivery
@@ -57,7 +58,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: all
             /// </summary>
-            public const string DeliveryReportFields = "dotnet.producer.delivery.report.fields";
+            public const string DeliveryReportFields = Config.PropertyNames.Producer.DeliveryReportFields;
         }
         
 
@@ -77,7 +78,7 @@ namespace Confluent.Kafka
             /// 
             ///     default: all
             /// </summary>
-            public const string ConsumeResultFields = "dotnet.consumer.consume.result.fields";
+            public const string ConsumeResultFields = Config.PropertyNames.Consumer.ConsumeResultFields;
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace Confluent.Kafka
         ///     default: 100
         ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
         /// </summary>
-        public const string CancellationDelayMaxMs = "dotnet.cancellation.delay.max.ms";
+        public const string CancellationDelayMaxMs = Config.PropertyNames.CancellationDelayMaxMs;
         
     }
 }

--- a/src/Confluent.Kafka/Config_PropertyNames.cs
+++ b/src/Confluent.Kafka/Config_PropertyNames.cs
@@ -1,0 +1,92 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Names of all configuration properties specific to the
+    ///     .NET Client.
+    /// </summary>
+    public partial class Config
+    {
+        public static partial class PropertyNames
+        {
+            /// <summary>
+            ///     Producer specific configuration properties.
+            /// </summary>
+            public static partial class Producer
+            {
+                /// <summary>
+                ///     Specifies whether or not the producer should start a background poll 
+                ///     thread to receive delivery reports and event notifications. Generally,
+                ///     this should be set to true. If set to false, you will need to call 
+                ///     the Poll function manually.
+                /// 
+                ///     default: true
+                /// </summary>
+                public const string EnableBackgroundPoll = "dotnet.producer.enable.background.poll";
+
+                /// <summary>
+                ///     Specifies whether to enable notification of delivery reports. Typically
+                ///     you should set this parameter to true. Set it to false for "fire and
+                ///     forget" semantics and a small boost in performance.
+                /// 
+                ///     default: true
+                /// </summary>
+                public const string EnableDeliveryReports = "dotnet.producer.enable.delivery.reports";
+
+                /// <summary>
+                ///     A comma separated list of fields that may be optionally set in delivery
+                ///     reports. Disabling delivery report fields that you do not require will
+                ///     improve maximum throughput and reduce memory usage. Allowed values:
+                ///     key, value, timestamp, headers, status, all, none.
+                /// 
+                ///     default: all
+                /// </summary>
+                public const string DeliveryReportFields = "dotnet.producer.delivery.report.fields";
+            }
+
+
+            /// <summary>
+            ///     Consumer specific configuration properties.
+            /// </summary>
+            public static partial class Consumer
+            {
+                /// <summary>
+                ///     A comma separated list of fields that may be optionally set
+                ///     in <see cref="Confluent.Kafka.ConsumeResult{TKey,TValue}" />
+                ///     objects returned by the
+                ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Consume(System.TimeSpan)" />
+                ///     method. Disabling fields that you do not require will improve 
+                ///     throughput and reduce memory consumption. Allowed values:
+                ///     headers, timestamp, topic, all, none
+                /// 
+                ///     default: all
+                /// </summary>
+                public const string ConsumeResultFields = "dotnet.consumer.consume.result.fields";
+            }
+
+            /// <summary>
+            ///     The maximum length of time (in milliseconds) before a cancellation request
+            ///     is acted on. Low values may result in measurably higher CPU usage.
+            ///     
+            ///     default: 100
+            ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
+            /// </summary>
+            public const string CancellationDelayMaxMs = "dotnet.cancellation.delay.max.ms";
+        }
+    }
+}

--- a/src/Confluent.Kafka/Config_PropertyNames.cs
+++ b/src/Confluent.Kafka/Config_PropertyNames.cs
@@ -16,6 +16,24 @@
 
 namespace Confluent.Kafka
 {
+    public partial class ClientConfig
+    {
+        /// <summary>
+        ///     Consumer specific configuration properties specific to the .NET Client.
+        /// </summary>
+        public static partial class PropertyNames
+        {
+            /// <summary>
+            ///     The maximum length of time (in milliseconds) before a cancellation request
+            ///     is acted on. Low values may result in measurably higher CPU usage.
+            ///     
+            ///     default: 100
+            ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
+            /// </summary>
+            public const string CancellationDelayMaxMs = "dotnet.cancellation.delay.max.ms";
+        }
+    }
+
     public partial class ProducerConfig
     {
         /// <summary>
@@ -51,15 +69,6 @@ namespace Confluent.Kafka
             ///     default: all
             /// </summary>
             public const string DeliveryReportFields = "dotnet.producer.delivery.report.fields";
-
-            /// <summary>
-            ///     The maximum length of time (in milliseconds) before a cancellation request
-            ///     is acted on. Low values may result in measurably higher CPU usage.
-            ///     
-            ///     default: 100
-            ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
-            /// </summary>
-            public const string CancellationDelayMaxMs = "dotnet.cancellation.delay.max.ms";
         }
     }
 
@@ -82,15 +91,6 @@ namespace Confluent.Kafka
             ///     default: all
             /// </summary>
             public const string ConsumeResultFields = "dotnet.consumer.consume.result.fields";
-
-            /// <summary>
-            ///     The maximum length of time (in milliseconds) before a cancellation request
-            ///     is acted on. Low values may result in measurably higher CPU usage.
-            ///     
-            ///     default: 100
-            ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
-            /// </summary>
-            public const string CancellationDelayMaxMs = "dotnet.cancellation.delay.max.ms";
         }
     }
 }

--- a/src/Confluent.Kafka/Config_PropertyNames.cs
+++ b/src/Confluent.Kafka/Config_PropertyNames.cs
@@ -16,68 +16,72 @@
 
 namespace Confluent.Kafka
 {
-    /// <summary>
-    ///     Names of all configuration properties specific to the
-    ///     .NET Client.
-    /// </summary>
-    public partial class Config
+    public partial class ProducerConfig
     {
+        /// <summary>
+        ///     Producer specific configuration properties specific to the .NET Client.
+        /// </summary>
         public static partial class PropertyNames
         {
             /// <summary>
-            ///     Producer specific configuration properties.
+            ///     Specifies whether or not the producer should start a background poll 
+            ///     thread to receive delivery reports and event notifications. Generally,
+            ///     this should be set to true. If set to false, you will need to call 
+            ///     the Poll function manually.
+            /// 
+            ///     default: true
             /// </summary>
-            public static partial class Producer
-            {
-                /// <summary>
-                ///     Specifies whether or not the producer should start a background poll 
-                ///     thread to receive delivery reports and event notifications. Generally,
-                ///     this should be set to true. If set to false, you will need to call 
-                ///     the Poll function manually.
-                /// 
-                ///     default: true
-                /// </summary>
-                public const string EnableBackgroundPoll = "dotnet.producer.enable.background.poll";
-
-                /// <summary>
-                ///     Specifies whether to enable notification of delivery reports. Typically
-                ///     you should set this parameter to true. Set it to false for "fire and
-                ///     forget" semantics and a small boost in performance.
-                /// 
-                ///     default: true
-                /// </summary>
-                public const string EnableDeliveryReports = "dotnet.producer.enable.delivery.reports";
-
-                /// <summary>
-                ///     A comma separated list of fields that may be optionally set in delivery
-                ///     reports. Disabling delivery report fields that you do not require will
-                ///     improve maximum throughput and reduce memory usage. Allowed values:
-                ///     key, value, timestamp, headers, status, all, none.
-                /// 
-                ///     default: all
-                /// </summary>
-                public const string DeliveryReportFields = "dotnet.producer.delivery.report.fields";
-            }
-
+            public const string EnableBackgroundPoll = "dotnet.producer.enable.background.poll";
 
             /// <summary>
-            ///     Consumer specific configuration properties.
+            ///     Specifies whether to enable notification of delivery reports. Typically
+            ///     you should set this parameter to true. Set it to false for "fire and
+            ///     forget" semantics and a small boost in performance.
+            /// 
+            ///     default: true
             /// </summary>
-            public static partial class Consumer
-            {
-                /// <summary>
-                ///     A comma separated list of fields that may be optionally set
-                ///     in <see cref="Confluent.Kafka.ConsumeResult{TKey,TValue}" />
-                ///     objects returned by the
-                ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Consume(System.TimeSpan)" />
-                ///     method. Disabling fields that you do not require will improve 
-                ///     throughput and reduce memory consumption. Allowed values:
-                ///     headers, timestamp, topic, all, none
-                /// 
-                ///     default: all
-                /// </summary>
-                public const string ConsumeResultFields = "dotnet.consumer.consume.result.fields";
-            }
+            public const string EnableDeliveryReports = "dotnet.producer.enable.delivery.reports";
+
+            /// <summary>
+            ///     A comma separated list of fields that may be optionally set in delivery
+            ///     reports. Disabling delivery report fields that you do not require will
+            ///     improve maximum throughput and reduce memory usage. Allowed values:
+            ///     key, value, timestamp, headers, status, all, none.
+            /// 
+            ///     default: all
+            /// </summary>
+            public const string DeliveryReportFields = "dotnet.producer.delivery.report.fields";
+
+            /// <summary>
+            ///     The maximum length of time (in milliseconds) before a cancellation request
+            ///     is acted on. Low values may result in measurably higher CPU usage.
+            ///     
+            ///     default: 100
+            ///     range: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000
+            /// </summary>
+            public const string CancellationDelayMaxMs = "dotnet.cancellation.delay.max.ms";
+        }
+    }
+
+    public partial class ConsumerConfig
+    {
+        /// <summary>
+        ///     Consumer specific configuration properties specific to the .NET Client.
+        /// </summary>
+        public static partial class PropertyNames
+        {
+            /// <summary>
+            ///     A comma separated list of fields that may be optionally set
+            ///     in <see cref="Confluent.Kafka.ConsumeResult{TKey,TValue}" />
+            ///     objects returned by the
+            ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Consume(System.TimeSpan)" />
+            ///     method. Disabling fields that you do not require will improve 
+            ///     throughput and reduce memory consumption. Allowed values:
+            ///     headers, timestamp, topic, all, none
+            /// 
+            ///     default: all
+            /// </summary>
+            public const string ConsumeResultFields = "dotnet.consumer.consume.result.fields";
 
             /// <summary>
             ///     The maximum length of time (in milliseconds) before a cancellation request

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -222,704 +222,1572 @@ namespace Confluent.Kafka
         /// <summary>
         ///     A reference to the configuration key names
         /// </summary>
-        public static class KeyNames
+        public static class PropertyNames
         {
             /// <summary>
-            ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
-            ///
-            ///     default: 5000
-            ///     importance: medium
-            /// </summary>
-            public const string RequestTimeoutMs = "request.timeout.ms";
-
-            /// <summary>
-            ///     Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
-            ///
-            ///     default: 300000
-            ///     importance: high
-            /// </summary>
-            public const string MessageTimeoutMs = "message.timeout.ms";
-
-            /// <summary>
-            ///     Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.).
-            ///
-            ///     default: consistent_random
-            ///     importance: high
-            /// </summary>
-            public const string Partitioner = "partitioner";
-
-            /// <summary>
-            ///     Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
-            ///
-            ///     default: -1
-            ///     importance: medium
-            /// </summary>
-            public const string CompressionLevel = "compression.level";
-
-            /// <summary>
-            ///     Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
-            ///
-            ///     default: largest
-            ///     importance: high
-            /// </summary>
-            public const string AutoOffsetReset = "auto.offset.reset";
-
-            /// <summary>
-            ///     Client identifier.
-            ///
-            ///     default: rdkafka
-            ///     importance: low
-            /// </summary>
-            public const string ClientId = "client.id";
-
-            /// <summary>
-            ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
-            ///
-            ///     default: ''
-            ///     importance: high
-            /// </summary>
-            public const string BootstrapServers = "bootstrap.servers";
-
-            /// <summary>
-            ///     Maximum Kafka protocol request message size.
-            ///
-            ///     default: 1000000
-            ///     importance: medium
-            /// </summary>
-            public const string MessageMaxBytes = "message.max.bytes";
-
-            /// <summary>
-            ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
-            ///
-            ///     default: 65535
-            ///     importance: low
-            /// </summary>
-            public const string MessageCopyMaxBytes = "message.copy.max.bytes";
-
-            /// <summary>
-            ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
-            ///
-            ///     default: 100000000
-            ///     importance: medium
-            /// </summary>
-            public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
-
-            /// <summary>
-            ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
-            ///
-            ///     default: 1000000
-            ///     importance: low
-            /// </summary>
-            public const string MaxInFlight = "max.in.flight";
-
-            /// <summary>
-            ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
-            ///
-            ///     default: 60000
-            ///     importance: low
-            /// </summary>
-            public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
-
-            /// <summary>
-            ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
-            ///
-            ///     default: 300000
-            ///     importance: low
-            /// </summary>
-            public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
-
-            /// <summary>
-            ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
-            ///
-            ///     default: 900000
-            ///     importance: low
-            /// </summary>
-            public const string MetadataMaxAgeMs = "metadata.max.age.ms";
-
-            /// <summary>
-            ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
-            ///
-            ///     default: 250
-            ///     importance: low
-            /// </summary>
-            public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
-
-            /// <summary>
-            ///     Sparse metadata requests (consumes less network bandwidth)
-            ///
-            ///     default: true
-            ///     importance: low
-            /// </summary>
-            public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
-
-            /// <summary>
-            ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string TopicBlacklist = "topic.blacklist";
-
-            /// <summary>
-            ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
-            ///
-            ///     default: ''
-            ///     importance: medium
-            /// </summary>
-            public const string Debug = "debug";
-
-            /// <summary>
-            ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
-            ///
-            ///     default: 60000
-            ///     importance: low
-            /// </summary>
-            public const string SocketTimeoutMs = "socket.timeout.ms";
-
-            /// <summary>
-            ///     Broker socket send buffer size. System default is used if 0.
-            ///
-            ///     default: 0
-            ///     importance: low
-            /// </summary>
-            public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
-
-            /// <summary>
-            ///     Broker socket receive buffer size. System default is used if 0.
-            ///
-            ///     default: 0
-            ///     importance: low
-            /// </summary>
-            public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
-
-            /// <summary>
-            ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
-            ///
-            ///     default: false
-            ///     importance: low
-            /// </summary>
-            public const string SocketKeepaliveEnable = "socket.keepalive.enable";
-
-            /// <summary>
-            ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
-            ///
-            ///     default: false
-            ///     importance: low
-            /// </summary>
-            public const string SocketNagleDisable = "socket.nagle.disable";
-
-            /// <summary>
-            ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
-            ///
-            ///     default: 1
-            ///     importance: low
-            /// </summary>
-            public const string SocketMaxFails = "socket.max.fails";
-
-            /// <summary>
-            ///     How long to cache the broker address resolving results (milliseconds).
-            ///
-            ///     default: 1000
-            ///     importance: low
-            /// </summary>
-            public const string BrokerAddressTtl = "broker.address.ttl";
-
-            /// <summary>
-            ///     Allowed broker IP address families: any, v4, v6
-            ///
-            ///     default: any
-            ///     importance: low
-            /// </summary>
-            public const string BrokerAddressFamily = "broker.address.family";
-
-            /// <summary>
-            ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
-            ///
-            ///     default: 100
-            ///     importance: medium
-            /// </summary>
-            public const string ReconnectBackoffMs = "reconnect.backoff.ms";
-
-            /// <summary>
-            ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
-            ///
-            ///     default: 10000
-            ///     importance: medium
-            /// </summary>
-            public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
-
-            /// <summary>
-            ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
-            ///
-            ///     default: 0
-            ///     importance: high
-            /// </summary>
-            public const string StatisticsIntervalMs = "statistics.interval.ms";
-
-            /// <summary>
-            ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
-            ///
-            ///     default: false
-            ///     importance: low
-            /// </summary>
-            public const string LogQueue = "log.queue";
-
-            /// <summary>
-            ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
-            ///
-            ///     default: true
-            ///     importance: low
-            /// </summary>
-            public const string LogThreadName = "log.thread.name";
-
-            /// <summary>
-            ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
-            ///
-            ///     default: true
-            ///     importance: low
-            /// </summary>
-            public const string LogConnectionClose = "log.connection.close";
-
-            /// <summary>
-            ///     Application opaque (set with rd_kafka_conf_set_opaque())
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string Opaque = "opaque";
-
-            /// <summary>
-            ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
-            ///
-            ///     default: 0
-            ///     importance: low
-            /// </summary>
-            public const string InternalTerminationSignal = "internal.termination.signal";
-
-            /// <summary>
-            ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
-            ///
-            ///     default: true
-            ///     importance: high
-            /// </summary>
-            public const string ApiVersionRequest = "api.version.request";
-
-            /// <summary>
-            ///     Timeout for broker API version requests.
-            ///
-            ///     default: 10000
-            ///     importance: low
-            /// </summary>
-            public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
-
-            /// <summary>
-            ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
-            ///
-            ///     default: 0
-            ///     importance: medium
-            /// </summary>
-            public const string ApiVersionFallbackMs = "api.version.fallback.ms";
-
-            /// <summary>
-            ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
-            ///
-            ///     default: 0.10.0
-            ///     importance: medium
-            /// </summary>
-            public const string BrokerVersionFallback = "broker.version.fallback";
-
-            /// <summary>
-            ///     Protocol used to communicate with brokers.
-            ///
-            ///     default: plaintext
-            ///     importance: high
-            /// </summary>
-            public const string SecurityProtocol = "security.protocol";
-
-            /// <summary>
-            ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslCipherSuites = "ssl.cipher.suites";
-
-            /// <summary>
-            ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslCurvesList = "ssl.curves.list";
-
-            /// <summary>
-            ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslSigalgsList = "ssl.sigalgs.list";
-
-            /// <summary>
-            ///     Path to client's private key (PEM) used for authentication.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslKeyLocation = "ssl.key.location";
-
-            /// <summary>
-            ///     Private key passphrase
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslKeyPassword = "ssl.key.password";
-
-            /// <summary>
-            ///     Path to client's public key (PEM) used for authentication.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslCertificateLocation = "ssl.certificate.location";
-
-            /// <summary>
-            ///     File or directory path to CA certificate(s) for verifying the broker's key.
-            ///
-            ///     default: ''
-            ///     importance: medium
-            /// </summary>
-            public const string SslCaLocation = "ssl.ca.location";
-
-            /// <summary>
-            ///     Path to CRL for verifying broker's certificate validity.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslCrlLocation = "ssl.crl.location";
-
-            /// <summary>
-            ///     Path to client's keystore (PKCS#12) used for authentication.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslKeystoreLocation = "ssl.keystore.location";
-
-            /// <summary>
-            ///     Client's keystore (PKCS#12) password.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SslKeystorePassword = "ssl.keystore.password";
-
-            /// <summary>
-            ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
-            ///
-            ///     default: kafka
-            ///     importance: low
-            /// </summary>
-            public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
-
-            /// <summary>
-            ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
-            ///
-            ///     default: kafkaclient
-            ///     importance: low
-            /// </summary>
-            public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
-
-            /// <summary>
-            ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
-            ///
-            ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
-            ///     importance: low
-            /// </summary>
-            public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
-
-            /// <summary>
-            ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
-
-            /// <summary>
-            ///     Minimum time in milliseconds between key refresh attempts.
-            ///
-            ///     default: 60000
-            ///     importance: low
-            /// </summary>
-            public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
-
-            /// <summary>
-            ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
-            ///
-            ///     default: ''
-            ///     importance: high
-            /// </summary>
-            public const string SaslUsername = "sasl.username";
-
-            /// <summary>
-            ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
-            ///
-            ///     default: ''
-            ///     importance: high
-            /// </summary>
-            public const string SaslPassword = "sasl.password";
-
-            /// <summary>
-            ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string PluginLibraryPaths = "plugin.library.paths";
-
-            /// <summary>
-            ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
-            ///
-            ///     default: ''
-            ///     importance: low
-            /// </summary>
-            public const string Interceptors = "interceptors";
-
-            /// <summary>
-            ///     Client group id string. All clients sharing the same group.id belong to the same group.
-            ///
-            ///     default: ''
-            ///     importance: high
-            /// </summary>
-            public const string GroupId = "group.id";
-
-            /// <summary>
-            ///     Name of partition assignment strategy to use when elected group leader assigns partitions to group members.
-            ///
-            ///     default: range,roundrobin
-            ///     importance: medium
-            /// </summary>
-            public const string PartitionAssignmentStrategy = "partition.assignment.strategy";
-
-            /// <summary>
-            ///     Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
-            ///
-            ///     default: 10000
-            ///     importance: high
-            /// </summary>
-            public const string SessionTimeoutMs = "session.timeout.ms";
-
-            /// <summary>
-            ///     Group session keepalive heartbeat interval.
-            ///
-            ///     default: 3000
-            ///     importance: low
-            /// </summary>
-            public const string HeartbeatIntervalMs = "heartbeat.interval.ms";
-
-            /// <summary>
-            ///     Group protocol type
-            ///
-            ///     default: consumer
-            ///     importance: low
-            /// </summary>
-            public const string GroupProtocolType = "group.protocol.type";
-
-            /// <summary>
-            ///     How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.
-            ///
-            ///     default: 600000
-            ///     importance: low
-            /// </summary>
-            public const string CoordinatorQueryIntervalMs = "coordinator.query.interval.ms";
-
-            /// <summary>
-            ///     Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.
-            ///
-            ///     default: 300000
-            ///     importance: high
-            /// </summary>
-            public const string MaxPollIntervalMs = "max.poll.interval.ms";
-
-            /// <summary>
-            ///     Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().
-            ///
-            ///     default: true
-            ///     importance: high
-            /// </summary>
-            public const string EnableAutoCommit = "enable.auto.commit";
-
-            /// <summary>
-            ///     The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.
-            ///
-            ///     default: 5000
-            ///     importance: medium
-            /// </summary>
-            public const string AutoCommitIntervalMs = "auto.commit.interval.ms";
-
-            /// <summary>
-            ///     Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
-            ///
-            ///     default: true
-            ///     importance: high
-            /// </summary>
-            public const string EnableAutoOffsetStore = "enable.auto.offset.store";
-
-            /// <summary>
-            ///     Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.
-            ///
-            ///     default: 100000
-            ///     importance: medium
-            /// </summary>
-            public const string QueuedMinMessages = "queued.min.messages";
-
-            /// <summary>
-            ///     Maximum number of kilobytes per topic+partition in the local consumer queue. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.
-            ///
-            ///     default: 1048576
-            ///     importance: medium
-            /// </summary>
-            public const string QueuedMaxMessagesKbytes = "queued.max.messages.kbytes";
-
-            /// <summary>
-            ///     Maximum time the broker may wait to fill the response with fetch.min.bytes.
-            ///
-            ///     default: 100
-            ///     importance: low
-            /// </summary>
-            public const string FetchWaitMaxMs = "fetch.wait.max.ms";
-
-            /// <summary>
-            ///     Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
-            ///
-            ///     default: 1048576
-            ///     importance: medium
-            /// </summary>
-            public const string MaxPartitionFetchBytes = "max.partition.fetch.bytes";
-
-            /// <summary>
-            ///     Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).
-            ///
-            ///     default: 52428800
-            ///     importance: medium
-            /// </summary>
-            public const string FetchMaxBytes = "fetch.max.bytes";
-
-            /// <summary>
-            ///     Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.
-            ///
-            ///     default: 1
-            ///     importance: low
-            /// </summary>
-            public const string FetchMinBytes = "fetch.min.bytes";
-
-            /// <summary>
-            ///     How long to postpone the next fetch request for a topic+partition in case of a fetch error.
-            ///
-            ///     default: 500
-            ///     importance: medium
-            /// </summary>
-            public const string FetchErrorBackoffMs = "fetch.error.backoff.ms";
-
-            /// <summary>
-            ///     Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.
-            ///
-            ///     default: false
-            ///     importance: low
-            /// </summary>
-            public const string EnablePartitionEof = "enable.partition.eof";
-
-            /// <summary>
-            ///     Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.
-            ///
-            ///     default: false
-            ///     importance: medium
-            /// </summary>
-            public const string CheckCrcs = "check.crcs";
-
-            /// <summary>
-            ///     When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.
-            ///
-            ///     default: false
-            ///     importance: high
-            /// </summary>
-            public const string EnableIdempotence = "enable.idempotence";
-
-            /// <summary>
-            ///     **EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.
-            ///
-            ///     default: false
-            ///     importance: low
-            /// </summary>
-            public const string EnableGaplessGuarantee = "enable.gapless.guarantee";
-
-            /// <summary>
-            ///     Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
-            ///
-            ///     default: 100000
-            ///     importance: high
-            /// </summary>
-            public const string QueueBufferingMaxMessages = "queue.buffering.max.messages";
-
-            /// <summary>
-            ///     Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.
-            ///
-            ///     default: 1048576
-            ///     importance: high
-            /// </summary>
-            public const string QueueBufferingMaxKbytes = "queue.buffering.max.kbytes";
-
-            /// <summary>
-            ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
-            ///
-            ///     default: 0
-            ///     importance: high
-            /// </summary>
-            public const string LingerMs = "linger.ms";
-
-            /// <summary>
-            ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
-            ///
-            ///     default: 2
-            ///     importance: high
-            /// </summary>
-            public const string MessageSendMaxRetries = "message.send.max.retries";
-
-            /// <summary>
-            ///     The backoff time in milliseconds before retrying a protocol request.
-            ///
-            ///     default: 100
-            ///     importance: medium
-            /// </summary>
-            public const string RetryBackoffMs = "retry.backoff.ms";
-
-            /// <summary>
-            ///     The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.
-            ///
-            ///     default: 1
-            ///     importance: low
-            /// </summary>
-            public const string QueueBufferingBackpressureThreshold = "queue.buffering.backpressure.threshold";
-
-            /// <summary>
-            ///     compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
-            ///
-            ///     default: none
-            ///     importance: medium
-            /// </summary>
-            public const string CompressionType = "compression.type";
-
-            /// <summary>
-            ///     Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by message.max.bytes.
-            ///
-            ///     default: 10000
-            ///     importance: medium
-            /// </summary>
-            public const string BatchNumMessages = "batch.num.messages";
-
+            ///     A reference to the configuration key names for Consumer
+            /// </summary>
+            public static class Consumer
+            {
+                /// <summary>
+                ///     Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
+                ///
+                ///     default: largest
+                ///     importance: high
+                /// </summary>
+                public const string AutoOffsetReset = "auto.offset.reset";
+
+                /// <summary>
+                ///     Client identifier.
+                ///
+                ///     default: rdkafka
+                ///     importance: low
+                /// </summary>
+                public const string ClientId = "client.id";
+
+                /// <summary>
+                ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string BootstrapServers = "bootstrap.servers";
+
+                /// <summary>
+                ///     Maximum Kafka protocol request message size.
+                ///
+                ///     default: 1000000
+                ///     importance: medium
+                /// </summary>
+                public const string MessageMaxBytes = "message.max.bytes";
+
+                /// <summary>
+                ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+                ///
+                ///     default: 65535
+                ///     importance: low
+                /// </summary>
+                public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+
+                /// <summary>
+                ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+                ///
+                ///     default: 100000000
+                ///     importance: medium
+                /// </summary>
+                public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+
+                /// <summary>
+                ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+                ///
+                ///     default: 1000000
+                ///     importance: low
+                /// </summary>
+                public const string MaxInFlight = "max.in.flight";
+
+                /// <summary>
+                ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+
+                /// <summary>
+                ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+                ///
+                ///     default: 300000
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+
+                /// <summary>
+                ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+                ///
+                ///     default: 900000
+                ///     importance: low
+                /// </summary>
+                public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+
+                /// <summary>
+                ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+                ///
+                ///     default: 250
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+
+                /// <summary>
+                ///     Sparse metadata requests (consumes less network bandwidth)
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+
+                /// <summary>
+                ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string TopicBlacklist = "topic.blacklist";
+
+                /// <summary>
+                ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+                ///
+                ///     default: ''
+                ///     importance: medium
+                /// </summary>
+                public const string Debug = "debug";
+
+                /// <summary>
+                ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string SocketTimeoutMs = "socket.timeout.ms";
+
+                /// <summary>
+                ///     Broker socket send buffer size. System default is used if 0.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+
+                /// <summary>
+                ///     Broker socket receive buffer size. System default is used if 0.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+
+                /// <summary>
+                ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+
+                /// <summary>
+                ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string SocketNagleDisable = "socket.nagle.disable";
+
+                /// <summary>
+                ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+                ///
+                ///     default: 1
+                ///     importance: low
+                /// </summary>
+                public const string SocketMaxFails = "socket.max.fails";
+
+                /// <summary>
+                ///     How long to cache the broker address resolving results (milliseconds).
+                ///
+                ///     default: 1000
+                ///     importance: low
+                /// </summary>
+                public const string BrokerAddressTtl = "broker.address.ttl";
+
+                /// <summary>
+                ///     Allowed broker IP address families: any, v4, v6
+                ///
+                ///     default: any
+                ///     importance: low
+                /// </summary>
+                public const string BrokerAddressFamily = "broker.address.family";
+
+                /// <summary>
+                ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+                ///
+                ///     default: 100
+                ///     importance: medium
+                /// </summary>
+                public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+
+                /// <summary>
+                ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+                ///
+                ///     default: 10000
+                ///     importance: medium
+                /// </summary>
+                public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+
+                /// <summary>
+                ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+                ///
+                ///     default: 0
+                ///     importance: high
+                /// </summary>
+                public const string StatisticsIntervalMs = "statistics.interval.ms";
+
+                /// <summary>
+                ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string LogQueue = "log.queue";
+
+                /// <summary>
+                ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string LogThreadName = "log.thread.name";
+
+                /// <summary>
+                ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string LogConnectionClose = "log.connection.close";
+
+                /// <summary>
+                ///     Application opaque (set with rd_kafka_conf_set_opaque())
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string Opaque = "opaque";
+
+                /// <summary>
+                ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string InternalTerminationSignal = "internal.termination.signal";
+
+                /// <summary>
+                ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+                ///
+                ///     default: true
+                ///     importance: high
+                /// </summary>
+                public const string ApiVersionRequest = "api.version.request";
+
+                /// <summary>
+                ///     Timeout for broker API version requests.
+                ///
+                ///     default: 10000
+                ///     importance: low
+                /// </summary>
+                public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+
+                /// <summary>
+                ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+                ///
+                ///     default: 0
+                ///     importance: medium
+                /// </summary>
+                public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+
+                /// <summary>
+                ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+                ///
+                ///     default: 0.10.0
+                ///     importance: medium
+                /// </summary>
+                public const string BrokerVersionFallback = "broker.version.fallback";
+
+                /// <summary>
+                ///     Protocol used to communicate with brokers.
+                ///
+                ///     default: plaintext
+                ///     importance: high
+                /// </summary>
+                public const string SecurityProtocol = "security.protocol";
+
+                /// <summary>
+                ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCipherSuites = "ssl.cipher.suites";
+
+                /// <summary>
+                ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCurvesList = "ssl.curves.list";
+
+                /// <summary>
+                ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslSigalgsList = "ssl.sigalgs.list";
+
+                /// <summary>
+                ///     Path to client's private key (PEM) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeyLocation = "ssl.key.location";
+
+                /// <summary>
+                ///     Private key passphrase
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeyPassword = "ssl.key.password";
+
+                /// <summary>
+                ///     Path to client's public key (PEM) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCertificateLocation = "ssl.certificate.location";
+
+                /// <summary>
+                ///     File or directory path to CA certificate(s) for verifying the broker's key.
+                ///
+                ///     default: ''
+                ///     importance: medium
+                /// </summary>
+                public const string SslCaLocation = "ssl.ca.location";
+
+                /// <summary>
+                ///     Path to CRL for verifying broker's certificate validity.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCrlLocation = "ssl.crl.location";
+
+                /// <summary>
+                ///     Path to client's keystore (PKCS#12) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeystoreLocation = "ssl.keystore.location";
+
+                /// <summary>
+                ///     Client's keystore (PKCS#12) password.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeystorePassword = "ssl.keystore.password";
+
+                /// <summary>
+                ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+                ///
+                ///     default: kafka
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+
+                /// <summary>
+                ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+                ///
+                ///     default: kafkaclient
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+
+                /// <summary>
+                ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+                ///
+                ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+
+                /// <summary>
+                ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+
+                /// <summary>
+                ///     Minimum time in milliseconds between key refresh attempts.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+
+                /// <summary>
+                ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string SaslUsername = "sasl.username";
+
+                /// <summary>
+                ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string SaslPassword = "sasl.password";
+
+                /// <summary>
+                ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string PluginLibraryPaths = "plugin.library.paths";
+
+                /// <summary>
+                ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string Interceptors = "interceptors";
+
+                /// <summary>
+                ///     Client group id string. All clients sharing the same group.id belong to the same group.
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string GroupId = "group.id";
+
+                /// <summary>
+                ///     Name of partition assignment strategy to use when elected group leader assigns partitions to group members.
+                ///
+                ///     default: range,roundrobin
+                ///     importance: medium
+                /// </summary>
+                public const string PartitionAssignmentStrategy = "partition.assignment.strategy";
+
+                /// <summary>
+                ///     Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
+                ///
+                ///     default: 10000
+                ///     importance: high
+                /// </summary>
+                public const string SessionTimeoutMs = "session.timeout.ms";
+
+                /// <summary>
+                ///     Group session keepalive heartbeat interval.
+                ///
+                ///     default: 3000
+                ///     importance: low
+                /// </summary>
+                public const string HeartbeatIntervalMs = "heartbeat.interval.ms";
+
+                /// <summary>
+                ///     Group protocol type
+                ///
+                ///     default: consumer
+                ///     importance: low
+                /// </summary>
+                public const string GroupProtocolType = "group.protocol.type";
+
+                /// <summary>
+                ///     How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.
+                ///
+                ///     default: 600000
+                ///     importance: low
+                /// </summary>
+                public const string CoordinatorQueryIntervalMs = "coordinator.query.interval.ms";
+
+                /// <summary>
+                ///     Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.
+                ///
+                ///     default: 300000
+                ///     importance: high
+                /// </summary>
+                public const string MaxPollIntervalMs = "max.poll.interval.ms";
+
+                /// <summary>
+                ///     Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().
+                ///
+                ///     default: true
+                ///     importance: high
+                /// </summary>
+                public const string EnableAutoCommit = "enable.auto.commit";
+
+                /// <summary>
+                ///     The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.
+                ///
+                ///     default: 5000
+                ///     importance: medium
+                /// </summary>
+                public const string AutoCommitIntervalMs = "auto.commit.interval.ms";
+
+                /// <summary>
+                ///     Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
+                ///
+                ///     default: true
+                ///     importance: high
+                /// </summary>
+                public const string EnableAutoOffsetStore = "enable.auto.offset.store";
+
+                /// <summary>
+                ///     Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.
+                ///
+                ///     default: 100000
+                ///     importance: medium
+                /// </summary>
+                public const string QueuedMinMessages = "queued.min.messages";
+
+                /// <summary>
+                ///     Maximum number of kilobytes per topic+partition in the local consumer queue. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.
+                ///
+                ///     default: 1048576
+                ///     importance: medium
+                /// </summary>
+                public const string QueuedMaxMessagesKbytes = "queued.max.messages.kbytes";
+
+                /// <summary>
+                ///     Maximum time the broker may wait to fill the response with fetch.min.bytes.
+                ///
+                ///     default: 100
+                ///     importance: low
+                /// </summary>
+                public const string FetchWaitMaxMs = "fetch.wait.max.ms";
+
+                /// <summary>
+                ///     Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
+                ///
+                ///     default: 1048576
+                ///     importance: medium
+                /// </summary>
+                public const string MaxPartitionFetchBytes = "max.partition.fetch.bytes";
+
+                /// <summary>
+                ///     Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).
+                ///
+                ///     default: 52428800
+                ///     importance: medium
+                /// </summary>
+                public const string FetchMaxBytes = "fetch.max.bytes";
+
+                /// <summary>
+                ///     Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.
+                ///
+                ///     default: 1
+                ///     importance: low
+                /// </summary>
+                public const string FetchMinBytes = "fetch.min.bytes";
+
+                /// <summary>
+                ///     How long to postpone the next fetch request for a topic+partition in case of a fetch error.
+                ///
+                ///     default: 500
+                ///     importance: medium
+                /// </summary>
+                public const string FetchErrorBackoffMs = "fetch.error.backoff.ms";
+
+                /// <summary>
+                ///     Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string EnablePartitionEof = "enable.partition.eof";
+
+                /// <summary>
+                ///     Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.
+                ///
+                ///     default: false
+                ///     importance: medium
+                /// </summary>
+                public const string CheckCrcs = "check.crcs";
+
+            }
+
+            /// <summary>
+            ///     A reference to the configuration key names for Producer
+            /// </summary>
+            public static class Producer
+            {
+                /// <summary>
+                ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
+                ///
+                ///     default: 5000
+                ///     importance: medium
+                /// </summary>
+                public const string RequestTimeoutMs = "request.timeout.ms";
+
+                /// <summary>
+                ///     Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
+                ///
+                ///     default: 300000
+                ///     importance: high
+                /// </summary>
+                public const string MessageTimeoutMs = "message.timeout.ms";
+
+                /// <summary>
+                ///     Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.).
+                ///
+                ///     default: consistent_random
+                ///     importance: high
+                /// </summary>
+                public const string Partitioner = "partitioner";
+
+                /// <summary>
+                ///     Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
+                ///
+                ///     default: -1
+                ///     importance: medium
+                /// </summary>
+                public const string CompressionLevel = "compression.level";
+
+                /// <summary>
+                ///     Client identifier.
+                ///
+                ///     default: rdkafka
+                ///     importance: low
+                /// </summary>
+                public const string ClientId = "client.id";
+
+                /// <summary>
+                ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string BootstrapServers = "bootstrap.servers";
+
+                /// <summary>
+                ///     Maximum Kafka protocol request message size.
+                ///
+                ///     default: 1000000
+                ///     importance: medium
+                /// </summary>
+                public const string MessageMaxBytes = "message.max.bytes";
+
+                /// <summary>
+                ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+                ///
+                ///     default: 65535
+                ///     importance: low
+                /// </summary>
+                public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+
+                /// <summary>
+                ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+                ///
+                ///     default: 100000000
+                ///     importance: medium
+                /// </summary>
+                public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+
+                /// <summary>
+                ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+                ///
+                ///     default: 1000000
+                ///     importance: low
+                /// </summary>
+                public const string MaxInFlight = "max.in.flight";
+
+                /// <summary>
+                ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+
+                /// <summary>
+                ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+                ///
+                ///     default: 300000
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+
+                /// <summary>
+                ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+                ///
+                ///     default: 900000
+                ///     importance: low
+                /// </summary>
+                public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+
+                /// <summary>
+                ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+                ///
+                ///     default: 250
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+
+                /// <summary>
+                ///     Sparse metadata requests (consumes less network bandwidth)
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+
+                /// <summary>
+                ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string TopicBlacklist = "topic.blacklist";
+
+                /// <summary>
+                ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+                ///
+                ///     default: ''
+                ///     importance: medium
+                /// </summary>
+                public const string Debug = "debug";
+
+                /// <summary>
+                ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string SocketTimeoutMs = "socket.timeout.ms";
+
+                /// <summary>
+                ///     Broker socket send buffer size. System default is used if 0.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+
+                /// <summary>
+                ///     Broker socket receive buffer size. System default is used if 0.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+
+                /// <summary>
+                ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+
+                /// <summary>
+                ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string SocketNagleDisable = "socket.nagle.disable";
+
+                /// <summary>
+                ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+                ///
+                ///     default: 1
+                ///     importance: low
+                /// </summary>
+                public const string SocketMaxFails = "socket.max.fails";
+
+                /// <summary>
+                ///     How long to cache the broker address resolving results (milliseconds).
+                ///
+                ///     default: 1000
+                ///     importance: low
+                /// </summary>
+                public const string BrokerAddressTtl = "broker.address.ttl";
+
+                /// <summary>
+                ///     Allowed broker IP address families: any, v4, v6
+                ///
+                ///     default: any
+                ///     importance: low
+                /// </summary>
+                public const string BrokerAddressFamily = "broker.address.family";
+
+                /// <summary>
+                ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+                ///
+                ///     default: 100
+                ///     importance: medium
+                /// </summary>
+                public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+
+                /// <summary>
+                ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+                ///
+                ///     default: 10000
+                ///     importance: medium
+                /// </summary>
+                public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+
+                /// <summary>
+                ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+                ///
+                ///     default: 0
+                ///     importance: high
+                /// </summary>
+                public const string StatisticsIntervalMs = "statistics.interval.ms";
+
+                /// <summary>
+                ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string LogQueue = "log.queue";
+
+                /// <summary>
+                ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string LogThreadName = "log.thread.name";
+
+                /// <summary>
+                ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string LogConnectionClose = "log.connection.close";
+
+                /// <summary>
+                ///     Application opaque (set with rd_kafka_conf_set_opaque())
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string Opaque = "opaque";
+
+                /// <summary>
+                ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string InternalTerminationSignal = "internal.termination.signal";
+
+                /// <summary>
+                ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+                ///
+                ///     default: true
+                ///     importance: high
+                /// </summary>
+                public const string ApiVersionRequest = "api.version.request";
+
+                /// <summary>
+                ///     Timeout for broker API version requests.
+                ///
+                ///     default: 10000
+                ///     importance: low
+                /// </summary>
+                public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+
+                /// <summary>
+                ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+                ///
+                ///     default: 0
+                ///     importance: medium
+                /// </summary>
+                public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+
+                /// <summary>
+                ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+                ///
+                ///     default: 0.10.0
+                ///     importance: medium
+                /// </summary>
+                public const string BrokerVersionFallback = "broker.version.fallback";
+
+                /// <summary>
+                ///     Protocol used to communicate with brokers.
+                ///
+                ///     default: plaintext
+                ///     importance: high
+                /// </summary>
+                public const string SecurityProtocol = "security.protocol";
+
+                /// <summary>
+                ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCipherSuites = "ssl.cipher.suites";
+
+                /// <summary>
+                ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCurvesList = "ssl.curves.list";
+
+                /// <summary>
+                ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslSigalgsList = "ssl.sigalgs.list";
+
+                /// <summary>
+                ///     Path to client's private key (PEM) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeyLocation = "ssl.key.location";
+
+                /// <summary>
+                ///     Private key passphrase
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeyPassword = "ssl.key.password";
+
+                /// <summary>
+                ///     Path to client's public key (PEM) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCertificateLocation = "ssl.certificate.location";
+
+                /// <summary>
+                ///     File or directory path to CA certificate(s) for verifying the broker's key.
+                ///
+                ///     default: ''
+                ///     importance: medium
+                /// </summary>
+                public const string SslCaLocation = "ssl.ca.location";
+
+                /// <summary>
+                ///     Path to CRL for verifying broker's certificate validity.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCrlLocation = "ssl.crl.location";
+
+                /// <summary>
+                ///     Path to client's keystore (PKCS#12) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeystoreLocation = "ssl.keystore.location";
+
+                /// <summary>
+                ///     Client's keystore (PKCS#12) password.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeystorePassword = "ssl.keystore.password";
+
+                /// <summary>
+                ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+                ///
+                ///     default: kafka
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+
+                /// <summary>
+                ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+                ///
+                ///     default: kafkaclient
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+
+                /// <summary>
+                ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+                ///
+                ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+
+                /// <summary>
+                ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+
+                /// <summary>
+                ///     Minimum time in milliseconds between key refresh attempts.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+
+                /// <summary>
+                ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string SaslUsername = "sasl.username";
+
+                /// <summary>
+                ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string SaslPassword = "sasl.password";
+
+                /// <summary>
+                ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string PluginLibraryPaths = "plugin.library.paths";
+
+                /// <summary>
+                ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string Interceptors = "interceptors";
+
+                /// <summary>
+                ///     When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.
+                ///
+                ///     default: false
+                ///     importance: high
+                /// </summary>
+                public const string EnableIdempotence = "enable.idempotence";
+
+                /// <summary>
+                ///     **EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string EnableGaplessGuarantee = "enable.gapless.guarantee";
+
+                /// <summary>
+                ///     Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
+                ///
+                ///     default: 100000
+                ///     importance: high
+                /// </summary>
+                public const string QueueBufferingMaxMessages = "queue.buffering.max.messages";
+
+                /// <summary>
+                ///     Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.
+                ///
+                ///     default: 1048576
+                ///     importance: high
+                /// </summary>
+                public const string QueueBufferingMaxKbytes = "queue.buffering.max.kbytes";
+
+                /// <summary>
+                ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
+                ///
+                ///     default: 0
+                ///     importance: high
+                /// </summary>
+                public const string LingerMs = "linger.ms";
+
+                /// <summary>
+                ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
+                ///
+                ///     default: 2
+                ///     importance: high
+                /// </summary>
+                public const string MessageSendMaxRetries = "message.send.max.retries";
+
+                /// <summary>
+                ///     The backoff time in milliseconds before retrying a protocol request.
+                ///
+                ///     default: 100
+                ///     importance: medium
+                /// </summary>
+                public const string RetryBackoffMs = "retry.backoff.ms";
+
+                /// <summary>
+                ///     The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.
+                ///
+                ///     default: 1
+                ///     importance: low
+                /// </summary>
+                public const string QueueBufferingBackpressureThreshold = "queue.buffering.backpressure.threshold";
+
+                /// <summary>
+                ///     compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
+                ///
+                ///     default: none
+                ///     importance: medium
+                /// </summary>
+                public const string CompressionType = "compression.type";
+
+                /// <summary>
+                ///     Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by message.max.bytes.
+                ///
+                ///     default: 10000
+                ///     importance: medium
+                /// </summary>
+                public const string BatchNumMessages = "batch.num.messages";
+
+            }
+
+            /// <summary>
+            ///     A reference to the configuration key names for Admin
+            /// </summary>
+            public static class Admin
+            {
+                /// <summary>
+                ///     Client identifier.
+                ///
+                ///     default: rdkafka
+                ///     importance: low
+                /// </summary>
+                public const string ClientId = "client.id";
+
+                /// <summary>
+                ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string BootstrapServers = "bootstrap.servers";
+
+                /// <summary>
+                ///     Maximum Kafka protocol request message size.
+                ///
+                ///     default: 1000000
+                ///     importance: medium
+                /// </summary>
+                public const string MessageMaxBytes = "message.max.bytes";
+
+                /// <summary>
+                ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+                ///
+                ///     default: 65535
+                ///     importance: low
+                /// </summary>
+                public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+
+                /// <summary>
+                ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+                ///
+                ///     default: 100000000
+                ///     importance: medium
+                /// </summary>
+                public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+
+                /// <summary>
+                ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+                ///
+                ///     default: 1000000
+                ///     importance: low
+                /// </summary>
+                public const string MaxInFlight = "max.in.flight";
+
+                /// <summary>
+                ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+
+                /// <summary>
+                ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+                ///
+                ///     default: 300000
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+
+                /// <summary>
+                ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+                ///
+                ///     default: 900000
+                ///     importance: low
+                /// </summary>
+                public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+
+                /// <summary>
+                ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+                ///
+                ///     default: 250
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+
+                /// <summary>
+                ///     Sparse metadata requests (consumes less network bandwidth)
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+
+                /// <summary>
+                ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string TopicBlacklist = "topic.blacklist";
+
+                /// <summary>
+                ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+                ///
+                ///     default: ''
+                ///     importance: medium
+                /// </summary>
+                public const string Debug = "debug";
+
+                /// <summary>
+                ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string SocketTimeoutMs = "socket.timeout.ms";
+
+                /// <summary>
+                ///     Broker socket send buffer size. System default is used if 0.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+
+                /// <summary>
+                ///     Broker socket receive buffer size. System default is used if 0.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+
+                /// <summary>
+                ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+
+                /// <summary>
+                ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string SocketNagleDisable = "socket.nagle.disable";
+
+                /// <summary>
+                ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+                ///
+                ///     default: 1
+                ///     importance: low
+                /// </summary>
+                public const string SocketMaxFails = "socket.max.fails";
+
+                /// <summary>
+                ///     How long to cache the broker address resolving results (milliseconds).
+                ///
+                ///     default: 1000
+                ///     importance: low
+                /// </summary>
+                public const string BrokerAddressTtl = "broker.address.ttl";
+
+                /// <summary>
+                ///     Allowed broker IP address families: any, v4, v6
+                ///
+                ///     default: any
+                ///     importance: low
+                /// </summary>
+                public const string BrokerAddressFamily = "broker.address.family";
+
+                /// <summary>
+                ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+                ///
+                ///     default: 100
+                ///     importance: medium
+                /// </summary>
+                public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+
+                /// <summary>
+                ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+                ///
+                ///     default: 10000
+                ///     importance: medium
+                /// </summary>
+                public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+
+                /// <summary>
+                ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+                ///
+                ///     default: 0
+                ///     importance: high
+                /// </summary>
+                public const string StatisticsIntervalMs = "statistics.interval.ms";
+
+                /// <summary>
+                ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+                ///
+                ///     default: false
+                ///     importance: low
+                /// </summary>
+                public const string LogQueue = "log.queue";
+
+                /// <summary>
+                ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string LogThreadName = "log.thread.name";
+
+                /// <summary>
+                ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+                ///
+                ///     default: true
+                ///     importance: low
+                /// </summary>
+                public const string LogConnectionClose = "log.connection.close";
+
+                /// <summary>
+                ///     Application opaque (set with rd_kafka_conf_set_opaque())
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string Opaque = "opaque";
+
+                /// <summary>
+                ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+                ///
+                ///     default: 0
+                ///     importance: low
+                /// </summary>
+                public const string InternalTerminationSignal = "internal.termination.signal";
+
+                /// <summary>
+                ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+                ///
+                ///     default: true
+                ///     importance: high
+                /// </summary>
+                public const string ApiVersionRequest = "api.version.request";
+
+                /// <summary>
+                ///     Timeout for broker API version requests.
+                ///
+                ///     default: 10000
+                ///     importance: low
+                /// </summary>
+                public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+
+                /// <summary>
+                ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+                ///
+                ///     default: 0
+                ///     importance: medium
+                /// </summary>
+                public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+
+                /// <summary>
+                ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+                ///
+                ///     default: 0.10.0
+                ///     importance: medium
+                /// </summary>
+                public const string BrokerVersionFallback = "broker.version.fallback";
+
+                /// <summary>
+                ///     Protocol used to communicate with brokers.
+                ///
+                ///     default: plaintext
+                ///     importance: high
+                /// </summary>
+                public const string SecurityProtocol = "security.protocol";
+
+                /// <summary>
+                ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCipherSuites = "ssl.cipher.suites";
+
+                /// <summary>
+                ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCurvesList = "ssl.curves.list";
+
+                /// <summary>
+                ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslSigalgsList = "ssl.sigalgs.list";
+
+                /// <summary>
+                ///     Path to client's private key (PEM) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeyLocation = "ssl.key.location";
+
+                /// <summary>
+                ///     Private key passphrase
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeyPassword = "ssl.key.password";
+
+                /// <summary>
+                ///     Path to client's public key (PEM) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCertificateLocation = "ssl.certificate.location";
+
+                /// <summary>
+                ///     File or directory path to CA certificate(s) for verifying the broker's key.
+                ///
+                ///     default: ''
+                ///     importance: medium
+                /// </summary>
+                public const string SslCaLocation = "ssl.ca.location";
+
+                /// <summary>
+                ///     Path to CRL for verifying broker's certificate validity.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslCrlLocation = "ssl.crl.location";
+
+                /// <summary>
+                ///     Path to client's keystore (PKCS#12) used for authentication.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeystoreLocation = "ssl.keystore.location";
+
+                /// <summary>
+                ///     Client's keystore (PKCS#12) password.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SslKeystorePassword = "ssl.keystore.password";
+
+                /// <summary>
+                ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+                ///
+                ///     default: kafka
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+
+                /// <summary>
+                ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+                ///
+                ///     default: kafkaclient
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+
+                /// <summary>
+                ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+                ///
+                ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+
+                /// <summary>
+                ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+
+                /// <summary>
+                ///     Minimum time in milliseconds between key refresh attempts.
+                ///
+                ///     default: 60000
+                ///     importance: low
+                /// </summary>
+                public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+
+                /// <summary>
+                ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string SaslUsername = "sasl.username";
+
+                /// <summary>
+                ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+                ///
+                ///     default: ''
+                ///     importance: high
+                /// </summary>
+                public const string SaslPassword = "sasl.password";
+
+                /// <summary>
+                ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string PluginLibraryPaths = "plugin.library.paths";
+
+                /// <summary>
+                ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+                ///
+                ///     default: ''
+                ///     importance: low
+                /// </summary>
+                public const string Interceptors = "interceptors";
+
+            }
         }
     }
 

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -229,7 +229,7 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name="configSource"></param>
         /// <returns></returns>
-        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+        public static new ClientConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new ClientConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
 
         /// <summary>
         ///     Initialize a new empty <see cref="ClientConfig" /> instance.
@@ -729,7 +729,7 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name="configSource"></param>
         /// <returns></returns>
-        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+        public static new AdminClientConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new AdminClientConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
 
         /// <summary>
         ///     Initialize a new empty <see cref="AdminClientConfig" /> instance.
@@ -764,7 +764,7 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name="configSource"></param>
         /// <returns></returns>
-        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+        public static new ProducerConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new ProducerConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
 
         /// <summary>
         ///     Initialize a new empty <see cref="ProducerConfig" /> instance.
@@ -944,7 +944,7 @@ namespace Confluent.Kafka
         /// </summary>
         /// <param name="configSource"></param>
         /// <returns></returns>
-        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+        public static new ConsumerConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new ConsumerConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
 
         /// <summary>
         ///     Initialize a new empty <see cref="ConsumerConfig" /> instance.

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -224,6 +224,29 @@ namespace Confluent.Kafka
     {
 
         /// <summary>
+        ///     Initialize a new empty <see cref="ClientConfig" /> instance.
+        /// </summary>
+        public ClientConfig() { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ClientConfig" /> instance based on
+        ///     an existing <see cref="ClientConfig" /> instance.
+        /// </summary>
+        public ClientConfig(ClientConfig config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ClientConfig" /> instance based on
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ClientConfig" /> wrapping
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public ClientConfig(IDictionary<string, string> config) : base(config) { }
+
+        /// <summary>
         ///     SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism.
         /// </summary>
         public SaslMechanism? SaslMechanism
@@ -695,22 +718,29 @@ namespace Confluent.Kafka
     /// </summary>
     public class AdminClientConfig : ClientConfig
     {
+
         /// <summary>
         ///     Initialize a new empty <see cref="AdminClientConfig" /> instance.
         /// </summary>
-        public AdminClientConfig() {}
+        public AdminClientConfig() { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance based on
         ///     an existing <see cref="ClientConfig" /> instance.
         /// </summary>
-        public AdminClientConfig(ClientConfig config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public AdminClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance based on
         ///     an existing key/value pair collection.
         /// </summary>
-        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="AdminClientConfig" /> wrapping
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public AdminClientConfig(IDictionary<string, string> config) : base(config) { }
     }
 
 
@@ -719,22 +749,29 @@ namespace Confluent.Kafka
     /// </summary>
     public class ProducerConfig : ClientConfig
     {
+
         /// <summary>
         ///     Initialize a new empty <see cref="ProducerConfig" /> instance.
         /// </summary>
-        public ProducerConfig() {}
+        public ProducerConfig() { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance based on
         ///     an existing <see cref="ClientConfig" /> instance.
         /// </summary>
-        public ProducerConfig(ClientConfig config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public ProducerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance based on
         ///     an existing key/value pair collection.
         /// </summary>
-        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ProducerConfig" /> wrapping
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public ProducerConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Specifies whether or not the producer should start a background poll 
@@ -888,22 +925,29 @@ namespace Confluent.Kafka
     /// </summary>
     public class ConsumerConfig : ClientConfig
     {
+
         /// <summary>
         ///     Initialize a new empty <see cref="ConsumerConfig" /> instance.
         /// </summary>
-        public ConsumerConfig() {}
+        public ConsumerConfig() { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance based on
         ///     an existing <see cref="ClientConfig" /> instance.
         /// </summary>
-        public ConsumerConfig(ClientConfig config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public ConsumerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance based on
         ///     an existing key/value pair collection.
         /// </summary>
-        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) { this.properties = new Dictionary<string, string>(config.ToDictionary(a => a.Key, a => a.Value)); }
+        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ConsumerConfig" /> wrapping
+        ///     an existing key/value pair collection.
+        /// </summary>
+        public ConsumerConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     A comma separated list of fields that may be optionally set

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -217,7 +217,10 @@ namespace Confluent.Kafka
         All = -1
     }
 
-    public partial class Config
+    /// <summary>
+    ///     A reference to the key names for Consumer specific configuration properties.
+    /// </summary>
+    public partial class ConsumerConfig
     {
         /// <summary>
         ///     A reference to the configuration key names
@@ -225,1576 +228,1582 @@ namespace Confluent.Kafka
         public static partial class PropertyNames
         {
             /// <summary>
-            ///     A reference to the key names for Consumer specific configuration properties.
+            ///     Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
+            ///
+            ///     default: largest
+            ///     importance: high
             /// </summary>
-            public static partial class Consumer
-            {
-                /// <summary>
-                ///     Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
-                ///
-                ///     default: largest
-                ///     importance: high
-                /// </summary>
-                public const string AutoOffsetReset = "auto.offset.reset";
-
-                /// <summary>
-                ///     Client identifier.
-                ///
-                ///     default: rdkafka
-                ///     importance: low
-                /// </summary>
-                public const string ClientId = "client.id";
-
-                /// <summary>
-                ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string BootstrapServers = "bootstrap.servers";
-
-                /// <summary>
-                ///     Maximum Kafka protocol request message size.
-                ///
-                ///     default: 1000000
-                ///     importance: medium
-                /// </summary>
-                public const string MessageMaxBytes = "message.max.bytes";
-
-                /// <summary>
-                ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
-                ///
-                ///     default: 65535
-                ///     importance: low
-                /// </summary>
-                public const string MessageCopyMaxBytes = "message.copy.max.bytes";
-
-                /// <summary>
-                ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
-                ///
-                ///     default: 100000000
-                ///     importance: medium
-                /// </summary>
-                public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
-
-                /// <summary>
-                ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
-                ///
-                ///     default: 1000000
-                ///     importance: low
-                /// </summary>
-                public const string MaxInFlight = "max.in.flight";
-
-                /// <summary>
-                ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
-
-                /// <summary>
-                ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
-                ///
-                ///     default: 300000
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
-
-                /// <summary>
-                ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
-                ///
-                ///     default: 900000
-                ///     importance: low
-                /// </summary>
-                public const string MetadataMaxAgeMs = "metadata.max.age.ms";
-
-                /// <summary>
-                ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
-                ///
-                ///     default: 250
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
-
-                /// <summary>
-                ///     Sparse metadata requests (consumes less network bandwidth)
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
-
-                /// <summary>
-                ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string TopicBlacklist = "topic.blacklist";
-
-                /// <summary>
-                ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
-                ///
-                ///     default: ''
-                ///     importance: medium
-                /// </summary>
-                public const string Debug = "debug";
-
-                /// <summary>
-                ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string SocketTimeoutMs = "socket.timeout.ms";
-
-                /// <summary>
-                ///     Broker socket send buffer size. System default is used if 0.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
-
-                /// <summary>
-                ///     Broker socket receive buffer size. System default is used if 0.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
-
-                /// <summary>
-                ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string SocketKeepaliveEnable = "socket.keepalive.enable";
-
-                /// <summary>
-                ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string SocketNagleDisable = "socket.nagle.disable";
-
-                /// <summary>
-                ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
-                ///
-                ///     default: 1
-                ///     importance: low
-                /// </summary>
-                public const string SocketMaxFails = "socket.max.fails";
-
-                /// <summary>
-                ///     How long to cache the broker address resolving results (milliseconds).
-                ///
-                ///     default: 1000
-                ///     importance: low
-                /// </summary>
-                public const string BrokerAddressTtl = "broker.address.ttl";
-
-                /// <summary>
-                ///     Allowed broker IP address families: any, v4, v6
-                ///
-                ///     default: any
-                ///     importance: low
-                /// </summary>
-                public const string BrokerAddressFamily = "broker.address.family";
-
-                /// <summary>
-                ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
-                ///
-                ///     default: 100
-                ///     importance: medium
-                /// </summary>
-                public const string ReconnectBackoffMs = "reconnect.backoff.ms";
-
-                /// <summary>
-                ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
-                ///
-                ///     default: 10000
-                ///     importance: medium
-                /// </summary>
-                public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
-
-                /// <summary>
-                ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
-                ///
-                ///     default: 0
-                ///     importance: high
-                /// </summary>
-                public const string StatisticsIntervalMs = "statistics.interval.ms";
-
-                /// <summary>
-                ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string LogQueue = "log.queue";
-
-                /// <summary>
-                ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string LogThreadName = "log.thread.name";
-
-                /// <summary>
-                ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string LogConnectionClose = "log.connection.close";
-
-                /// <summary>
-                ///     Application opaque (set with rd_kafka_conf_set_opaque())
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string Opaque = "opaque";
-
-                /// <summary>
-                ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string InternalTerminationSignal = "internal.termination.signal";
-
-                /// <summary>
-                ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
-                ///
-                ///     default: true
-                ///     importance: high
-                /// </summary>
-                public const string ApiVersionRequest = "api.version.request";
-
-                /// <summary>
-                ///     Timeout for broker API version requests.
-                ///
-                ///     default: 10000
-                ///     importance: low
-                /// </summary>
-                public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
-
-                /// <summary>
-                ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
-                ///
-                ///     default: 0
-                ///     importance: medium
-                /// </summary>
-                public const string ApiVersionFallbackMs = "api.version.fallback.ms";
-
-                /// <summary>
-                ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
-                ///
-                ///     default: 0.10.0
-                ///     importance: medium
-                /// </summary>
-                public const string BrokerVersionFallback = "broker.version.fallback";
-
-                /// <summary>
-                ///     Protocol used to communicate with brokers.
-                ///
-                ///     default: plaintext
-                ///     importance: high
-                /// </summary>
-                public const string SecurityProtocol = "security.protocol";
-
-                /// <summary>
-                ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCipherSuites = "ssl.cipher.suites";
-
-                /// <summary>
-                ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCurvesList = "ssl.curves.list";
-
-                /// <summary>
-                ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslSigalgsList = "ssl.sigalgs.list";
-
-                /// <summary>
-                ///     Path to client's private key (PEM) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeyLocation = "ssl.key.location";
-
-                /// <summary>
-                ///     Private key passphrase
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeyPassword = "ssl.key.password";
-
-                /// <summary>
-                ///     Path to client's public key (PEM) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCertificateLocation = "ssl.certificate.location";
-
-                /// <summary>
-                ///     File or directory path to CA certificate(s) for verifying the broker's key.
-                ///
-                ///     default: ''
-                ///     importance: medium
-                /// </summary>
-                public const string SslCaLocation = "ssl.ca.location";
-
-                /// <summary>
-                ///     Path to CRL for verifying broker's certificate validity.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCrlLocation = "ssl.crl.location";
-
-                /// <summary>
-                ///     Path to client's keystore (PKCS#12) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeystoreLocation = "ssl.keystore.location";
-
-                /// <summary>
-                ///     Client's keystore (PKCS#12) password.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeystorePassword = "ssl.keystore.password";
-
-                /// <summary>
-                ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
-                ///
-                ///     default: kafka
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
-
-                /// <summary>
-                ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
-                ///
-                ///     default: kafkaclient
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
-
-                /// <summary>
-                ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
-                ///
-                ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
-
-                /// <summary>
-                ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
-
-                /// <summary>
-                ///     Minimum time in milliseconds between key refresh attempts.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
-
-                /// <summary>
-                ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string SaslUsername = "sasl.username";
-
-                /// <summary>
-                ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string SaslPassword = "sasl.password";
-
-                /// <summary>
-                ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string PluginLibraryPaths = "plugin.library.paths";
-
-                /// <summary>
-                ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string Interceptors = "interceptors";
-
-                /// <summary>
-                ///     Client group id string. All clients sharing the same group.id belong to the same group.
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string GroupId = "group.id";
-
-                /// <summary>
-                ///     Name of partition assignment strategy to use when elected group leader assigns partitions to group members.
-                ///
-                ///     default: range,roundrobin
-                ///     importance: medium
-                /// </summary>
-                public const string PartitionAssignmentStrategy = "partition.assignment.strategy";
-
-                /// <summary>
-                ///     Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
-                ///
-                ///     default: 10000
-                ///     importance: high
-                /// </summary>
-                public const string SessionTimeoutMs = "session.timeout.ms";
-
-                /// <summary>
-                ///     Group session keepalive heartbeat interval.
-                ///
-                ///     default: 3000
-                ///     importance: low
-                /// </summary>
-                public const string HeartbeatIntervalMs = "heartbeat.interval.ms";
-
-                /// <summary>
-                ///     Group protocol type
-                ///
-                ///     default: consumer
-                ///     importance: low
-                /// </summary>
-                public const string GroupProtocolType = "group.protocol.type";
-
-                /// <summary>
-                ///     How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.
-                ///
-                ///     default: 600000
-                ///     importance: low
-                /// </summary>
-                public const string CoordinatorQueryIntervalMs = "coordinator.query.interval.ms";
-
-                /// <summary>
-                ///     Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.
-                ///
-                ///     default: 300000
-                ///     importance: high
-                /// </summary>
-                public const string MaxPollIntervalMs = "max.poll.interval.ms";
-
-                /// <summary>
-                ///     Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().
-                ///
-                ///     default: true
-                ///     importance: high
-                /// </summary>
-                public const string EnableAutoCommit = "enable.auto.commit";
-
-                /// <summary>
-                ///     The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.
-                ///
-                ///     default: 5000
-                ///     importance: medium
-                /// </summary>
-                public const string AutoCommitIntervalMs = "auto.commit.interval.ms";
-
-                /// <summary>
-                ///     Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
-                ///
-                ///     default: true
-                ///     importance: high
-                /// </summary>
-                public const string EnableAutoOffsetStore = "enable.auto.offset.store";
-
-                /// <summary>
-                ///     Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.
-                ///
-                ///     default: 100000
-                ///     importance: medium
-                /// </summary>
-                public const string QueuedMinMessages = "queued.min.messages";
-
-                /// <summary>
-                ///     Maximum number of kilobytes per topic+partition in the local consumer queue. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.
-                ///
-                ///     default: 1048576
-                ///     importance: medium
-                /// </summary>
-                public const string QueuedMaxMessagesKbytes = "queued.max.messages.kbytes";
-
-                /// <summary>
-                ///     Maximum time the broker may wait to fill the response with fetch.min.bytes.
-                ///
-                ///     default: 100
-                ///     importance: low
-                /// </summary>
-                public const string FetchWaitMaxMs = "fetch.wait.max.ms";
-
-                /// <summary>
-                ///     Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
-                ///
-                ///     default: 1048576
-                ///     importance: medium
-                /// </summary>
-                public const string MaxPartitionFetchBytes = "max.partition.fetch.bytes";
-
-                /// <summary>
-                ///     Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).
-                ///
-                ///     default: 52428800
-                ///     importance: medium
-                /// </summary>
-                public const string FetchMaxBytes = "fetch.max.bytes";
-
-                /// <summary>
-                ///     Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.
-                ///
-                ///     default: 1
-                ///     importance: low
-                /// </summary>
-                public const string FetchMinBytes = "fetch.min.bytes";
-
-                /// <summary>
-                ///     How long to postpone the next fetch request for a topic+partition in case of a fetch error.
-                ///
-                ///     default: 500
-                ///     importance: medium
-                /// </summary>
-                public const string FetchErrorBackoffMs = "fetch.error.backoff.ms";
-
-                /// <summary>
-                ///     Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string EnablePartitionEof = "enable.partition.eof";
-
-                /// <summary>
-                ///     Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.
-                ///
-                ///     default: false
-                ///     importance: medium
-                /// </summary>
-                public const string CheckCrcs = "check.crcs";
-
-            }
+            public const string AutoOffsetReset = "auto.offset.reset";
 
             /// <summary>
-            ///     A reference to the key names for Producer specific configuration properties.
+            ///     Client identifier.
+            ///
+            ///     default: rdkafka
+            ///     importance: low
             /// </summary>
-            public static partial class Producer
-            {
-                /// <summary>
-                ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
-                ///
-                ///     default: 5000
-                ///     importance: medium
-                /// </summary>
-                public const string RequestTimeoutMs = "request.timeout.ms";
-
-                /// <summary>
-                ///     Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
-                ///
-                ///     default: 300000
-                ///     importance: high
-                /// </summary>
-                public const string MessageTimeoutMs = "message.timeout.ms";
-
-                /// <summary>
-                ///     Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.).
-                ///
-                ///     default: consistent_random
-                ///     importance: high
-                /// </summary>
-                public const string Partitioner = "partitioner";
-
-                /// <summary>
-                ///     Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
-                ///
-                ///     default: -1
-                ///     importance: medium
-                /// </summary>
-                public const string CompressionLevel = "compression.level";
-
-                /// <summary>
-                ///     Client identifier.
-                ///
-                ///     default: rdkafka
-                ///     importance: low
-                /// </summary>
-                public const string ClientId = "client.id";
-
-                /// <summary>
-                ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string BootstrapServers = "bootstrap.servers";
-
-                /// <summary>
-                ///     Maximum Kafka protocol request message size.
-                ///
-                ///     default: 1000000
-                ///     importance: medium
-                /// </summary>
-                public const string MessageMaxBytes = "message.max.bytes";
-
-                /// <summary>
-                ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
-                ///
-                ///     default: 65535
-                ///     importance: low
-                /// </summary>
-                public const string MessageCopyMaxBytes = "message.copy.max.bytes";
-
-                /// <summary>
-                ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
-                ///
-                ///     default: 100000000
-                ///     importance: medium
-                /// </summary>
-                public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
-
-                /// <summary>
-                ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
-                ///
-                ///     default: 1000000
-                ///     importance: low
-                /// </summary>
-                public const string MaxInFlight = "max.in.flight";
-
-                /// <summary>
-                ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
-
-                /// <summary>
-                ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
-                ///
-                ///     default: 300000
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
-
-                /// <summary>
-                ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
-                ///
-                ///     default: 900000
-                ///     importance: low
-                /// </summary>
-                public const string MetadataMaxAgeMs = "metadata.max.age.ms";
-
-                /// <summary>
-                ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
-                ///
-                ///     default: 250
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
-
-                /// <summary>
-                ///     Sparse metadata requests (consumes less network bandwidth)
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
-
-                /// <summary>
-                ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string TopicBlacklist = "topic.blacklist";
-
-                /// <summary>
-                ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
-                ///
-                ///     default: ''
-                ///     importance: medium
-                /// </summary>
-                public const string Debug = "debug";
-
-                /// <summary>
-                ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string SocketTimeoutMs = "socket.timeout.ms";
-
-                /// <summary>
-                ///     Broker socket send buffer size. System default is used if 0.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
-
-                /// <summary>
-                ///     Broker socket receive buffer size. System default is used if 0.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
-
-                /// <summary>
-                ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string SocketKeepaliveEnable = "socket.keepalive.enable";
-
-                /// <summary>
-                ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string SocketNagleDisable = "socket.nagle.disable";
-
-                /// <summary>
-                ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
-                ///
-                ///     default: 1
-                ///     importance: low
-                /// </summary>
-                public const string SocketMaxFails = "socket.max.fails";
-
-                /// <summary>
-                ///     How long to cache the broker address resolving results (milliseconds).
-                ///
-                ///     default: 1000
-                ///     importance: low
-                /// </summary>
-                public const string BrokerAddressTtl = "broker.address.ttl";
-
-                /// <summary>
-                ///     Allowed broker IP address families: any, v4, v6
-                ///
-                ///     default: any
-                ///     importance: low
-                /// </summary>
-                public const string BrokerAddressFamily = "broker.address.family";
-
-                /// <summary>
-                ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
-                ///
-                ///     default: 100
-                ///     importance: medium
-                /// </summary>
-                public const string ReconnectBackoffMs = "reconnect.backoff.ms";
-
-                /// <summary>
-                ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
-                ///
-                ///     default: 10000
-                ///     importance: medium
-                /// </summary>
-                public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
-
-                /// <summary>
-                ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
-                ///
-                ///     default: 0
-                ///     importance: high
-                /// </summary>
-                public const string StatisticsIntervalMs = "statistics.interval.ms";
-
-                /// <summary>
-                ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string LogQueue = "log.queue";
-
-                /// <summary>
-                ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string LogThreadName = "log.thread.name";
-
-                /// <summary>
-                ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string LogConnectionClose = "log.connection.close";
-
-                /// <summary>
-                ///     Application opaque (set with rd_kafka_conf_set_opaque())
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string Opaque = "opaque";
-
-                /// <summary>
-                ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string InternalTerminationSignal = "internal.termination.signal";
-
-                /// <summary>
-                ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
-                ///
-                ///     default: true
-                ///     importance: high
-                /// </summary>
-                public const string ApiVersionRequest = "api.version.request";
-
-                /// <summary>
-                ///     Timeout for broker API version requests.
-                ///
-                ///     default: 10000
-                ///     importance: low
-                /// </summary>
-                public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
-
-                /// <summary>
-                ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
-                ///
-                ///     default: 0
-                ///     importance: medium
-                /// </summary>
-                public const string ApiVersionFallbackMs = "api.version.fallback.ms";
-
-                /// <summary>
-                ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
-                ///
-                ///     default: 0.10.0
-                ///     importance: medium
-                /// </summary>
-                public const string BrokerVersionFallback = "broker.version.fallback";
-
-                /// <summary>
-                ///     Protocol used to communicate with brokers.
-                ///
-                ///     default: plaintext
-                ///     importance: high
-                /// </summary>
-                public const string SecurityProtocol = "security.protocol";
-
-                /// <summary>
-                ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCipherSuites = "ssl.cipher.suites";
-
-                /// <summary>
-                ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCurvesList = "ssl.curves.list";
-
-                /// <summary>
-                ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslSigalgsList = "ssl.sigalgs.list";
-
-                /// <summary>
-                ///     Path to client's private key (PEM) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeyLocation = "ssl.key.location";
-
-                /// <summary>
-                ///     Private key passphrase
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeyPassword = "ssl.key.password";
-
-                /// <summary>
-                ///     Path to client's public key (PEM) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCertificateLocation = "ssl.certificate.location";
-
-                /// <summary>
-                ///     File or directory path to CA certificate(s) for verifying the broker's key.
-                ///
-                ///     default: ''
-                ///     importance: medium
-                /// </summary>
-                public const string SslCaLocation = "ssl.ca.location";
-
-                /// <summary>
-                ///     Path to CRL for verifying broker's certificate validity.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCrlLocation = "ssl.crl.location";
-
-                /// <summary>
-                ///     Path to client's keystore (PKCS#12) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeystoreLocation = "ssl.keystore.location";
-
-                /// <summary>
-                ///     Client's keystore (PKCS#12) password.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeystorePassword = "ssl.keystore.password";
-
-                /// <summary>
-                ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
-                ///
-                ///     default: kafka
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
-
-                /// <summary>
-                ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
-                ///
-                ///     default: kafkaclient
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
-
-                /// <summary>
-                ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
-                ///
-                ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
-
-                /// <summary>
-                ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
-
-                /// <summary>
-                ///     Minimum time in milliseconds between key refresh attempts.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
-
-                /// <summary>
-                ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string SaslUsername = "sasl.username";
-
-                /// <summary>
-                ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string SaslPassword = "sasl.password";
-
-                /// <summary>
-                ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string PluginLibraryPaths = "plugin.library.paths";
-
-                /// <summary>
-                ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string Interceptors = "interceptors";
-
-                /// <summary>
-                ///     When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.
-                ///
-                ///     default: false
-                ///     importance: high
-                /// </summary>
-                public const string EnableIdempotence = "enable.idempotence";
-
-                /// <summary>
-                ///     **EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string EnableGaplessGuarantee = "enable.gapless.guarantee";
-
-                /// <summary>
-                ///     Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
-                ///
-                ///     default: 100000
-                ///     importance: high
-                /// </summary>
-                public const string QueueBufferingMaxMessages = "queue.buffering.max.messages";
-
-                /// <summary>
-                ///     Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.
-                ///
-                ///     default: 1048576
-                ///     importance: high
-                /// </summary>
-                public const string QueueBufferingMaxKbytes = "queue.buffering.max.kbytes";
-
-                /// <summary>
-                ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
-                ///
-                ///     default: 0
-                ///     importance: high
-                /// </summary>
-                public const string LingerMs = "linger.ms";
-
-                /// <summary>
-                ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
-                ///
-                ///     default: 2
-                ///     importance: high
-                /// </summary>
-                public const string MessageSendMaxRetries = "message.send.max.retries";
-
-                /// <summary>
-                ///     The backoff time in milliseconds before retrying a protocol request.
-                ///
-                ///     default: 100
-                ///     importance: medium
-                /// </summary>
-                public const string RetryBackoffMs = "retry.backoff.ms";
-
-                /// <summary>
-                ///     The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.
-                ///
-                ///     default: 1
-                ///     importance: low
-                /// </summary>
-                public const string QueueBufferingBackpressureThreshold = "queue.buffering.backpressure.threshold";
-
-                /// <summary>
-                ///     compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
-                ///
-                ///     default: none
-                ///     importance: medium
-                /// </summary>
-                public const string CompressionType = "compression.type";
-
-                /// <summary>
-                ///     Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by message.max.bytes.
-                ///
-                ///     default: 10000
-                ///     importance: medium
-                /// </summary>
-                public const string BatchNumMessages = "batch.num.messages";
-
-            }
+            public const string ClientId = "client.id";
 
             /// <summary>
-            ///     A reference to the key names for Admin specific configuration properties.
+            ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+            ///
+            ///     default: ''
+            ///     importance: high
             /// </summary>
-            public static partial class Admin
-            {
-                /// <summary>
-                ///     Client identifier.
-                ///
-                ///     default: rdkafka
-                ///     importance: low
-                /// </summary>
-                public const string ClientId = "client.id";
+            public const string BootstrapServers = "bootstrap.servers";
 
-                /// <summary>
-                ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string BootstrapServers = "bootstrap.servers";
+            /// <summary>
+            ///     Maximum Kafka protocol request message size.
+            ///
+            ///     default: 1000000
+            ///     importance: medium
+            /// </summary>
+            public const string MessageMaxBytes = "message.max.bytes";
 
-                /// <summary>
-                ///     Maximum Kafka protocol request message size.
-                ///
-                ///     default: 1000000
-                ///     importance: medium
-                /// </summary>
-                public const string MessageMaxBytes = "message.max.bytes";
+            /// <summary>
+            ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+            ///
+            ///     default: 65535
+            ///     importance: low
+            /// </summary>
+            public const string MessageCopyMaxBytes = "message.copy.max.bytes";
 
-                /// <summary>
-                ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
-                ///
-                ///     default: 65535
-                ///     importance: low
-                /// </summary>
-                public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+            /// <summary>
+            ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+            ///
+            ///     default: 100000000
+            ///     importance: medium
+            /// </summary>
+            public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
 
-                /// <summary>
-                ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
-                ///
-                ///     default: 100000000
-                ///     importance: medium
-                /// </summary>
-                public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+            /// <summary>
+            ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+            ///
+            ///     default: 1000000
+            ///     importance: low
+            /// </summary>
+            public const string MaxInFlight = "max.in.flight";
 
-                /// <summary>
-                ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
-                ///
-                ///     default: 1000000
-                ///     importance: low
-                /// </summary>
-                public const string MaxInFlight = "max.in.flight";
+            /// <summary>
+            ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
 
-                /// <summary>
-                ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+            /// <summary>
+            ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+            ///
+            ///     default: 300000
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
 
-                /// <summary>
-                ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
-                ///
-                ///     default: 300000
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+            /// <summary>
+            ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+            ///
+            ///     default: 900000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataMaxAgeMs = "metadata.max.age.ms";
 
-                /// <summary>
-                ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
-                ///
-                ///     default: 900000
-                ///     importance: low
-                /// </summary>
-                public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+            /// <summary>
+            ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+            ///
+            ///     default: 250
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
 
-                /// <summary>
-                ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
-                ///
-                ///     default: 250
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+            /// <summary>
+            ///     Sparse metadata requests (consumes less network bandwidth)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
 
-                /// <summary>
-                ///     Sparse metadata requests (consumes less network bandwidth)
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+            /// <summary>
+            ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string TopicBlacklist = "topic.blacklist";
 
-                /// <summary>
-                ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string TopicBlacklist = "topic.blacklist";
+            /// <summary>
+            ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string Debug = "debug";
 
-                /// <summary>
-                ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
-                ///
-                ///     default: ''
-                ///     importance: medium
-                /// </summary>
-                public const string Debug = "debug";
+            /// <summary>
+            ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SocketTimeoutMs = "socket.timeout.ms";
 
-                /// <summary>
-                ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string SocketTimeoutMs = "socket.timeout.ms";
+            /// <summary>
+            ///     Broker socket send buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
 
-                /// <summary>
-                ///     Broker socket send buffer size. System default is used if 0.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+            /// <summary>
+            ///     Broker socket receive buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
 
-                /// <summary>
-                ///     Broker socket receive buffer size. System default is used if 0.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+            /// <summary>
+            ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketKeepaliveEnable = "socket.keepalive.enable";
 
-                /// <summary>
-                ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+            /// <summary>
+            ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketNagleDisable = "socket.nagle.disable";
 
-                /// <summary>
-                ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string SocketNagleDisable = "socket.nagle.disable";
+            /// <summary>
+            ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string SocketMaxFails = "socket.max.fails";
 
-                /// <summary>
-                ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
-                ///
-                ///     default: 1
-                ///     importance: low
-                /// </summary>
-                public const string SocketMaxFails = "socket.max.fails";
+            /// <summary>
+            ///     How long to cache the broker address resolving results (milliseconds).
+            ///
+            ///     default: 1000
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressTtl = "broker.address.ttl";
 
-                /// <summary>
-                ///     How long to cache the broker address resolving results (milliseconds).
-                ///
-                ///     default: 1000
-                ///     importance: low
-                /// </summary>
-                public const string BrokerAddressTtl = "broker.address.ttl";
+            /// <summary>
+            ///     Allowed broker IP address families: any, v4, v6
+            ///
+            ///     default: any
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressFamily = "broker.address.family";
 
-                /// <summary>
-                ///     Allowed broker IP address families: any, v4, v6
-                ///
-                ///     default: any
-                ///     importance: low
-                /// </summary>
-                public const string BrokerAddressFamily = "broker.address.family";
+            /// <summary>
+            ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+            ///
+            ///     default: 100
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMs = "reconnect.backoff.ms";
 
-                /// <summary>
-                ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
-                ///
-                ///     default: 100
-                ///     importance: medium
-                /// </summary>
-                public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+            /// <summary>
+            ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+            ///
+            ///     default: 10000
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
 
-                /// <summary>
-                ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
-                ///
-                ///     default: 10000
-                ///     importance: medium
-                /// </summary>
-                public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+            /// <summary>
+            ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+            ///
+            ///     default: 0
+            ///     importance: high
+            /// </summary>
+            public const string StatisticsIntervalMs = "statistics.interval.ms";
 
-                /// <summary>
-                ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
-                ///
-                ///     default: 0
-                ///     importance: high
-                /// </summary>
-                public const string StatisticsIntervalMs = "statistics.interval.ms";
+            /// <summary>
+            ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string LogQueue = "log.queue";
 
-                /// <summary>
-                ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
-                ///
-                ///     default: false
-                ///     importance: low
-                /// </summary>
-                public const string LogQueue = "log.queue";
+            /// <summary>
+            ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogThreadName = "log.thread.name";
 
-                /// <summary>
-                ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string LogThreadName = "log.thread.name";
+            /// <summary>
+            ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogConnectionClose = "log.connection.close";
 
-                /// <summary>
-                ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
-                ///
-                ///     default: true
-                ///     importance: low
-                /// </summary>
-                public const string LogConnectionClose = "log.connection.close";
+            /// <summary>
+            ///     Application opaque (set with rd_kafka_conf_set_opaque())
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Opaque = "opaque";
 
-                /// <summary>
-                ///     Application opaque (set with rd_kafka_conf_set_opaque())
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string Opaque = "opaque";
+            /// <summary>
+            ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string InternalTerminationSignal = "internal.termination.signal";
 
-                /// <summary>
-                ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
-                ///
-                ///     default: 0
-                ///     importance: low
-                /// </summary>
-                public const string InternalTerminationSignal = "internal.termination.signal";
+            /// <summary>
+            ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string ApiVersionRequest = "api.version.request";
 
-                /// <summary>
-                ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
-                ///
-                ///     default: true
-                ///     importance: high
-                /// </summary>
-                public const string ApiVersionRequest = "api.version.request";
+            /// <summary>
+            ///     Timeout for broker API version requests.
+            ///
+            ///     default: 10000
+            ///     importance: low
+            /// </summary>
+            public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
 
-                /// <summary>
-                ///     Timeout for broker API version requests.
-                ///
-                ///     default: 10000
-                ///     importance: low
-                /// </summary>
-                public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+            /// <summary>
+            ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+            ///
+            ///     default: 0
+            ///     importance: medium
+            /// </summary>
+            public const string ApiVersionFallbackMs = "api.version.fallback.ms";
 
-                /// <summary>
-                ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
-                ///
-                ///     default: 0
-                ///     importance: medium
-                /// </summary>
-                public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+            /// <summary>
+            ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+            ///
+            ///     default: 0.10.0
+            ///     importance: medium
+            /// </summary>
+            public const string BrokerVersionFallback = "broker.version.fallback";
 
-                /// <summary>
-                ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
-                ///
-                ///     default: 0.10.0
-                ///     importance: medium
-                /// </summary>
-                public const string BrokerVersionFallback = "broker.version.fallback";
+            /// <summary>
+            ///     Protocol used to communicate with brokers.
+            ///
+            ///     default: plaintext
+            ///     importance: high
+            /// </summary>
+            public const string SecurityProtocol = "security.protocol";
 
-                /// <summary>
-                ///     Protocol used to communicate with brokers.
-                ///
-                ///     default: plaintext
-                ///     importance: high
-                /// </summary>
-                public const string SecurityProtocol = "security.protocol";
+            /// <summary>
+            ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCipherSuites = "ssl.cipher.suites";
 
-                /// <summary>
-                ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCipherSuites = "ssl.cipher.suites";
+            /// <summary>
+            ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCurvesList = "ssl.curves.list";
 
-                /// <summary>
-                ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCurvesList = "ssl.curves.list";
+            /// <summary>
+            ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslSigalgsList = "ssl.sigalgs.list";
 
-                /// <summary>
-                ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslSigalgsList = "ssl.sigalgs.list";
+            /// <summary>
+            ///     Path to client's private key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyLocation = "ssl.key.location";
 
-                /// <summary>
-                ///     Path to client's private key (PEM) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeyLocation = "ssl.key.location";
+            /// <summary>
+            ///     Private key passphrase
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyPassword = "ssl.key.password";
 
-                /// <summary>
-                ///     Private key passphrase
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeyPassword = "ssl.key.password";
+            /// <summary>
+            ///     Path to client's public key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCertificateLocation = "ssl.certificate.location";
 
-                /// <summary>
-                ///     Path to client's public key (PEM) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCertificateLocation = "ssl.certificate.location";
+            /// <summary>
+            ///     File or directory path to CA certificate(s) for verifying the broker's key.
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string SslCaLocation = "ssl.ca.location";
 
-                /// <summary>
-                ///     File or directory path to CA certificate(s) for verifying the broker's key.
-                ///
-                ///     default: ''
-                ///     importance: medium
-                /// </summary>
-                public const string SslCaLocation = "ssl.ca.location";
+            /// <summary>
+            ///     Path to CRL for verifying broker's certificate validity.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCrlLocation = "ssl.crl.location";
 
-                /// <summary>
-                ///     Path to CRL for verifying broker's certificate validity.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslCrlLocation = "ssl.crl.location";
+            /// <summary>
+            ///     Path to client's keystore (PKCS#12) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystoreLocation = "ssl.keystore.location";
 
-                /// <summary>
-                ///     Path to client's keystore (PKCS#12) used for authentication.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeystoreLocation = "ssl.keystore.location";
+            /// <summary>
+            ///     Client's keystore (PKCS#12) password.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystorePassword = "ssl.keystore.password";
 
-                /// <summary>
-                ///     Client's keystore (PKCS#12) password.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SslKeystorePassword = "ssl.keystore.password";
+            /// <summary>
+            ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+            ///
+            ///     default: kafka
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
 
-                /// <summary>
-                ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
-                ///
-                ///     default: kafka
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+            /// <summary>
+            ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+            ///
+            ///     default: kafkaclient
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
 
-                /// <summary>
-                ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
-                ///
-                ///     default: kafkaclient
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+            /// <summary>
+            ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+            ///
+            ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
 
-                /// <summary>
-                ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
-                ///
-                ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+            /// <summary>
+            ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
 
-                /// <summary>
-                ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+            /// <summary>
+            ///     Minimum time in milliseconds between key refresh attempts.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
 
-                /// <summary>
-                ///     Minimum time in milliseconds between key refresh attempts.
-                ///
-                ///     default: 60000
-                ///     importance: low
-                /// </summary>
-                public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+            /// <summary>
+            ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslUsername = "sasl.username";
 
-                /// <summary>
-                ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string SaslUsername = "sasl.username";
+            /// <summary>
+            ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslPassword = "sasl.password";
 
-                /// <summary>
-                ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
-                ///
-                ///     default: ''
-                ///     importance: high
-                /// </summary>
-                public const string SaslPassword = "sasl.password";
+            /// <summary>
+            ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string PluginLibraryPaths = "plugin.library.paths";
 
-                /// <summary>
-                ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string PluginLibraryPaths = "plugin.library.paths";
+            /// <summary>
+            ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Interceptors = "interceptors";
 
-                /// <summary>
-                ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
-                ///
-                ///     default: ''
-                ///     importance: low
-                /// </summary>
-                public const string Interceptors = "interceptors";
+            /// <summary>
+            ///     Client group id string. All clients sharing the same group.id belong to the same group.
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string GroupId = "group.id";
 
-            }
+            /// <summary>
+            ///     Name of partition assignment strategy to use when elected group leader assigns partitions to group members.
+            ///
+            ///     default: range,roundrobin
+            ///     importance: medium
+            /// </summary>
+            public const string PartitionAssignmentStrategy = "partition.assignment.strategy";
+
+            /// <summary>
+            ///     Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
+            ///
+            ///     default: 10000
+            ///     importance: high
+            /// </summary>
+            public const string SessionTimeoutMs = "session.timeout.ms";
+
+            /// <summary>
+            ///     Group session keepalive heartbeat interval.
+            ///
+            ///     default: 3000
+            ///     importance: low
+            /// </summary>
+            public const string HeartbeatIntervalMs = "heartbeat.interval.ms";
+
+            /// <summary>
+            ///     Group protocol type
+            ///
+            ///     default: consumer
+            ///     importance: low
+            /// </summary>
+            public const string GroupProtocolType = "group.protocol.type";
+
+            /// <summary>
+            ///     How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.
+            ///
+            ///     default: 600000
+            ///     importance: low
+            /// </summary>
+            public const string CoordinatorQueryIntervalMs = "coordinator.query.interval.ms";
+
+            /// <summary>
+            ///     Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.
+            ///
+            ///     default: 300000
+            ///     importance: high
+            /// </summary>
+            public const string MaxPollIntervalMs = "max.poll.interval.ms";
+
+            /// <summary>
+            ///     Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string EnableAutoCommit = "enable.auto.commit";
+
+            /// <summary>
+            ///     The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.
+            ///
+            ///     default: 5000
+            ///     importance: medium
+            /// </summary>
+            public const string AutoCommitIntervalMs = "auto.commit.interval.ms";
+
+            /// <summary>
+            ///     Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string EnableAutoOffsetStore = "enable.auto.offset.store";
+
+            /// <summary>
+            ///     Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.
+            ///
+            ///     default: 100000
+            ///     importance: medium
+            /// </summary>
+            public const string QueuedMinMessages = "queued.min.messages";
+
+            /// <summary>
+            ///     Maximum number of kilobytes per topic+partition in the local consumer queue. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.
+            ///
+            ///     default: 1048576
+            ///     importance: medium
+            /// </summary>
+            public const string QueuedMaxMessagesKbytes = "queued.max.messages.kbytes";
+
+            /// <summary>
+            ///     Maximum time the broker may wait to fill the response with fetch.min.bytes.
+            ///
+            ///     default: 100
+            ///     importance: low
+            /// </summary>
+            public const string FetchWaitMaxMs = "fetch.wait.max.ms";
+
+            /// <summary>
+            ///     Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
+            ///
+            ///     default: 1048576
+            ///     importance: medium
+            /// </summary>
+            public const string MaxPartitionFetchBytes = "max.partition.fetch.bytes";
+
+            /// <summary>
+            ///     Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).
+            ///
+            ///     default: 52428800
+            ///     importance: medium
+            /// </summary>
+            public const string FetchMaxBytes = "fetch.max.bytes";
+
+            /// <summary>
+            ///     Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string FetchMinBytes = "fetch.min.bytes";
+
+            /// <summary>
+            ///     How long to postpone the next fetch request for a topic+partition in case of a fetch error.
+            ///
+            ///     default: 500
+            ///     importance: medium
+            /// </summary>
+            public const string FetchErrorBackoffMs = "fetch.error.backoff.ms";
+
+            /// <summary>
+            ///     Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string EnablePartitionEof = "enable.partition.eof";
+
+            /// <summary>
+            ///     Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.
+            ///
+            ///     default: false
+            ///     importance: medium
+            /// </summary>
+            public const string CheckCrcs = "check.crcs";
+
+        }
+    }
+
+    /// <summary>
+    ///     A reference to the key names for Producer specific configuration properties.
+    /// </summary>
+    public partial class ProducerConfig
+    {
+        /// <summary>
+        ///     A reference to the configuration key names
+        /// </summary>
+        public static partial class PropertyNames
+        {
+            /// <summary>
+            ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
+            ///
+            ///     default: 5000
+            ///     importance: medium
+            /// </summary>
+            public const string RequestTimeoutMs = "request.timeout.ms";
+
+            /// <summary>
+            ///     Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
+            ///
+            ///     default: 300000
+            ///     importance: high
+            /// </summary>
+            public const string MessageTimeoutMs = "message.timeout.ms";
+
+            /// <summary>
+            ///     Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.).
+            ///
+            ///     default: consistent_random
+            ///     importance: high
+            /// </summary>
+            public const string Partitioner = "partitioner";
+
+            /// <summary>
+            ///     Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
+            ///
+            ///     default: -1
+            ///     importance: medium
+            /// </summary>
+            public const string CompressionLevel = "compression.level";
+
+            /// <summary>
+            ///     Client identifier.
+            ///
+            ///     default: rdkafka
+            ///     importance: low
+            /// </summary>
+            public const string ClientId = "client.id";
+
+            /// <summary>
+            ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string BootstrapServers = "bootstrap.servers";
+
+            /// <summary>
+            ///     Maximum Kafka protocol request message size.
+            ///
+            ///     default: 1000000
+            ///     importance: medium
+            /// </summary>
+            public const string MessageMaxBytes = "message.max.bytes";
+
+            /// <summary>
+            ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+            ///
+            ///     default: 65535
+            ///     importance: low
+            /// </summary>
+            public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+
+            /// <summary>
+            ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+            ///
+            ///     default: 100000000
+            ///     importance: medium
+            /// </summary>
+            public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+
+            /// <summary>
+            ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+            ///
+            ///     default: 1000000
+            ///     importance: low
+            /// </summary>
+            public const string MaxInFlight = "max.in.flight";
+
+            /// <summary>
+            ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+
+            /// <summary>
+            ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+            ///
+            ///     default: 300000
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+
+            /// <summary>
+            ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+            ///
+            ///     default: 900000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+
+            /// <summary>
+            ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+            ///
+            ///     default: 250
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+
+            /// <summary>
+            ///     Sparse metadata requests (consumes less network bandwidth)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+
+            /// <summary>
+            ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string TopicBlacklist = "topic.blacklist";
+
+            /// <summary>
+            ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string Debug = "debug";
+
+            /// <summary>
+            ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SocketTimeoutMs = "socket.timeout.ms";
+
+            /// <summary>
+            ///     Broker socket send buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+
+            /// <summary>
+            ///     Broker socket receive buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+
+            /// <summary>
+            ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+
+            /// <summary>
+            ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketNagleDisable = "socket.nagle.disable";
+
+            /// <summary>
+            ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string SocketMaxFails = "socket.max.fails";
+
+            /// <summary>
+            ///     How long to cache the broker address resolving results (milliseconds).
+            ///
+            ///     default: 1000
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressTtl = "broker.address.ttl";
+
+            /// <summary>
+            ///     Allowed broker IP address families: any, v4, v6
+            ///
+            ///     default: any
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressFamily = "broker.address.family";
+
+            /// <summary>
+            ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+            ///
+            ///     default: 100
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+
+            /// <summary>
+            ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+            ///
+            ///     default: 10000
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+
+            /// <summary>
+            ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+            ///
+            ///     default: 0
+            ///     importance: high
+            /// </summary>
+            public const string StatisticsIntervalMs = "statistics.interval.ms";
+
+            /// <summary>
+            ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string LogQueue = "log.queue";
+
+            /// <summary>
+            ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogThreadName = "log.thread.name";
+
+            /// <summary>
+            ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogConnectionClose = "log.connection.close";
+
+            /// <summary>
+            ///     Application opaque (set with rd_kafka_conf_set_opaque())
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Opaque = "opaque";
+
+            /// <summary>
+            ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string InternalTerminationSignal = "internal.termination.signal";
+
+            /// <summary>
+            ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string ApiVersionRequest = "api.version.request";
+
+            /// <summary>
+            ///     Timeout for broker API version requests.
+            ///
+            ///     default: 10000
+            ///     importance: low
+            /// </summary>
+            public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+
+            /// <summary>
+            ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+            ///
+            ///     default: 0
+            ///     importance: medium
+            /// </summary>
+            public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+
+            /// <summary>
+            ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+            ///
+            ///     default: 0.10.0
+            ///     importance: medium
+            /// </summary>
+            public const string BrokerVersionFallback = "broker.version.fallback";
+
+            /// <summary>
+            ///     Protocol used to communicate with brokers.
+            ///
+            ///     default: plaintext
+            ///     importance: high
+            /// </summary>
+            public const string SecurityProtocol = "security.protocol";
+
+            /// <summary>
+            ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCipherSuites = "ssl.cipher.suites";
+
+            /// <summary>
+            ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCurvesList = "ssl.curves.list";
+
+            /// <summary>
+            ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslSigalgsList = "ssl.sigalgs.list";
+
+            /// <summary>
+            ///     Path to client's private key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyLocation = "ssl.key.location";
+
+            /// <summary>
+            ///     Private key passphrase
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyPassword = "ssl.key.password";
+
+            /// <summary>
+            ///     Path to client's public key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCertificateLocation = "ssl.certificate.location";
+
+            /// <summary>
+            ///     File or directory path to CA certificate(s) for verifying the broker's key.
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string SslCaLocation = "ssl.ca.location";
+
+            /// <summary>
+            ///     Path to CRL for verifying broker's certificate validity.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCrlLocation = "ssl.crl.location";
+
+            /// <summary>
+            ///     Path to client's keystore (PKCS#12) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystoreLocation = "ssl.keystore.location";
+
+            /// <summary>
+            ///     Client's keystore (PKCS#12) password.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystorePassword = "ssl.keystore.password";
+
+            /// <summary>
+            ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+            ///
+            ///     default: kafka
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+
+            /// <summary>
+            ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+            ///
+            ///     default: kafkaclient
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+
+            /// <summary>
+            ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+            ///
+            ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+
+            /// <summary>
+            ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+
+            /// <summary>
+            ///     Minimum time in milliseconds between key refresh attempts.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+
+            /// <summary>
+            ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslUsername = "sasl.username";
+
+            /// <summary>
+            ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslPassword = "sasl.password";
+
+            /// <summary>
+            ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string PluginLibraryPaths = "plugin.library.paths";
+
+            /// <summary>
+            ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Interceptors = "interceptors";
+
+            /// <summary>
+            ///     When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.
+            ///
+            ///     default: false
+            ///     importance: high
+            /// </summary>
+            public const string EnableIdempotence = "enable.idempotence";
+
+            /// <summary>
+            ///     **EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string EnableGaplessGuarantee = "enable.gapless.guarantee";
+
+            /// <summary>
+            ///     Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
+            ///
+            ///     default: 100000
+            ///     importance: high
+            /// </summary>
+            public const string QueueBufferingMaxMessages = "queue.buffering.max.messages";
+
+            /// <summary>
+            ///     Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.
+            ///
+            ///     default: 1048576
+            ///     importance: high
+            /// </summary>
+            public const string QueueBufferingMaxKbytes = "queue.buffering.max.kbytes";
+
+            /// <summary>
+            ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
+            ///
+            ///     default: 0
+            ///     importance: high
+            /// </summary>
+            public const string LingerMs = "linger.ms";
+
+            /// <summary>
+            ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
+            ///
+            ///     default: 2
+            ///     importance: high
+            /// </summary>
+            public const string MessageSendMaxRetries = "message.send.max.retries";
+
+            /// <summary>
+            ///     The backoff time in milliseconds before retrying a protocol request.
+            ///
+            ///     default: 100
+            ///     importance: medium
+            /// </summary>
+            public const string RetryBackoffMs = "retry.backoff.ms";
+
+            /// <summary>
+            ///     The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string QueueBufferingBackpressureThreshold = "queue.buffering.backpressure.threshold";
+
+            /// <summary>
+            ///     compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
+            ///
+            ///     default: none
+            ///     importance: medium
+            /// </summary>
+            public const string CompressionType = "compression.type";
+
+            /// <summary>
+            ///     Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by message.max.bytes.
+            ///
+            ///     default: 10000
+            ///     importance: medium
+            /// </summary>
+            public const string BatchNumMessages = "batch.num.messages";
+
+        }
+    }
+
+    /// <summary>
+    ///     A reference to the key names for Admin specific configuration properties.
+    /// </summary>
+    public partial class AdminConfig
+    {
+        /// <summary>
+        ///     A reference to the configuration key names
+        /// </summary>
+        public static partial class PropertyNames
+        {
+            /// <summary>
+            ///     Client identifier.
+            ///
+            ///     default: rdkafka
+            ///     importance: low
+            /// </summary>
+            public const string ClientId = "client.id";
+
+            /// <summary>
+            ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string BootstrapServers = "bootstrap.servers";
+
+            /// <summary>
+            ///     Maximum Kafka protocol request message size.
+            ///
+            ///     default: 1000000
+            ///     importance: medium
+            /// </summary>
+            public const string MessageMaxBytes = "message.max.bytes";
+
+            /// <summary>
+            ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+            ///
+            ///     default: 65535
+            ///     importance: low
+            /// </summary>
+            public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+
+            /// <summary>
+            ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+            ///
+            ///     default: 100000000
+            ///     importance: medium
+            /// </summary>
+            public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+
+            /// <summary>
+            ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+            ///
+            ///     default: 1000000
+            ///     importance: low
+            /// </summary>
+            public const string MaxInFlight = "max.in.flight";
+
+            /// <summary>
+            ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+
+            /// <summary>
+            ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+            ///
+            ///     default: 300000
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+
+            /// <summary>
+            ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+            ///
+            ///     default: 900000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+
+            /// <summary>
+            ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+            ///
+            ///     default: 250
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+
+            /// <summary>
+            ///     Sparse metadata requests (consumes less network bandwidth)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+
+            /// <summary>
+            ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string TopicBlacklist = "topic.blacklist";
+
+            /// <summary>
+            ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string Debug = "debug";
+
+            /// <summary>
+            ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SocketTimeoutMs = "socket.timeout.ms";
+
+            /// <summary>
+            ///     Broker socket send buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+
+            /// <summary>
+            ///     Broker socket receive buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+
+            /// <summary>
+            ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+
+            /// <summary>
+            ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketNagleDisable = "socket.nagle.disable";
+
+            /// <summary>
+            ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string SocketMaxFails = "socket.max.fails";
+
+            /// <summary>
+            ///     How long to cache the broker address resolving results (milliseconds).
+            ///
+            ///     default: 1000
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressTtl = "broker.address.ttl";
+
+            /// <summary>
+            ///     Allowed broker IP address families: any, v4, v6
+            ///
+            ///     default: any
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressFamily = "broker.address.family";
+
+            /// <summary>
+            ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+            ///
+            ///     default: 100
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+
+            /// <summary>
+            ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+            ///
+            ///     default: 10000
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+
+            /// <summary>
+            ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+            ///
+            ///     default: 0
+            ///     importance: high
+            /// </summary>
+            public const string StatisticsIntervalMs = "statistics.interval.ms";
+
+            /// <summary>
+            ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string LogQueue = "log.queue";
+
+            /// <summary>
+            ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogThreadName = "log.thread.name";
+
+            /// <summary>
+            ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogConnectionClose = "log.connection.close";
+
+            /// <summary>
+            ///     Application opaque (set with rd_kafka_conf_set_opaque())
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Opaque = "opaque";
+
+            /// <summary>
+            ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string InternalTerminationSignal = "internal.termination.signal";
+
+            /// <summary>
+            ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string ApiVersionRequest = "api.version.request";
+
+            /// <summary>
+            ///     Timeout for broker API version requests.
+            ///
+            ///     default: 10000
+            ///     importance: low
+            /// </summary>
+            public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+
+            /// <summary>
+            ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+            ///
+            ///     default: 0
+            ///     importance: medium
+            /// </summary>
+            public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+
+            /// <summary>
+            ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+            ///
+            ///     default: 0.10.0
+            ///     importance: medium
+            /// </summary>
+            public const string BrokerVersionFallback = "broker.version.fallback";
+
+            /// <summary>
+            ///     Protocol used to communicate with brokers.
+            ///
+            ///     default: plaintext
+            ///     importance: high
+            /// </summary>
+            public const string SecurityProtocol = "security.protocol";
+
+            /// <summary>
+            ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCipherSuites = "ssl.cipher.suites";
+
+            /// <summary>
+            ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCurvesList = "ssl.curves.list";
+
+            /// <summary>
+            ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslSigalgsList = "ssl.sigalgs.list";
+
+            /// <summary>
+            ///     Path to client's private key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyLocation = "ssl.key.location";
+
+            /// <summary>
+            ///     Private key passphrase
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyPassword = "ssl.key.password";
+
+            /// <summary>
+            ///     Path to client's public key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCertificateLocation = "ssl.certificate.location";
+
+            /// <summary>
+            ///     File or directory path to CA certificate(s) for verifying the broker's key.
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string SslCaLocation = "ssl.ca.location";
+
+            /// <summary>
+            ///     Path to CRL for verifying broker's certificate validity.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCrlLocation = "ssl.crl.location";
+
+            /// <summary>
+            ///     Path to client's keystore (PKCS#12) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystoreLocation = "ssl.keystore.location";
+
+            /// <summary>
+            ///     Client's keystore (PKCS#12) password.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystorePassword = "ssl.keystore.password";
+
+            /// <summary>
+            ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+            ///
+            ///     default: kafka
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+
+            /// <summary>
+            ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+            ///
+            ///     default: kafkaclient
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+
+            /// <summary>
+            ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+            ///
+            ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+
+            /// <summary>
+            ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+
+            /// <summary>
+            ///     Minimum time in milliseconds between key refresh attempts.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+
+            /// <summary>
+            ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslUsername = "sasl.username";
+
+            /// <summary>
+            ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslPassword = "sasl.password";
+
+            /// <summary>
+            ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string PluginLibraryPaths = "plugin.library.paths";
+
+            /// <summary>
+            ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Interceptors = "interceptors";
+
         }
     }
 
     /// <summary>
     ///     Configuration common to all clients
     /// </summary>
-    public class ClientConfig : Config
+    public partial class ClientConfig : Config
     {
         /// <summary>
         ///     Initialize a new empty <see cref="ClientConfig" /> instance.
@@ -2293,7 +2302,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     AdminClient configuration properties
     /// </summary>
-    public class AdminClientConfig : ClientConfig
+    public partial class AdminClientConfig : ClientConfig
     {
         /// <summary>
         ///     Initialize a new empty <see cref="AdminClientConfig" /> instance.
@@ -2327,7 +2336,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Producer configuration properties
     /// </summary>
-    public class ProducerConfig : ClientConfig
+    public partial class ProducerConfig : ClientConfig
     {
         /// <summary>
         ///     Initialize a new empty <see cref="ProducerConfig" /> instance.
@@ -2506,7 +2515,7 @@ namespace Confluent.Kafka
     /// <summary>
     ///     Consumer configuration properties
     /// </summary>
-    public class ConsumerConfig : ClientConfig
+    public partial class ConsumerConfig : ClientConfig
     {
         /// <summary>
         ///     Initialize a new empty <see cref="ConsumerConfig" /> instance.

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -1,4 +1,4 @@
-// *** Auto-generated from librdkafka branch v1.0.0 *** - do not modify manually.
+// *** Auto-generated from librdkafka v1.0.0 *** - do not modify manually.
 //
 // Copyright 2018 Confluent Inc.
 //
@@ -229,22 +229,33 @@ namespace Confluent.Kafka
         public ClientConfig() { }
 
         /// <summary>
-        ///     Initialize a new <see cref="ClientConfig" /> instance based on
+        ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
+        /// </summary>
+        /// <summary>
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public ClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
-        ///     Initialize a new <see cref="ClientConfig" /> instance based on
+        ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        /// </summary>
-        public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="ClientConfig" /> wrapping
-        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public ClientConfig(IDictionary<string, string> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ClientConfig" /> instance copying
+        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     </para>
+        /// </summary>
+        public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
         /// <summary>
         ///     SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism.
@@ -725,22 +736,33 @@ namespace Confluent.Kafka
         public AdminClientConfig() { }
 
         /// <summary>
-        ///     Initialize a new <see cref="AdminClientConfig" /> instance based on
+        ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
+        /// </summary>
+        /// <summary>
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public AdminClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
-        ///     Initialize a new <see cref="AdminClientConfig" /> instance based on
+        ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        /// </summary>
-        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="AdminClientConfig" /> wrapping
-        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public AdminClientConfig(IDictionary<string, string> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="AdminClientConfig" /> instance copying
+        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     </para>
+        /// </summary>
+        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
     }
 
 
@@ -756,22 +778,33 @@ namespace Confluent.Kafka
         public ProducerConfig() { }
 
         /// <summary>
-        ///     Initialize a new <see cref="ProducerConfig" /> instance based on
+        ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
+        /// </summary>
+        /// <summary>
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public ProducerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
-        ///     Initialize a new <see cref="ProducerConfig" /> instance based on
+        ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        /// </summary>
-        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="ProducerConfig" /> wrapping
-        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public ProducerConfig(IDictionary<string, string> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ProducerConfig" /> instance copying
+        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     </para>
+        /// </summary>
+        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
         /// <summary>
         ///     Specifies whether or not the producer should start a background poll 
@@ -932,22 +965,33 @@ namespace Confluent.Kafka
         public ConsumerConfig() { }
 
         /// <summary>
-        ///     Initialize a new <see cref="ConsumerConfig" /> instance based on
+        ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
+        /// </summary>
+        /// <summary>
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public ConsumerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
-        ///     Initialize a new <see cref="ConsumerConfig" /> instance based on
+        ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        /// </summary>
-        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="ConsumerConfig" /> wrapping
-        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     </para>
         /// </summary>
         public ConsumerConfig(IDictionary<string, string> config) : base(config) { }
+
+        /// <summary>
+        ///     Initialize a new <see cref="ConsumerConfig" /> instance copying
+        ///     an existing key/value pair collection.
+        ///     <para>
+        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     </para>
+        /// </summary>
+        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
         /// <summary>
         ///     A comma separated list of fields that may be optionally set

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -225,7 +225,7 @@ namespace Confluent.Kafka
         public static class PropertyNames
         {
             /// <summary>
-            ///     A reference to the configuration key names for Consumer
+            ///     A reference to the key names for Consumer specific configuration properties.
             /// </summary>
             public static class Consumer
             {
@@ -816,7 +816,7 @@ namespace Confluent.Kafka
             }
 
             /// <summary>
-            ///     A reference to the configuration key names for Producer
+            ///     A reference to the key names for Producer specific configuration properties.
             /// </summary>
             public static class Producer
             {
@@ -1359,7 +1359,7 @@ namespace Confluent.Kafka
             }
 
             /// <summary>
-            ///     A reference to the configuration key names for Admin
+            ///     A reference to the key names for Admin specific configuration properties.
             /// </summary>
             public static class Admin
             {

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -231,21 +231,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ClientConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
+        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
         /// </summary>
         public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
@@ -730,21 +730,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public AdminClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public AdminClientConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
+        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
         /// </summary>
         public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
     }
@@ -764,21 +764,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ProducerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ProducerConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
+        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
         /// </summary>
         public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
@@ -943,21 +943,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ConsumerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     This will change the values "in-place" i.e. the original will be modified
+        ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ConsumerConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
+        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
         /// </summary>
         public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -231,29 +231,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        /// </summary>
-        /// <summary>
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public ClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public ClientConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will make a copy of the provided values i.e. the original will be NOT modified
-        ///     </para>
         /// </summary>
         public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
@@ -738,29 +730,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        /// </summary>
-        /// <summary>
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public AdminClientConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public AdminClientConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will make a copy of the provided values i.e. the original will be NOT modified
-        ///     </para>
         /// </summary>
         public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
     }
@@ -780,29 +764,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        /// </summary>
-        /// <summary>
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public ProducerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public ProducerConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will make a copy of the provided values i.e. the original will be NOT modified
-        ///     </para>
         /// </summary>
         public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
@@ -967,29 +943,21 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
         ///     an existing <see cref="ClientConfig" /> instance.
-        /// </summary>
-        /// <summary>
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public ConsumerConfig(ClientConfig config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will change the values "in-place" i.e. the original will be modified
-        ///     </para>
         /// </summary>
         public ConsumerConfig(IDictionary<string, string> config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     <para>
         ///     This will make a copy of the provided values i.e. the original will be NOT modified
-        ///     </para>
         /// </summary>
         public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -222,12 +222,12 @@ namespace Confluent.Kafka
         /// <summary>
         ///     A reference to the configuration key names
         /// </summary>
-        public static class PropertyNames
+        public static partial class PropertyNames
         {
             /// <summary>
             ///     A reference to the key names for Consumer specific configuration properties.
             /// </summary>
-            public static class Consumer
+            public static partial class Consumer
             {
                 /// <summary>
                 ///     Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
@@ -818,7 +818,7 @@ namespace Confluent.Kafka
             /// <summary>
             ///     A reference to the key names for Producer specific configuration properties.
             /// </summary>
-            public static class Producer
+            public static partial class Producer
             {
                 /// <summary>
                 ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
@@ -1361,7 +1361,7 @@ namespace Confluent.Kafka
             /// <summary>
             ///     A reference to the key names for Admin specific configuration properties.
             /// </summary>
-            public static class Admin
+            public static partial class Admin
             {
                 /// <summary>
                 ///     Client identifier.

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -217,6 +217,712 @@ namespace Confluent.Kafka
         All = -1
     }
 
+    public partial class Config
+    {
+        /// <summary>
+        ///     A reference to the configuration key names
+        /// </summary>
+        public static class KeyNames
+        {
+            /// <summary>
+            ///     The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.
+            ///
+            ///     default: 5000
+            ///     importance: medium
+            /// </summary>
+            public const string RequestTimeoutMs = "request.timeout.ms";
+
+            /// <summary>
+            ///     Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded.
+            ///
+            ///     default: 300000
+            ///     importance: high
+            /// </summary>
+            public const string MessageTimeoutMs = "message.timeout.ms";
+
+            /// <summary>
+            ///     Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.).
+            ///
+            ///     default: consistent_random
+            ///     importance: high
+            /// </summary>
+            public const string Partitioner = "partitioner";
+
+            /// <summary>
+            ///     Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
+            ///
+            ///     default: -1
+            ///     importance: medium
+            /// </summary>
+            public const string CompressionLevel = "compression.level";
+
+            /// <summary>
+            ///     Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error which is retrieved by consuming messages and checking 'message->err'.
+            ///
+            ///     default: largest
+            ///     importance: high
+            /// </summary>
+            public const string AutoOffsetReset = "auto.offset.reset";
+
+            /// <summary>
+            ///     Client identifier.
+            ///
+            ///     default: rdkafka
+            ///     importance: low
+            /// </summary>
+            public const string ClientId = "client.id";
+
+            /// <summary>
+            ///     Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string BootstrapServers = "bootstrap.servers";
+
+            /// <summary>
+            ///     Maximum Kafka protocol request message size.
+            ///
+            ///     default: 1000000
+            ///     importance: medium
+            /// </summary>
+            public const string MessageMaxBytes = "message.max.bytes";
+
+            /// <summary>
+            ///     Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+            ///
+            ///     default: 65535
+            ///     importance: low
+            /// </summary>
+            public const string MessageCopyMaxBytes = "message.copy.max.bytes";
+
+            /// <summary>
+            ///     Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.
+            ///
+            ///     default: 100000000
+            ///     importance: medium
+            /// </summary>
+            public const string ReceiveMessageMaxBytes = "receive.message.max.bytes";
+
+            /// <summary>
+            ///     Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+            ///
+            ///     default: 1000000
+            ///     importance: low
+            /// </summary>
+            public const string MaxInFlight = "max.in.flight";
+
+            /// <summary>
+            ///     Non-topic request timeout in milliseconds. This is for metadata requests, etc.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataRequestTimeoutMs = "metadata.request.timeout.ms";
+
+            /// <summary>
+            ///     Topic metadata refresh interval in milliseconds. The metadata is automatically refreshed on error and connect. Use -1 to disable the intervalled refresh.
+            ///
+            ///     default: 300000
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshIntervalMs = "topic.metadata.refresh.interval.ms";
+
+            /// <summary>
+            ///     Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3
+            ///
+            ///     default: 900000
+            ///     importance: low
+            /// </summary>
+            public const string MetadataMaxAgeMs = "metadata.max.age.ms";
+
+            /// <summary>
+            ///     When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+            ///
+            ///     default: 250
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshFastIntervalMs = "topic.metadata.refresh.fast.interval.ms";
+
+            /// <summary>
+            ///     Sparse metadata requests (consumes less network bandwidth)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string TopicMetadataRefreshSparse = "topic.metadata.refresh.sparse";
+
+            /// <summary>
+            ///     Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string TopicBlacklist = "topic.blacklist";
+
+            /// <summary>
+            ///     A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string Debug = "debug";
+
+            /// <summary>
+            ///     Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SocketTimeoutMs = "socket.timeout.ms";
+
+            /// <summary>
+            ///     Broker socket send buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketSendBufferBytes = "socket.send.buffer.bytes";
+
+            /// <summary>
+            ///     Broker socket receive buffer size. System default is used if 0.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string SocketReceiveBufferBytes = "socket.receive.buffer.bytes";
+
+            /// <summary>
+            ///     Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketKeepaliveEnable = "socket.keepalive.enable";
+
+            /// <summary>
+            ///     Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string SocketNagleDisable = "socket.nagle.disable";
+
+            /// <summary>
+            ///     Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string SocketMaxFails = "socket.max.fails";
+
+            /// <summary>
+            ///     How long to cache the broker address resolving results (milliseconds).
+            ///
+            ///     default: 1000
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressTtl = "broker.address.ttl";
+
+            /// <summary>
+            ///     Allowed broker IP address families: any, v4, v6
+            ///
+            ///     default: any
+            ///     importance: low
+            /// </summary>
+            public const string BrokerAddressFamily = "broker.address.family";
+
+            /// <summary>
+            ///     The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.
+            ///
+            ///     default: 100
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMs = "reconnect.backoff.ms";
+
+            /// <summary>
+            ///     The maximum time to wait before reconnecting to a broker after the connection has been closed.
+            ///
+            ///     default: 10000
+            ///     importance: medium
+            /// </summary>
+            public const string ReconnectBackoffMaxMs = "reconnect.backoff.max.ms";
+
+            /// <summary>
+            ///     librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.
+            ///
+            ///     default: 0
+            ///     importance: high
+            /// </summary>
+            public const string StatisticsIntervalMs = "statistics.interval.ms";
+
+            /// <summary>
+            ///     Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string LogQueue = "log.queue";
+
+            /// <summary>
+            ///     Print internal thread name in log messages (useful for debugging librdkafka internals)
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogThreadName = "log.thread.name";
+
+            /// <summary>
+            ///     Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connection.max.idle.ms` value.
+            ///
+            ///     default: true
+            ///     importance: low
+            /// </summary>
+            public const string LogConnectionClose = "log.connection.close";
+
+            /// <summary>
+            ///     Application opaque (set with rd_kafka_conf_set_opaque())
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Opaque = "opaque";
+
+            /// <summary>
+            ///     Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.
+            ///
+            ///     default: 0
+            ///     importance: low
+            /// </summary>
+            public const string InternalTerminationSignal = "internal.termination.signal";
+
+            /// <summary>
+            ///     Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string ApiVersionRequest = "api.version.request";
+
+            /// <summary>
+            ///     Timeout for broker API version requests.
+            ///
+            ///     default: 10000
+            ///     importance: low
+            /// </summary>
+            public const string ApiVersionRequestTimeoutMs = "api.version.request.timeout.ms";
+
+            /// <summary>
+            ///     Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).
+            ///
+            ///     default: 0
+            ///     importance: medium
+            /// </summary>
+            public const string ApiVersionFallbackMs = "api.version.fallback.ms";
+
+            /// <summary>
+            ///     Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value >= 0.10, such as 0.10.2.1, enables ApiVersionRequests.
+            ///
+            ///     default: 0.10.0
+            ///     importance: medium
+            /// </summary>
+            public const string BrokerVersionFallback = "broker.version.fallback";
+
+            /// <summary>
+            ///     Protocol used to communicate with brokers.
+            ///
+            ///     default: plaintext
+            ///     importance: high
+            /// </summary>
+            public const string SecurityProtocol = "security.protocol";
+
+            /// <summary>
+            ///     A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCipherSuites = "ssl.cipher.suites";
+
+            /// <summary>
+            ///     The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCurvesList = "ssl.curves.list";
+
+            /// <summary>
+            ///     The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL >= 1.0.2 required.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslSigalgsList = "ssl.sigalgs.list";
+
+            /// <summary>
+            ///     Path to client's private key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyLocation = "ssl.key.location";
+
+            /// <summary>
+            ///     Private key passphrase
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeyPassword = "ssl.key.password";
+
+            /// <summary>
+            ///     Path to client's public key (PEM) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCertificateLocation = "ssl.certificate.location";
+
+            /// <summary>
+            ///     File or directory path to CA certificate(s) for verifying the broker's key.
+            ///
+            ///     default: ''
+            ///     importance: medium
+            /// </summary>
+            public const string SslCaLocation = "ssl.ca.location";
+
+            /// <summary>
+            ///     Path to CRL for verifying broker's certificate validity.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslCrlLocation = "ssl.crl.location";
+
+            /// <summary>
+            ///     Path to client's keystore (PKCS#12) used for authentication.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystoreLocation = "ssl.keystore.location";
+
+            /// <summary>
+            ///     Client's keystore (PKCS#12) password.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SslKeystorePassword = "ssl.keystore.password";
+
+            /// <summary>
+            ///     Kerberos principal name that Kafka runs as, not including /hostname@REALM
+            ///
+            ///     default: kafka
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosServiceName = "sasl.kerberos.service.name";
+
+            /// <summary>
+            ///     This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+            ///
+            ///     default: kafkaclient
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosPrincipal = "sasl.kerberos.principal";
+
+            /// <summary>
+            ///     Full kerberos kinit command string, %{config.prop.name} is replaced by corresponding config object value, %{broker.name} returns the broker's hostname.
+            ///
+            ///     default: kinit -S "%{sasl.kerberos.service.name}/%{broker.name}" -k -t "%{sasl.kerberos.keytab}" %{sasl.kerberos.principal}
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKinitCmd = "sasl.kerberos.kinit.cmd";
+
+            /// <summary>
+            ///     Path to Kerberos keytab file. Uses system default if not set.**NOTE**: This is not automatically used but must be added to the template in sasl.kerberos.kinit.cmd as ` ... -t %{sasl.kerberos.keytab}`.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosKeytab = "sasl.kerberos.keytab";
+
+            /// <summary>
+            ///     Minimum time in milliseconds between key refresh attempts.
+            ///
+            ///     default: 60000
+            ///     importance: low
+            /// </summary>
+            public const string SaslKerberosMinTimeBeforeRelogin = "sasl.kerberos.min.time.before.relogin";
+
+            /// <summary>
+            ///     SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslUsername = "sasl.username";
+
+            /// <summary>
+            ///     SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string SaslPassword = "sasl.password";
+
+            /// <summary>
+            ///     List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string PluginLibraryPaths = "plugin.library.paths";
+
+            /// <summary>
+            ///     Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors.
+            ///
+            ///     default: ''
+            ///     importance: low
+            /// </summary>
+            public const string Interceptors = "interceptors";
+
+            /// <summary>
+            ///     Client group id string. All clients sharing the same group.id belong to the same group.
+            ///
+            ///     default: ''
+            ///     importance: high
+            /// </summary>
+            public const string GroupId = "group.id";
+
+            /// <summary>
+            ///     Name of partition assignment strategy to use when elected group leader assigns partitions to group members.
+            ///
+            ///     default: range,roundrobin
+            ///     importance: medium
+            /// </summary>
+            public const string PartitionAssignmentStrategy = "partition.assignment.strategy";
+
+            /// <summary>
+            ///     Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
+            ///
+            ///     default: 10000
+            ///     importance: high
+            /// </summary>
+            public const string SessionTimeoutMs = "session.timeout.ms";
+
+            /// <summary>
+            ///     Group session keepalive heartbeat interval.
+            ///
+            ///     default: 3000
+            ///     importance: low
+            /// </summary>
+            public const string HeartbeatIntervalMs = "heartbeat.interval.ms";
+
+            /// <summary>
+            ///     Group protocol type
+            ///
+            ///     default: consumer
+            ///     importance: low
+            /// </summary>
+            public const string GroupProtocolType = "group.protocol.type";
+
+            /// <summary>
+            ///     How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.
+            ///
+            ///     default: 600000
+            ///     importance: low
+            /// </summary>
+            public const string CoordinatorQueryIntervalMs = "coordinator.query.interval.ms";
+
+            /// <summary>
+            ///     Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.
+            ///
+            ///     default: 300000
+            ///     importance: high
+            /// </summary>
+            public const string MaxPollIntervalMs = "max.poll.interval.ms";
+
+            /// <summary>
+            ///     Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string EnableAutoCommit = "enable.auto.commit";
+
+            /// <summary>
+            ///     The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.
+            ///
+            ///     default: 5000
+            ///     importance: medium
+            /// </summary>
+            public const string AutoCommitIntervalMs = "auto.commit.interval.ms";
+
+            /// <summary>
+            ///     Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
+            ///
+            ///     default: true
+            ///     importance: high
+            /// </summary>
+            public const string EnableAutoOffsetStore = "enable.auto.offset.store";
+
+            /// <summary>
+            ///     Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.
+            ///
+            ///     default: 100000
+            ///     importance: medium
+            /// </summary>
+            public const string QueuedMinMessages = "queued.min.messages";
+
+            /// <summary>
+            ///     Maximum number of kilobytes per topic+partition in the local consumer queue. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.
+            ///
+            ///     default: 1048576
+            ///     importance: medium
+            /// </summary>
+            public const string QueuedMaxMessagesKbytes = "queued.max.messages.kbytes";
+
+            /// <summary>
+            ///     Maximum time the broker may wait to fill the response with fetch.min.bytes.
+            ///
+            ///     default: 100
+            ///     importance: low
+            /// </summary>
+            public const string FetchWaitMaxMs = "fetch.wait.max.ms";
+
+            /// <summary>
+            ///     Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
+            ///
+            ///     default: 1048576
+            ///     importance: medium
+            /// </summary>
+            public const string MaxPartitionFetchBytes = "max.partition.fetch.bytes";
+
+            /// <summary>
+            ///     Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).
+            ///
+            ///     default: 52428800
+            ///     importance: medium
+            /// </summary>
+            public const string FetchMaxBytes = "fetch.max.bytes";
+
+            /// <summary>
+            ///     Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string FetchMinBytes = "fetch.min.bytes";
+
+            /// <summary>
+            ///     How long to postpone the next fetch request for a topic+partition in case of a fetch error.
+            ///
+            ///     default: 500
+            ///     importance: medium
+            /// </summary>
+            public const string FetchErrorBackoffMs = "fetch.error.backoff.ms";
+
+            /// <summary>
+            ///     Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string EnablePartitionEof = "enable.partition.eof";
+
+            /// <summary>
+            ///     Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.
+            ///
+            ///     default: false
+            ///     importance: medium
+            /// </summary>
+            public const string CheckCrcs = "check.crcs";
+
+            /// <summary>
+            ///     When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.
+            ///
+            ///     default: false
+            ///     importance: high
+            /// </summary>
+            public const string EnableIdempotence = "enable.idempotence";
+
+            /// <summary>
+            ///     **EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.
+            ///
+            ///     default: false
+            ///     importance: low
+            /// </summary>
+            public const string EnableGaplessGuarantee = "enable.gapless.guarantee";
+
+            /// <summary>
+            ///     Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
+            ///
+            ///     default: 100000
+            ///     importance: high
+            /// </summary>
+            public const string QueueBufferingMaxMessages = "queue.buffering.max.messages";
+
+            /// <summary>
+            ///     Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.
+            ///
+            ///     default: 1048576
+            ///     importance: high
+            /// </summary>
+            public const string QueueBufferingMaxKbytes = "queue.buffering.max.kbytes";
+
+            /// <summary>
+            ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
+            ///
+            ///     default: 0
+            ///     importance: high
+            /// </summary>
+            public const string LingerMs = "linger.ms";
+
+            /// <summary>
+            ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
+            ///
+            ///     default: 2
+            ///     importance: high
+            /// </summary>
+            public const string MessageSendMaxRetries = "message.send.max.retries";
+
+            /// <summary>
+            ///     The backoff time in milliseconds before retrying a protocol request.
+            ///
+            ///     default: 100
+            ///     importance: medium
+            /// </summary>
+            public const string RetryBackoffMs = "retry.backoff.ms";
+
+            /// <summary>
+            ///     The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.
+            ///
+            ///     default: 1
+            ///     importance: low
+            /// </summary>
+            public const string QueueBufferingBackpressureThreshold = "queue.buffering.backpressure.threshold";
+
+            /// <summary>
+            ///     compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
+            ///
+            ///     default: none
+            ///     importance: medium
+            /// </summary>
+            public const string CompressionType = "compression.type";
+
+            /// <summary>
+            ///     Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by message.max.bytes.
+            ///
+            ///     default: 10000
+            ///     importance: medium
+            /// </summary>
+            public const string BatchNumMessages = "batch.num.messages";
+
+        }
+    }
+
     /// <summary>
     ///     Configuration common to all clients
     /// </summary>

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -928,26 +928,25 @@ namespace Confluent.Kafka
     /// </summary>
     public class ClientConfig : Config
     {
-
-        /// <summary>
-        /// Creates a new ClientConfig class by taking a copy of the provided <paramref name="configSource"/>.
-        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
-        /// </summary>
-        /// <param name="configSource"></param>
-        /// <returns></returns>
-        public static new ClientConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new ClientConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
-
         /// <summary>
         ///     Initialize a new empty <see cref="ClientConfig" /> instance.
         /// </summary>
         public ClientConfig() : base() { }
 
         /// <summary>
+        ///     Initialize a new <see cref="ClientConfig" /> instance copying
+        ///     an existing key/value collection.
+        ///     This will create a copy of the <paramref name="configSource"/> i.e. operations on this class WILL NOT modify the provided collection
+        /// </summary>
+        /// <param name="configSource"></param>
+        public ClientConfig(IEnumerable<KeyValuePair<string, string>> configSource) : base(configSource) { }
+
+        /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
-        ///     an existing <see cref="ClientConfig" /> instance.
+        ///     an existing <see cref="Config" /> instance.
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
-        public ClientConfig(ClientConfig config) : base(config) { }
+        public ClientConfig(Config config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
@@ -1428,26 +1427,25 @@ namespace Confluent.Kafka
     /// </summary>
     public class AdminClientConfig : ClientConfig
     {
-
-        /// <summary>
-        /// Creates a new AdminClientConfig class by taking a copy of the provided <paramref name="configSource"/>.
-        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
-        /// </summary>
-        /// <param name="configSource"></param>
-        /// <returns></returns>
-        public static new AdminClientConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new AdminClientConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
-
         /// <summary>
         ///     Initialize a new empty <see cref="AdminClientConfig" /> instance.
         /// </summary>
         public AdminClientConfig() : base() { }
 
         /// <summary>
+        ///     Initialize a new <see cref="AdminClientConfig" /> instance copying
+        ///     an existing key/value collection.
+        ///     This will create a copy of the <paramref name="configSource"/> i.e. operations on this class WILL NOT modify the provided collection
+        /// </summary>
+        /// <param name="configSource"></param>
+        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> configSource) : base(configSource) { }
+
+        /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
-        ///     an existing <see cref="ClientConfig" /> instance.
+        ///     an existing <see cref="Config" /> instance.
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
-        public AdminClientConfig(ClientConfig config) : base(config) { }
+        public AdminClientConfig(Config config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
@@ -1463,26 +1461,25 @@ namespace Confluent.Kafka
     /// </summary>
     public class ProducerConfig : ClientConfig
     {
-
-        /// <summary>
-        /// Creates a new ProducerConfig class by taking a copy of the provided <paramref name="configSource"/>.
-        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
-        /// </summary>
-        /// <param name="configSource"></param>
-        /// <returns></returns>
-        public static new ProducerConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new ProducerConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
-
         /// <summary>
         ///     Initialize a new empty <see cref="ProducerConfig" /> instance.
         /// </summary>
         public ProducerConfig() : base() { }
 
         /// <summary>
+        ///     Initialize a new <see cref="ProducerConfig" /> instance copying
+        ///     an existing key/value collection.
+        ///     This will create a copy of the <paramref name="configSource"/> i.e. operations on this class WILL NOT modify the provided collection
+        /// </summary>
+        /// <param name="configSource"></param>
+        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> configSource) : base(configSource) { }
+
+        /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
-        ///     an existing <see cref="ClientConfig" /> instance.
+        ///     an existing <see cref="Config" /> instance.
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
-        public ProducerConfig(ClientConfig config) : base(config) { }
+        public ProducerConfig(Config config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
@@ -1643,26 +1640,25 @@ namespace Confluent.Kafka
     /// </summary>
     public class ConsumerConfig : ClientConfig
     {
-
-        /// <summary>
-        /// Creates a new ConsumerConfig class by taking a copy of the provided <paramref name="configSource"/>.
-        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
-        /// </summary>
-        /// <param name="configSource"></param>
-        /// <returns></returns>
-        public static new ConsumerConfig CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new ConsumerConfig(configSource.ToDictionary(a => a.Key, a => a.Value));
-
         /// <summary>
         ///     Initialize a new empty <see cref="ConsumerConfig" /> instance.
         /// </summary>
         public ConsumerConfig() : base() { }
 
         /// <summary>
+        ///     Initialize a new <see cref="ConsumerConfig" /> instance copying
+        ///     an existing key/value collection.
+        ///     This will create a copy of the <paramref name="configSource"/> i.e. operations on this class WILL NOT modify the provided collection
+        /// </summary>
+        /// <param name="configSource"></param>
+        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> configSource) : base(configSource) { }
+
+        /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
-        ///     an existing <see cref="ClientConfig" /> instance.
+        ///     an existing <see cref="Config" /> instance.
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
-        public ConsumerConfig(ClientConfig config) : base(config) { }
+        public ConsumerConfig(Config config) : base(config) { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -224,9 +224,17 @@ namespace Confluent.Kafka
     {
 
         /// <summary>
+        /// Creates a new ClientConfig class by taking a copy of the provided <paramref name="configSource"/>.
+        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
+        /// </summary>
+        /// <param name="configSource"></param>
+        /// <returns></returns>
+        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+
+        /// <summary>
         ///     Initialize a new empty <see cref="ClientConfig" /> instance.
         /// </summary>
-        public ClientConfig() { }
+        public ClientConfig() : base() { }
 
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance wrapping
@@ -241,13 +249,6 @@ namespace Confluent.Kafka
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ClientConfig(IDictionary<string, string> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="ClientConfig" /> instance copying
-        ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
-        /// </summary>
-        public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
         /// <summary>
         ///     SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism.
@@ -723,9 +724,17 @@ namespace Confluent.Kafka
     {
 
         /// <summary>
+        /// Creates a new AdminClientConfig class by taking a copy of the provided <paramref name="configSource"/>.
+        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
+        /// </summary>
+        /// <param name="configSource"></param>
+        /// <returns></returns>
+        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+
+        /// <summary>
         ///     Initialize a new empty <see cref="AdminClientConfig" /> instance.
         /// </summary>
-        public AdminClientConfig() { }
+        public AdminClientConfig() : base() { }
 
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance wrapping
@@ -740,13 +749,6 @@ namespace Confluent.Kafka
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public AdminClientConfig(IDictionary<string, string> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="AdminClientConfig" /> instance copying
-        ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
-        /// </summary>
-        public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
     }
 
 
@@ -757,9 +759,17 @@ namespace Confluent.Kafka
     {
 
         /// <summary>
+        /// Creates a new ProducerConfig class by taking a copy of the provided <paramref name="configSource"/>.
+        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
+        /// </summary>
+        /// <param name="configSource"></param>
+        /// <returns></returns>
+        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+
+        /// <summary>
         ///     Initialize a new empty <see cref="ProducerConfig" /> instance.
         /// </summary>
-        public ProducerConfig() { }
+        public ProducerConfig() : base() { }
 
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance wrapping
@@ -774,13 +784,6 @@ namespace Confluent.Kafka
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ProducerConfig(IDictionary<string, string> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="ProducerConfig" /> instance copying
-        ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
-        /// </summary>
-        public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
         /// <summary>
         ///     Specifies whether or not the producer should start a background poll 
@@ -936,9 +939,17 @@ namespace Confluent.Kafka
     {
 
         /// <summary>
+        /// Creates a new ConsumerConfig class by taking a copy of the provided <paramref name="configSource"/>.
+        /// The <paramref name="configSource"/> can be any of: IEnumerable; Dictonary; any of the Config types.
+        /// </summary>
+        /// <param name="configSource"></param>
+        /// <returns></returns>
+        public static Config CopyFrom(IEnumerable<KeyValuePair<string, string>> configSource) => new Config(configSource.ToDictionary(a => a.Key, a => a.Value));
+
+        /// <summary>
         ///     Initialize a new empty <see cref="ConsumerConfig" /> instance.
         /// </summary>
-        public ConsumerConfig() { }
+        public ConsumerConfig() : base() { }
 
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance wrapping
@@ -953,13 +964,6 @@ namespace Confluent.Kafka
         ///     This will change the values "in-place" i.e. operations on this class WILL modify the provided collection
         /// </summary>
         public ConsumerConfig(IDictionary<string, string> config) : base(config) { }
-
-        /// <summary>
-        ///     Initialize a new <see cref="ConsumerConfig" /> instance copying
-        ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. operations on this class WILL NOT modify the provided collection
-        /// </summary>
-        public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
         /// <summary>
         ///     A comma separated list of fields that may be optionally set

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -245,7 +245,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ClientConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
         /// </summary>
         public ClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
@@ -744,7 +744,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="AdminClientConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
         /// </summary>
         public AdminClientConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
     }
@@ -778,7 +778,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ProducerConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
         /// </summary>
         public ProducerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 
@@ -957,7 +957,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Initialize a new <see cref="ConsumerConfig" /> instance copying
         ///     an existing key/value pair collection.
-        ///     This will make a copy of the provided values i.e. the original will be NOT modified
+        ///     This will make a copy of the provided values i.e. operations on this class will NOT modify the original
         /// </summary>
         public ConsumerConfig(IEnumerable<KeyValuePair<string, string>> config) : base(config) { }
 

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -544,9 +544,9 @@ namespace Confluent.Kafka
             }
 
             var modifiedConfig = config
-                .Where(prop => prop.Key != ConfigPropertyNames.Consumer.ConsumeResultFields);
+                .Where(prop => prop.Key != Kafka.Config.PropertyNames.Consumer.ConsumeResultFields);
 
-            var enabledFieldsObj = config.FirstOrDefault(prop => prop.Key == ConfigPropertyNames.Consumer.ConsumeResultFields).Value;
+            var enabledFieldsObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Consumer.ConsumeResultFields).Value;
             if (enabledFieldsObj != null)
             {
                 var fields = enabledFieldsObj.Replace(" ", "");
@@ -566,7 +566,7 @@ namespace Confluent.Kafka
                                 case "timestamp": this.enableTimestampMarshaling = true; break;
                                 case "topic": this.enableTopicNameMarshaling = true; break;
                                 default: throw new ArgumentException(
-                                    $"Unexpected consume result field name '{part}' in config value '{ConfigPropertyNames.Consumer.ConsumeResultFields}'.");
+                                    $"Unexpected consume result field name '{part}' in config value '{Kafka.Config.PropertyNames.Consumer.ConsumeResultFields}'.");
                             }
                         }
                     }

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -544,9 +544,9 @@ namespace Confluent.Kafka
             }
 
             var modifiedConfig = config
-                .Where(prop => prop.Key != Kafka.Config.PropertyNames.Consumer.ConsumeResultFields);
+                .Where(prop => prop.Key != ConsumerConfig.PropertyNames.ConsumeResultFields);
 
-            var enabledFieldsObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Consumer.ConsumeResultFields).Value;
+            var enabledFieldsObj = config.FirstOrDefault(prop => prop.Key == ConsumerConfig.PropertyNames.ConsumeResultFields).Value;
             if (enabledFieldsObj != null)
             {
                 var fields = enabledFieldsObj.Replace(" ", "");
@@ -566,7 +566,7 @@ namespace Confluent.Kafka
                                 case "timestamp": this.enableTimestampMarshaling = true; break;
                                 case "topic": this.enableTopicNameMarshaling = true; break;
                                 default: throw new ArgumentException(
-                                    $"Unexpected consume result field name '{part}' in config value '{Kafka.Config.PropertyNames.Consumer.ConsumeResultFields}'.");
+                                    $"Unexpected consume result field name '{part}' in config value '{ConsumerConfig.PropertyNames.ConsumeResultFields}'.");
                             }
                         }
                     }

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -109,7 +109,7 @@ namespace Confluent.Kafka
         ///     A collection of librdkafka configuration parameters 
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     <see cref="Confluent.Kafka.Config.PropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
         ///     specified.
         /// </param>

--- a/src/Confluent.Kafka/ConsumerBuilder.cs
+++ b/src/Confluent.Kafka/ConsumerBuilder.cs
@@ -109,7 +109,7 @@ namespace Confluent.Kafka
         ///     A collection of librdkafka configuration parameters 
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.Config.PropertyNames" />).
+        ///     <see cref="ConsumerConfig.PropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' and 'group.id' must be
         ///     specified.
         /// </param>

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -511,9 +511,9 @@ namespace Confluent.Kafka
 
             var modifiedConfig = config
                 .Where(prop => 
-                    prop.Key != ConfigPropertyNames.Producer.EnableBackgroundPoll &&
-                    prop.Key != ConfigPropertyNames.Producer.EnableDeliveryReports &&
-                    prop.Key != ConfigPropertyNames.Producer.DeliveryReportFields);
+                    prop.Key != Kafka.Config.PropertyNames.Producer.EnableBackgroundPoll &&
+                    prop.Key != Kafka.Config.PropertyNames.Producer.EnableDeliveryReports &&
+                    prop.Key != Kafka.Config.PropertyNames.Producer.DeliveryReportFields);
 
             if (modifiedConfig.Where(obj => obj.Key == "delivery.report.only.error").Count() > 0)
             {
@@ -524,19 +524,19 @@ namespace Confluent.Kafka
                 throw new ArgumentException("The 'delivery.report.only.error' property is not supported by this client");
             }
 
-            var enableBackgroundPollObj = config.FirstOrDefault(prop => prop.Key == ConfigPropertyNames.Producer.EnableBackgroundPoll).Value;
+            var enableBackgroundPollObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Producer.EnableBackgroundPoll).Value;
             if (enableBackgroundPollObj != null)
             {
                 this.manualPoll = !bool.Parse(enableBackgroundPollObj);
             }
 
-            var enableDeliveryReportsObj = config.FirstOrDefault(prop => prop.Key == ConfigPropertyNames.Producer.EnableDeliveryReports).Value;
+            var enableDeliveryReportsObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Producer.EnableDeliveryReports).Value;
             if (enableDeliveryReportsObj != null)
             {
                 this.enableDeliveryReports = bool.Parse(enableDeliveryReportsObj);
             }
 
-            var deliveryReportEnabledFieldsObj = config.FirstOrDefault(prop => prop.Key == ConfigPropertyNames.Producer.DeliveryReportFields).Value;
+            var deliveryReportEnabledFieldsObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Producer.DeliveryReportFields).Value;
             if (deliveryReportEnabledFieldsObj != null)
             {
                 var fields = deliveryReportEnabledFieldsObj.Replace(" ", "");
@@ -560,7 +560,7 @@ namespace Confluent.Kafka
                                 case "headers": this.enableDeliveryReportHeaders = true; break;
                                 case "status": this.enableDeliveryReportPersistedStatus = true; break;
                                 default: throw new ArgumentException(
-                                    $"Unknown delivery report field name '{part}' in config value '{ConfigPropertyNames.Producer.DeliveryReportFields}'.");
+                                    $"Unknown delivery report field name '{part}' in config value '{Kafka.Config.PropertyNames.Producer.DeliveryReportFields}'.");
                             }
                         }
                     }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -511,9 +511,9 @@ namespace Confluent.Kafka
 
             var modifiedConfig = config
                 .Where(prop => 
-                    prop.Key != Kafka.Config.PropertyNames.Producer.EnableBackgroundPoll &&
-                    prop.Key != Kafka.Config.PropertyNames.Producer.EnableDeliveryReports &&
-                    prop.Key != Kafka.Config.PropertyNames.Producer.DeliveryReportFields);
+                    prop.Key != ProducerConfig.PropertyNames.EnableBackgroundPoll &&
+                    prop.Key != ProducerConfig.PropertyNames.EnableDeliveryReports &&
+                    prop.Key != ProducerConfig.PropertyNames.DeliveryReportFields);
 
             if (modifiedConfig.Where(obj => obj.Key == "delivery.report.only.error").Count() > 0)
             {
@@ -524,19 +524,19 @@ namespace Confluent.Kafka
                 throw new ArgumentException("The 'delivery.report.only.error' property is not supported by this client");
             }
 
-            var enableBackgroundPollObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Producer.EnableBackgroundPoll).Value;
+            var enableBackgroundPollObj = config.FirstOrDefault(prop => prop.Key == ProducerConfig.PropertyNames.EnableBackgroundPoll).Value;
             if (enableBackgroundPollObj != null)
             {
                 this.manualPoll = !bool.Parse(enableBackgroundPollObj);
             }
 
-            var enableDeliveryReportsObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Producer.EnableDeliveryReports).Value;
+            var enableDeliveryReportsObj = config.FirstOrDefault(prop => prop.Key == ProducerConfig.PropertyNames.EnableDeliveryReports).Value;
             if (enableDeliveryReportsObj != null)
             {
                 this.enableDeliveryReports = bool.Parse(enableDeliveryReportsObj);
             }
 
-            var deliveryReportEnabledFieldsObj = config.FirstOrDefault(prop => prop.Key == Kafka.Config.PropertyNames.Producer.DeliveryReportFields).Value;
+            var deliveryReportEnabledFieldsObj = config.FirstOrDefault(prop => prop.Key == ProducerConfig.PropertyNames.DeliveryReportFields).Value;
             if (deliveryReportEnabledFieldsObj != null)
             {
                 var fields = deliveryReportEnabledFieldsObj.Replace(" ", "");
@@ -560,7 +560,7 @@ namespace Confluent.Kafka
                                 case "headers": this.enableDeliveryReportHeaders = true; break;
                                 case "status": this.enableDeliveryReportPersistedStatus = true; break;
                                 default: throw new ArgumentException(
-                                    $"Unknown delivery report field name '{part}' in config value '{Kafka.Config.PropertyNames.Producer.DeliveryReportFields}'.");
+                                    $"Unknown delivery report field name '{part}' in config value '{ProducerConfig.PropertyNames.DeliveryReportFields}'.");
                             }
                         }
                     }

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -87,7 +87,7 @@ namespace Confluent.Kafka
         ///     A collection of librdkafka configuration parameters 
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.Config.PropertyNames" />).
+        ///     <see cref="ProducerConfig.PropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </summary>
         public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -87,7 +87,7 @@ namespace Confluent.Kafka
         ///     A collection of librdkafka configuration parameters 
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
         ///     and parameters specific to this client (refer to: 
-        ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
+        ///     <see cref="Confluent.Kafka.Config.PropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </summary>
         public ProducerBuilder(IEnumerable<KeyValuePair<string, string>> config)


### PR DESCRIPTION
 * delegate to base ctors
 * simplify the creation of the kvp -> dictionary
 * add ability to update a dictionary "in place"
Last one is handy for config validation, setting defaults etc in dotnetCore IOptions stuff