### PR TITLE
removed redundant access properties from ConsumeResult<TKey, TValue>

### DIFF
--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -124,7 +124,7 @@ namespace AvroBlogExample
 
                             Console.WriteLine(
                                 consumeResult.Message.Timestamp.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")
-                                + $": [{consumeResult.Value.Severity}] {consumeResult.Value.Message}");
+                                + $": [{consumeResult.Message?.Value.Severity}] {consumeResult.Message?.Value.Message}");
                         }
                         catch (ConsumeException e)
                         {

--- a/examples/AvroGeneric/Program.cs
+++ b/examples/AvroGeneric/Program.cs
@@ -77,7 +77,7 @@ namespace Confluent.Kafka.Examples.AvroGeneric
                             {
                                 var consumeResult = consumer.Consume(cts.Token);
 
-                                Console.WriteLine($"Key: {consumeResult.Message.Key}\nValue: {consumeResult.Value}");
+                                Console.WriteLine($"Key: {consumeResult.Message.Key}\nValue: {consumeResult.Message?.Value}");
                             }
                             catch (ConsumeException e)
                             {

--- a/examples/AvroSpecific/Program.cs
+++ b/examples/AvroSpecific/Program.cs
@@ -96,7 +96,7 @@ namespace Confluent.Kafka.Examples.AvroSpecific
                             {
                                 var consumeResult = consumer.Consume(cts.Token);
 
-                                Console.WriteLine($"user key name: {consumeResult.Message.Key}, user value favorite color: {consumeResult.Value.favorite_color}");
+                                Console.WriteLine($"user key name: {consumeResult.Message.Key}, user value favorite color: {consumeResult.Message?.Value.favorite_color}");
                             }
                             catch (ConsumeException e)
                             {

--- a/examples/ConfluentCloud/Program.cs
+++ b/examples/ConfluentCloud/Program.cs
@@ -93,7 +93,7 @@ namespace ConfluentCloudExample
                 try
                 {
                     var consumeResult = consumer.Consume();
-                    Console.WriteLine($"consumed: {consumeResult.Value}");
+                    Console.WriteLine($"consumed: {consumeResult.Message?.Value}");
                 }
                 catch (ConsumeException e)
                 {

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -92,7 +92,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                                 continue;
                             }
 
-                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: {consumeResult.Value}");
+                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: {consumeResult.Message?.Value}");
 
                             if (consumeResult.Offset % commitPeriod == 0)
                             {
@@ -163,7 +163,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                             // Note: End of partition notification has not been enabled, so
                             // it is guaranteed that the ConsumeResult instance corresponds
                             // to a Message, and not a PartitionEOF event.
-                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: ${consumeResult.Value}");
+                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: ${consumeResult.Message?.Value}");
                         }
                         catch (ConsumeException e)
                         {

--- a/examples/Protobuf/Program.cs
+++ b/examples/Protobuf/Program.cs
@@ -75,7 +75,7 @@ namespace Confluent.Kafka.Examples.Protobuf
                 {
                     consumer.Subscribe("protobuf-test-topic");
                     var cr = consumer.Consume();
-                    Console.WriteLine($"User: [id: {cr.Key}, favorite color: {cr.Message.Value.FavoriteColor}]");
+                    Console.WriteLine($"User: [id: {cr.Message?.Key}, favorite color: {cr.Message.Value.FavoriteColor}]");
                 }
             });
 

--- a/src/Confluent.Kafka/ConsumeResult.cs
+++ b/src/Confluent.Kafka/ConsumeResult.cs
@@ -69,42 +69,6 @@ namespace Confluent.Kafka
         public Message<TKey, TValue> Message { get; set; }
 
         /// <summary>
-        ///     The Kafka message Key.
-        /// </summary>
-        public TKey Key
-        {
-            get { return Message.Key; }
-            set { Message.Key = value; }
-        }
-
-        /// <summary>
-        ///     The Kafka message Value.
-        /// </summary>
-        public TValue Value
-        {
-            get { return Message.Value; }
-            set { Message.Value = value; }
-        }
-
-        /// <summary>
-        ///     The Kafka message timestamp.
-        /// </summary>
-        public Timestamp Timestamp
-        {
-            get { return Message.Timestamp; }
-            set { Message.Timestamp = value; }
-        }
-
-        /// <summary>
-        ///     The Kafka message headers.
-        /// </summary>
-        public Headers Headers
-        {
-            get { return Message.Headers; }
-            set { Message.Headers = value; }
-        }
-
-        /// <summary>
         ///     True if this instance represents an end of partition
         ///     event, false if it represents a message in kafka.
         /// </summary>

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -63,7 +63,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(dr.TopicPartition, dr.Offset) });
                 var cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 consumer.Commit();
