### PR TITLE
added API-SUBJECT-TO-CHANGE notice

### DIFF
--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -23,6 +23,9 @@ namespace Confluent.Kafka
     /// <summary>
     ///     A builder class for <see cref="IProducer{TKey, TValue}" /> instance
     ///     implementations that leverage an existing client handle.
+    ///
+    ///     [API-SUBJECT-TO-CHANGE] - This class may be removed in the future
+    ///     in favor of an improved API for this functionality.
     /// </summary>
     public class DependentProducerBuilder<TKey, TValue>
     {


### PR DESCRIPTION
This way of leveraging a single producer handle with different data types is flawed and also a bit inconvenient to use. this PR allows for the possibility for this to be solved properly in the future without a major version bump.