### PR TITLE
Expose additional compatibility methods on Schema Registry client

### DIFF
--- a/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
@@ -44,9 +44,15 @@ namespace Confluent.SchemaRegistry
     ///      - <see cref="CachedSchemaRegistryClient.LookupSchemaAsync(string, Schema, bool)" />
     ///      - <see cref="CachedSchemaRegistryClient.GetLatestSchemaAsync(string)" />
     ///      - <see cref="CachedSchemaRegistryClient.GetAllSubjectsAsync" />
+    ///      - <see cref="CachedSchemaRegistryClient.GetCompatibilityAsync(string)" />
+    ///      - <see cref="CachedSchemaRegistryClient.GetGlobalCompatibilityAsync" />
     ///      - <see cref="CachedSchemaRegistryClient.GetSubjectVersionsAsync(string)" />
     ///      - <see cref="CachedSchemaRegistryClient.IsCompatibleAsync(string, Schema)" />
+    ///      - <see cref="CachedSchemaRegistryClient.IsCompatibleAsync(string, int, Schema)" />
     ///      - <see cref="CachedSchemaRegistryClient.IsCompatibleAsync(string, string)" />
+    ///      - <see cref="CachedSchemaRegistryClient.IsCompatibleAsync(string, int, string)" />
+    ///      - <see cref="CachedSchemaRegistryClient.UpdateCompatibilityAsync(string, Compatibility)" />
+    ///      - <see cref="CachedSchemaRegistryClient.UpdateGlobalCompatibilityAsync(Compatibility)" />
     /// </summary>
     public class CachedSchemaRegistryClient : ISchemaRegistryClient, IDisposable
     {
@@ -509,8 +515,38 @@ namespace Confluent.SchemaRegistry
 
 
         /// <inheritdoc/>
+        public async Task<bool> IsCompatibleAsync(string subject, int versionId, Schema schema)
+            => await restService.TestCompatibilityAsync(subject, versionId, schema).ConfigureAwait(continueOnCapturedContext: false);
+
+
+        /// <inheritdoc/>
         public async Task<bool> IsCompatibleAsync(string subject, string avroSchema)
             => await restService.TestLatestCompatibilityAsync(subject, new Schema(avroSchema, EmptyReferencesList, SchemaType.Avro)).ConfigureAwait(continueOnCapturedContext: false);
+
+
+        /// <inheritdoc/>
+        public async Task<bool> IsCompatibleAsync(string subject, int versionId, string avroSchema)
+            => await restService.TestCompatibilityAsync(subject, versionId, new Schema(avroSchema, EmptyReferencesList, SchemaType.Avro)).ConfigureAwait(continueOnCapturedContext: false);
+
+
+        /// <inheritdoc/>
+        public async Task<Compatibility> GetCompatibilityAsync(string subject)
+            => await restService.GetCompatibilityAsync(subject).ConfigureAwait(continueOnCapturedContext: false);
+
+
+        /// <inheritdoc/>
+        public async Task UpdateCompatibilityAsync(string subject, Compatibility compatibility)
+            => await restService.SetCompatibilityAsync(subject, compatibility).ConfigureAwait(continueOnCapturedContext: false);
+
+
+        /// <inheritdoc/>
+        public async Task<Compatibility> GetGlobalCompatibilityAsync()
+            => await restService.GetGlobalCompatibilityAsync().ConfigureAwait(continueOnCapturedContext: false);
+
+
+        /// <inheritdoc/>
+        public async Task UpdateGlobalCompatibilityAsync(Compatibility compatibility)
+            => await restService.SetGlobalCompatibilityAsync(compatibility).ConfigureAwait(continueOnCapturedContext: false);
 
 
         /// <inheritdoc />

--- a/src/Confluent.SchemaRegistry/ISchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/ISchemaRegistryClient.cs
@@ -208,7 +208,7 @@ namespace Confluent.SchemaRegistry
 
 
         /// <summary>
-        ///     Check if an avro schema is compatible with latest version registered against a 
+        ///     Check if an avro schema is compatible with latest version registered against a
         ///     specified subject.
         /// </summary>
         /// <param name="subject">
@@ -219,14 +219,36 @@ namespace Confluent.SchemaRegistry
         /// </param>
         /// <returns>
         ///     true if <paramref name="avroSchema" /> is compatible with the latest version 
-        ///     registered against a specified subject, false otherwise.
+        ///     registered against <paramref name="subject" />, false otherwise.
         /// </returns>
         [Obsolete("Superseded by IsCompatibleAsync(string, Schema)")]
         Task<bool> IsCompatibleAsync(string subject, string avroSchema);
 
 
         /// <summary>
-        ///     Check if a schema is compatible with latest version registered against a 
+        ///     Check if an avro schema is compatible with a particular version registered against
+        ///     a specified subject.
+        /// </summary>
+        /// <param name="subject">
+        ///     The subject to check.
+        /// </param>
+        /// <param name="versionId">
+        ///     The version of the subject to check.
+        /// </param>
+        /// <param name="avroSchema">
+        ///     The schema to check.
+        /// </param>
+        /// <returns>
+        ///     true if <paramref name="avroSchema" /> is compatible with the specified 
+        ///     <paramref name="versionId" /> registered against <paramref name="subject" />, false
+        ///     otherwise.
+        /// </returns>
+        [Obsolete("Superseded by IsCompatibleAsync(string, int, Schema)")]
+        Task<bool> IsCompatibleAsync(string subject, int versionId, string avroSchema);
+
+
+        /// <summary>
+        ///     Check if an avro schema is compatible with latest version registered against a
         ///     specified subject.
         /// </summary>
         /// <param name="subject">
@@ -237,9 +259,75 @@ namespace Confluent.SchemaRegistry
         /// </param>
         /// <returns>
         ///     true if <paramref name="schema" /> is compatible with the latest version 
-        ///     registered against a specified subject, false otherwise.
+        ///     registered against <paramref name="subject" />, false otherwise.
         /// </returns>
         Task<bool> IsCompatibleAsync(string subject, Schema schema);
+
+
+        /// <summary>
+        ///     Check if a schema is compatible with a particular version registered against a
+        ///     specified subject.
+        /// </summary>
+        /// <param name="subject">
+        ///     The subject to check.
+        /// </param>
+        /// <param name="versionId">
+        ///     The version of the subject to check.
+        /// </param>
+        /// <param name="schema">
+        ///     The schema to check.
+        /// </param>
+        /// <returns>
+        ///     true if <paramref name="avroSchema" /> is compatible with the specified 
+        ///     <paramref name="versionId" /> registered against <paramref name="subject" />, false
+        ///     otherwise.
+        /// </returns>
+        Task<bool> IsCompatibleAsync(string subject, int versionId, Schema schema);
+
+
+        /// <summary>
+        ///     Get the compatibility level of a specified <paramref name="subject" />.
+        /// </summary>
+        /// <param name="subject">
+        ///     The subject to get the compatibility level for.
+        /// </param>
+        /// <returns>
+        ///     The compatibility level of <paramref name="subject" />.
+        /// </returns>
+        /// <exception cref="SchemaRegistryException">
+        ///     Thrown if no compatibility level has been set for <paramref name="subject" />.
+        /// </exception>
+        Task<Compatibility> GetCompatibilityAsync(string subject);
+
+
+        /// <summary>
+        ///     Update the compatibility level of a specified <paramref name="subject" />.
+        /// </summary>
+        /// <param name="subject">
+        ///     The subject to update.
+        /// </param>
+        /// <param name="compatibility">
+        ///     The new compatibility level.
+        /// </param>
+        Task UpdateCompatibilityAsync(string subject, Compatibility compatibility);
+
+
+        /// <summary>
+        ///     Get the global compatibility level.
+        /// </summary>
+        /// <returns>
+        ///     The global compatibility level.
+        /// </returns>
+        Task<Compatibility> GetGlobalCompatibilityAsync();
+
+
+        /// <summary>
+        ///     Update the global compatibility level.
+        /// </summary>
+        /// <param name="compatibility">
+        ///     The new compatibility level.
+        /// </param>
+        Task UpdateGlobalCompatibilityAsync(Compatibility compatibility);
 
 
         /// <summary>

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
@@ -45,7 +45,9 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             sr.RegisterSchemaAsync(subject, testSchema1).Wait();
 
             Assert.False(sr.IsCompatibleAsync(subject, testSchema2).Result);
+            Assert.False(sr.IsCompatibleAsync(subject, 1, testSchema2).Result);
             Assert.True(sr.IsCompatibleAsync(subject, testSchema1).Result);
+            Assert.True(sr.IsCompatibleAsync(subject, 1, testSchema1).Result);
 
 
             // case 2: record not specified.

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/UpdateCompatibilityLevel.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/UpdateCompatibilityLevel.cs
@@ -1,0 +1,43 @@
+// Copyright 20 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace Confluent.SchemaRegistry.IntegrationTests
+{
+    public static partial class Tests
+    {
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static async Task UpdateCompatibilityLevel(Config config)
+        {   
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
+
+            var topic = Guid.NewGuid().ToString();
+            var subject = sr.ConstructValueSubjectName(topic);
+
+            await Assert.ThrowsAsync<SchemaRegistryException>(() => sr.GetCompatibilityAsync(subject));
+
+            var compatibility = Compatibility.Full;
+            await sr.UpdateCompatibilityAsync(subject, compatibility);
+
+            Assert.Equal(compatibility, await sr.GetCompatibilityAsync(subject));
+        }
+    }
+}

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/UpdateGlobalCompatibilityLevel.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/UpdateGlobalCompatibilityLevel.cs
@@ -1,0 +1,38 @@
+// Copyright 20 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace Confluent.SchemaRegistry.IntegrationTests
+{
+    public static partial class Tests
+    {
+        [Theory, MemberData(nameof(SchemaRegistryParameters))]
+        public static async Task UpdateGlobalCompatibilityLevel(Config config)
+        {   
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
+
+            var compatibility = Compatibility.Full;
+            await sr.UpdateGlobalCompatibilityAsync(compatibility);
+
+            Assert.Equal(compatibility, await sr.GetGlobalCompatibilityAsync());
+        }
+    }
+}


### PR DESCRIPTION
New methods on the client that had already been implemented on the REST service:

- `IsCompatibleAsync` (overload for specific version)
- `GetCompatibilityAsync`/`SetCompatibilityAsync`
- `GetGlobalCompatibilityAsync`/`SetGlobalCompatibilityAsync`