-                Assert.Equal(cr.Value, testString);
+                Assert.Equal(cr.Message?.Value, testString);
                 
                 // Determine offset to consume from automatically.
                 consumer.Assign(new List<TopicPartition>() { dr.TopicPartition });
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new TopicPartitionOffset(dr.TopicPartition, dr3.Offset));
                 cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 consumer.Commit();
-                Assert.Equal(cr.Value, testString3);
+                Assert.Equal(cr.Message?.Value, testString3);
 
                 // Determine offset to consume from automatically.
                 consumer.Assign(dr.TopicPartition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -123,8 +123,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 c.Assign(dr.TopicPartitionOffset);
                 var cr = c.Consume(TimeSpan.FromSeconds(10));
-                Assert.Equal("abc", cr.Key);
-                Assert.Equal("123", cr.Value);
+                Assert.Equal("abc", cr.Message?.Key);
+                Assert.Equal("123", cr.Message?.Value);
             }
 
             using (var c = new ConsumerBuilder<byte[], byte[]>(consumerConfig).Build())
@@ -132,8 +132,8 @@ namespace Confluent.Kafka.IntegrationTests
                 c.Assign(dr.TopicPartitionOffset);
                 var cr = c.Consume(TimeSpan.FromSeconds(10));
                 // check that each character is serialized into 4 bytes.
-                Assert.Equal(3*4, cr.Key.Length);
-                Assert.Equal(3*4, cr.Value.Length);
+                Assert.Equal(3*4, cr.Message?.Key.Length);
+                Assert.Equal(3*4, cr.Message?.Value.Length);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -64,8 +64,8 @@ namespace Confluent.Kafka.IntegrationTests
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Null(record.Message.Headers);
-                Assert.NotEqual(TimestampType.NotAvailable, record.Timestamp.Type);
-                Assert.NotEqual(0, record.Timestamp.UnixTimestampMs);
+                Assert.NotEqual(TimestampType.NotAvailable, record.Message?.Timestamp.Type);
+                Assert.NotEqual(0, record.Message?.Timestamp.UnixTimestampMs);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -64,8 +64,8 @@ namespace Confluent.Kafka.IntegrationTests
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.NotNull(record.Message.Headers);
-                Assert.Equal(TimestampType.NotAvailable, record.Timestamp.Type);
-                Assert.Equal(0, record.Timestamp.UnixTimestampMs);
+                Assert.Equal(TimestampType.NotAvailable, record.Message?.Timestamp.Type);
+                Assert.Equal(0, record.Message?.Timestamp.UnixTimestampMs);
             }
             
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -318,7 +318,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, nulldr.Offset));
                 var cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(cr?.Message);
-                Assert.Single(cr.Headers);
+                Assert.Single(cr.Message?.Headers);
                 Assert.Equal("my-header", cr.Message.Headers[0].Key);
                 Assert.Null(cr.Message.Headers[0].GetValueBytes());
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -73,10 +73,10 @@ namespace Confluent.Kafka.IntegrationTests
 
                 ConsumeResult<Ignore, byte[]> record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
-                Assert.Null(record.Key);
-                Assert.NotNull(record.Value);
-                Assert.Equal(42, record.Value[0]);
-                Assert.Equal(240, record.Value[1]);
+                Assert.Null(record.Message.Key);
+                Assert.NotNull(record.Message.Value);
+                Assert.Equal(42, record.Message.Value[0]);
+                Assert.Equal(240, record.Message.Value[1]);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
@@ -87,8 +87,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
                     var r1 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(new byte[] { 42 }, r1.Key);
-                    Assert.Equal(new byte[] { 33 }, r1.Value);
+                    Assert.Equal(new byte[] { 42 }, r1.Message?.Key);
+                    Assert.Equal(new byte[] { 33 }, r1.Message?.Value);
                     Assert.Equal(0, r1.Offset);
                 }
 
@@ -96,8 +96,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 1));
                     var r2 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal("hello", r2.Key);
-                    Assert.Equal("world", r2.Value);
+                    Assert.Equal("hello", r2.Message?.Key);
+                    Assert.Equal("world", r2.Message?.Value);
                     Assert.Equal(1, r2.Offset);
                 }
 
@@ -105,8 +105,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 2));
                     var r3 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(new byte[] { 40 }, r3.Key);
-                    Assert.Equal(new byte[] { 31 }, r3.Value);
+                    Assert.Equal(new byte[] { 40 }, r3.Message?.Key);
+                    Assert.Equal(new byte[] { 31 }, r3.Message?.Value);
                     Assert.Equal(2, r3.Offset);
                 }
 
@@ -114,8 +114,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 3));
                     var r4 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(42, r4.Key);
