### PR TITLE
make consumer benchmark 5x faster

### DIFF
--- a/test/Confluent.Kafka.Benchmark/BenchmarkConsumer.cs
+++ b/test/Confluent.Kafka.Benchmark/BenchmarkConsumer.cs
@@ -30,7 +30,8 @@ namespace Confluent.Kafka.Benchmark
                 GroupId = "benchmark-consumer-group",
                 BootstrapServers = bootstrapServers,
                 SessionTimeoutMs = 6000,
-                ConsumeResultFields = nHeaders == 0 ? "none" : "headers"
+                ConsumeResultFields = nHeaders == 0 ? "none" : "headers",
+                QueuedMinMessages = 1000000
             };
 
             using (var consumer = new ConsumerBuilder<Ignore, Ignore>(consumerConfig).Build())


### PR DESCRIPTION
quick win - this gives 5x throughput gain to > 1M msg/s on my localhost.