### PR TITLE
prevent NullReferenceExceptions on ConsumeResult

### DIFF
--- a/src/Confluent.Kafka/ConsumeResult.cs
+++ b/src/Confluent.Kafka/ConsumeResult.cs
@@ -73,8 +73,15 @@ namespace Confluent.Kafka
         /// </summary>
         public TKey Key
         {
-            get { return Message.Key; }
-            set { Message.Key = value; }
+            get
+            {
+                if (Message == null)
+                {
+                    throw new MessageNullException();
+                }
+
+                return Message.Key;
+            }
         }
 
         /// <summary>
@@ -82,8 +89,15 @@ namespace Confluent.Kafka
         /// </summary>
         public TValue Value
         {
-            get { return Message.Value; }
-            set { Message.Value = value; }
+            get
+            {
+                if (Message == null)
+                {
+                    throw new MessageNullException();
+                }
+                
+                return Message.Value;
+            }
         }
 
         /// <summary>
@@ -91,8 +105,15 @@ namespace Confluent.Kafka
         /// </summary>
         public Timestamp Timestamp
         {
-            get { return Message.Timestamp; }
-            set { Message.Timestamp = value; }
+            get
+            {
+                if (Message == null)
+                {
+                    throw new MessageNullException();
+                }
+
+                return Message.Timestamp;
+            }
         }
 
         /// <summary>
@@ -100,8 +121,15 @@ namespace Confluent.Kafka
         /// </summary>
         public Headers Headers
         {
-            get { return Message.Headers; }
-            set { Message.Headers = value; }
+            get
+            {
+                if (Message == null)
+                {
+                    throw new MessageNullException();
+                }
+                
+                return Message.Headers;
+            }
         }
 
         /// <summary>

--- a/src/Confluent.Kafka/Exceptions/MessageNullException.cs
+++ b/src/Confluent.Kafka/Exceptions/MessageNullException.cs
@@ -1,0 +1,31 @@
+// Copyright 2019 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Thrown when there is an attempt to dereference a null Message reference.
+    /// </summary>
+    public class MessageNullException : NullReferenceException
+    {
+        public MessageNullException()
+            : base("Attempt to dereference null Message reference")
+        {
+        }
+    }
+}


### PR DESCRIPTION
resolves #919 by throwing a more verbose exception when accessing the
convenience properties in ConsumeResult.