-                    Assert.Equal("mellow world", r4.Value);
+                    Assert.Equal(42, r4.Message?.Key);
+                    Assert.Equal("mellow world", r4.Message?.Value);
                     Assert.Equal(3, r4.Offset);
                 }
 
@@ -123,8 +123,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 4));
                     var r5 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(int.MaxValue, r5.Key);
-                    Assert.Equal(int.MinValue, r5.Value);
+                    Assert.Equal(int.MaxValue, r5.Message?.Key);
+                    Assert.Equal(int.MinValue, r5.Message?.Value);
                     Assert.Equal(4, r5.Offset);
                 }
 
@@ -132,8 +132,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 5));
                     var r6 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal("yellow mould", r6.Key);
-                    Assert.Equal(new byte[] { 69 }, r6.Value);
+                    Assert.Equal("yellow mould", r6.Message?.Key);
+                    Assert.Equal(new byte[] { 69 }, r6.Message?.Value);
                     Assert.Equal(5, r6.Offset);
                 }
 
@@ -141,8 +141,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 6));
                     var r7 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(44.0, r7.Key);
-                    Assert.Equal(234.4, r7.Value);
+                    Assert.Equal(44.0, r7.Message?.Key);
+                    Assert.Equal(234.4, r7.Message?.Value);
                     Assert.Equal(6, r7.Offset);
                 }
             }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -116,8 +116,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     {
                         consumer.Assign(new TopicPartitionOffset(topic1.Name, 0, 0));
                         var cr = consumer.Consume();
-                        Assert.Equal("hello", cr.Key);
-                        Assert.Equal("world", cr.Value);
+                        Assert.Equal("hello", cr.Message?.Key);
+                        Assert.Equal("world", cr.Message?.Value);
                     }
 
                     using (var consumer =
@@ -127,8 +127,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     {
                         consumer.Assign(new TopicPartitionOffset(topic2.Name, 0, 0));
                         var cr = consumer.Consume();
-                        Assert.Equal("hello", cr.Key);
-                        Assert.Equal("world", cr.Value);
+                        Assert.Equal("hello", cr.Message?.Key);
+                        Assert.Equal("world", cr.Message?.Value);
                     }
 
                     using (var consumer =

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
@@ -247,8 +247,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(nullTopic, 0, 0) });
                     var result8 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Null(result8.Key);
-                    Assert.Null(result8.Value);
+                    Assert.Null(result8.Message?.Key);
+                    Assert.Null(result8.Message?.Value);
                 }
             }
         }


### PR DESCRIPTION
I stumbled over this rather weird piece of API when we had the issue, that our application packaged into linux containers produces `NullReference` Exceptions when consuming messages, which it did not on our Windows development environments. We quickly figured that it was actually the partition EOF message but the reason it was taking us a long time to find out what was wrong in the first place was, that the issue manifested where it should not have!

Here is our consume code before the refactoring:

``` csharp
while (!stoppingToken.IsCancellationRequested)
{
    try
    {
        var msg = consumer.Consume(stoppingToken);
        if (msg != null)
        {
            logger.LogDebug($"Received message from topic '{msg.Topic}:{msg.Partition}' with offset: '{msg.Offset}[{msg.TopicPartitionOffset}]'");

            using (var scope = serviceProvider.CreateScope())
            {
                var handler = scope.ServiceProvider.GetService<IKafkaMessageHandler<TKey, TValue>>();
                if (handler == null)
                {
                    logger.LogError("Failed to resolve message handler. Did you add it to your DI setup.");
                    continue;
                }
                try
                {
                    // Invoke the handler
                    await handler.Handle(msg);
                }
                catch (Exception e)
                {
                    logger.LogError(e, "Message handler failed", e);
                    continue;
                }
            }
        }
        else
        {
            logger.LogDebug("No messages received");
        }
    }
}
```
Seemed fine to us until we got a nullref exception deeper down in the stack of `handler.Handle(msg)`. After some debugging we found that the properties `Key`, `Value` and `Timestamp` on `ConsumeResult<,>` were just wrappers around the same properties of the object in the `Message` property. We had checks for the cases that `Key` or `Value` could be null, but we did not expect `if (msg.Key == null)` to throw a nullref. We fixed our code in [this commit](https://github.com/leuchterag/Microsoft.Extensions.Hosting.Kafka/commit/9708c95579b2aa4ab2b15193cb0e53517d9c514f) and just opted for an additional check if there is actually a message present in the `ConsumeResult`.

Now, we could not figure out why it was implemented this way but we figured that duplicating functionality like that is an antipattern and this is also the reason I submit this PR. I know, that 1.0.0 has just been released and the time for breaking API changes is actually over, but if we don't merge this PR because of the fact it introduces a breaking change by removing the redundant properties, we should at least change the code so that it does not throw `NullReferenceException`s when accessing properties...