### PR TITLE
-> 1.0-RC6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.0-RC5
+# 1.0.0-RC6
 
 ## New Features
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ confluent-kafka-dotnet is distributed via NuGet. We provide three packages:
 To install Confluent.Kafka from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
 
 ```
-Install-Package Confluent.Kafka -Version 1.0.0-RC5
+Install-Package Confluent.Kafka -Version 1.0.0-RC6
 ```
 
 To add a reference to a dotnet core project, execute the following at the command line:
 
 ```
-dotnet add package -v 1.0.0-RC5 Confluent.Kafka
+dotnet add package -v 1.0.0-RC6 Confluent.Kafka
 ```
 
-**Note:** We recommend using the `1.0.0-RC5` version of Confluent.Kafka for new projects in preference to the most recent stable release (0.11.6).
+**Note:** We recommend using the `1.0.0-RC6` version of Confluent.Kafka for new projects in preference to the most recent stable release (0.11.6).
 The 1.0 API provides more features, is considerably improved and is more performant than 0.11.x releases.
 
 ### Branch builds

--- a/examples/AdminClient/AdminClient.csproj
+++ b/examples/AdminClient/AdminClient.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/AvroBlogExamples/AvroBlogExamples.csproj
+++ b/examples/AvroBlogExamples/AvroBlogExamples.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes/Confluent.SchemaRegistry.Serdes.csproj" />
   </ItemGroup>
 

--- a/examples/AvroGeneric/AvroGeneric.csproj
+++ b/examples/AvroGeneric/AvroGeneric.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes/Confluent.SchemaRegistry.Serdes.csproj" />
   </ItemGroup>
 

--- a/examples/AvroSpecific/AvroSpecific.csproj
+++ b/examples/AvroSpecific/AvroSpecific.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes/Confluent.SchemaRegistry.Serdes.csproj" />
   </ItemGroup>
 

--- a/examples/ConfluentCloud/ConfluentCloud.csproj
+++ b/examples/ConfluentCloud/ConfluentCloud.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Consumer/Consumer.csproj
+++ b/examples/Consumer/Consumer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Producer/Producer.csproj
+++ b/examples/Producer/Producer.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
   

--- a/examples/Protobuf/Protobuf.csproj
+++ b/examples/Protobuf/Protobuf.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC5" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC6" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
     <PackageReference Include="Grpc.Tools" Version="1.16.0" />
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -12,7 +12,7 @@
     <PackageId>Confluent.Kafka</PackageId>
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
-    <VersionPrefix>1.0.0-RC5</VersionPrefix>
+    <VersionPrefix>1.0.0-RC6</VersionPrefix>
     <TargetFrameworks>net45;net46;netcoreapp2.1;netstandard1.3;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Confluent.SchemaRegistry.Serdes/Confluent.SchemaRegistry.Serdes.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes/Confluent.SchemaRegistry.Serdes.csproj
@@ -13,7 +13,7 @@
     <PackageId>Confluent.SchemaRegistry.Serdes</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes</Title>
     <AssemblyName>Confluent.SchemaRegistry.Serdes</AssemblyName>
-    <VersionPrefix>1.0.0-R53</VersionPrefix>
+    <VersionPrefix>1.0.0-RC6</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net452;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
+++ b/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
@@ -13,7 +13,7 @@
     <PackageId>Confluent.SchemaRegistry</PackageId>
     <Title>Confluent.SchemaRegistry</Title>
     <AssemblyName>Confluent.SchemaRegistry</AssemblyName>
-    <VersionPrefix>1.0.0-RC5</VersionPrefix>
+    <VersionPrefix>1.0.0-RC6</VersionPrefix>
     <TargetFrameworks>net452;netstandard1.4;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
I accidentally versioned Confluent.SchemaRegistry.Serdes v1.0-R53 not 1.0-RC5. the other artifacts are already on nuget, the only non-hack thing we can do is -> RC6.