### PR TITLE
moved all sync-over-async functionality to it's own namespace

### DIFF
--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -16,6 +16,7 @@
 
 using Avro.Generic;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using System;

--- a/examples/AvroGeneric/Program.cs
+++ b/examples/AvroGeneric/Program.cs
@@ -16,6 +16,7 @@
 
 using Avro;
 using Avro.Generic;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using System;

--- a/examples/AvroSpecific/Program.cs
+++ b/examples/AvroSpecific/Program.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 

--- a/src/Confluent.Kafka/SyncOverAsyncDeserializer.cs
+++ b/src/Confluent.Kafka/SyncOverAsyncDeserializer.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Confluent.Kafka
+namespace Confluent.Kafka.SyncOverAsync
 {
     /// <summary>
     ///     An adapter that allows an async deserializer
@@ -86,7 +86,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Create a sync deserializer by wrapping an async
         ///     one. For more information on the potential
-        ///     pitfalls in doing this, refer to <see cref="Confluent.Kafka.SyncOverAsyncDeserializer{T}" />.
+        ///     pitfalls in doing this, refer to <see cref="Confluent.Kafka.SyncOverAsync.SyncOverAsyncDeserializer{T}" />.
         /// </summary>
         public static IDeserializer<T> AsSyncOverAsync<T>(this IAsyncDeserializer<T> asyncDeserializer)
             => new SyncOverAsyncDeserializer<T>(asyncDeserializer);

--- a/src/Confluent.Kafka/SyncOverAsyncSerializer.cs
+++ b/src/Confluent.Kafka/SyncOverAsyncSerializer.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Confluent.Kafka
+namespace Confluent.Kafka.SyncOverAsync
 {
     /// <summary>
     ///     An adapter that allows an async serializer
@@ -76,7 +76,6 @@ namespace Confluent.Kafka
                 .GetResult();
     }
 
-
     /// <summary>
     ///     Extension methods related to SyncOverAsyncSerializer.
     /// </summary>
@@ -85,7 +84,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Create a sync serializer by wrapping an async
         ///     one. For more information on the potential
-        ///     pitfalls in doing this, refer to <see cref="Confluent.Kafka.SyncOverAsyncSerializer{T}" />.
+        ///     pitfalls in doing this, refer to <see cref="Confluent.Kafka.SyncOverAsync.SyncOverAsyncSerializer{T}" />.
         /// </summary>
         public static ISerializer<T> AsSyncOverAsync<T>(this IAsyncSerializer<T> asyncSerializer)
             => new SyncOverAsyncSerializer<T>(asyncSerializer);

--- a/test/Confluent.Kafka.IntegrationTests/Serdes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Serdes.cs
@@ -17,6 +17,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 
 namespace Confluent.Kafka.IntegrationTests
 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -17,6 +17,7 @@
 using Confluent.Kafka;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.Kafka.Examples.AvroSpecific;
 using System;
 using System.Collections.Generic;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using Confluent.Kafka;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.Kafka.Examples.AvroSpecific;
 using Xunit;
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.Kafka.Examples.AvroSpecific;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Xunit;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsume.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsume.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Confluent.Kafka.Examples.AvroSpecific;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Xunit;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsumeGeneric.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsumeGeneric.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Confluent.Kafka;
 using Confluent.Kafka.Examples.AvroSpecific;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry.Serdes;
 using Confluent.SchemaRegistry;
 using Avro;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/SyncOverAsync.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/SyncOverAsync.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 using Xunit;
 
 


### PR DESCRIPTION
it's not usual for library implementers to provide SyncOverAsync helper methods. our case is special though because we currently force people to do sync-over-async in order to use the consumer with the avro serializers. However, when we implement `ConsumeAsync`, we won't want people to do this, and we won't really want these extension methods visible to all who do `using Confluent.Kafka`. This PR moves SyncOverAsync functionality to it's own namespace, which is easy to ignore in the future, whilst not being too much of a burden to use now.