### PR TITLE
Depreciate SchemaRegistry property name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - References librdkafka v1.2.0. Refer to the [release notes](https://github.com/edenhill/librdkafka/releases/tag/v1.2.0) for more information. Headline feature is consumer side support for transactions.
 - Added `IDictionary` overload to `Config` constructors (contribution by @AndyPook).
-- `Confluent.Kafka`, `Confluent.SchemaRegistry` and `Confluent.SchemaRegistry.Serdes` are now all signed, and `Confluent.Kafka.StrongName` depreciated.
+- `Confluent.Kafka`, `Confluent.SchemaRegistry` and `Confluent.SchemaRegistry.Serdes` are now all signed, and `Confluent.Kafka.StrongName` deprecated.
 
 ## Fixes
 
@@ -249,7 +249,7 @@ Feature highlights:
 - The methods used to produce messages have changed:
   - Methods that accept a callback are now named `BeginProduce` (not `ProduceAsync`), analogous to similar methods in the standard library.
   - Callbacks are now specified as `Action<DeliveryReportResult<TKey, TValue>>` delegates, not implementations of `IDeliveryHandler`.
-  - The `IDeliveryHandler` interface has been depreciated.
+  - The `IDeliveryHandler` interface has been deprecated.
   - There are two variants of `ProduceAsync` and `BeginProduce`, the first takes a topic name and a `Message`. The second takes a `TopicPartition` and a message.
     - i.e. when producing, there is now clear separation between what is produced and where it is produced to.
   - The new API is more future proof.

--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -37,7 +37,7 @@ namespace AvroBlogExample
     {
         async static Task ProduceGeneric(string bootstrapServers, string schemaRegistryUrl)
         {
-            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryUrl }))
+            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryUrl }))
             using (var producer =
                 new ProducerBuilder<Null, GenericRecord>(new ProducerConfig { BootstrapServers = bootstrapServers })
                     .SetValueSerializer(new AvroSerializer<GenericRecord>(schemaRegistry))
@@ -69,7 +69,7 @@ namespace AvroBlogExample
 
         async static Task ProduceSpecific(string bootstrapServers, string schemaRegistryUrl)
         {
-            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryUrl }))
+            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryUrl }))
             using (var producer =
                 new ProducerBuilder<Null, MessageTypes.LogMessage>(new ProducerConfig { BootstrapServers = bootstrapServers })
                     .SetValueSerializer(new AvroSerializer<MessageTypes.LogMessage>(schemaRegistry))
@@ -106,7 +106,7 @@ namespace AvroBlogExample
                 AutoOffsetReset = AutoOffsetReset.Earliest
             };
 
-            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryUrl }))
+            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryUrl }))
             using (var consumer =
                 new ConsumerBuilder<Null, MessageTypes.LogMessage>(consumerConfig)
                     .SetValueDeserializer(new AvroDeserializer<MessageTypes.LogMessage>(schemaRegistry).AsSyncOverAsync())

--- a/examples/AvroGeneric/Program.cs
+++ b/examples/AvroGeneric/Program.cs
@@ -59,7 +59,7 @@ namespace Confluent.Kafka.Examples.AvroGeneric
             CancellationTokenSource cts = new CancellationTokenSource();
             var consumeTask = Task.Run(() =>
             {
-                using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryUrl }))
+                using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryUrl }))
                 using (var consumer =
                     new ConsumerBuilder<string, GenericRecord>(new ConsumerConfig { BootstrapServers = bootstrapServers, GroupId = groupName })
                         .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry).AsSyncOverAsync())
@@ -93,7 +93,7 @@ namespace Confluent.Kafka.Examples.AvroGeneric
                 }
             });
 
-            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryUrl }))
+            using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryUrl }))
             using (var producer =
                 new ProducerBuilder<string, GenericRecord>(new ProducerConfig { BootstrapServers = bootstrapServers })
                     .SetKeySerializer(new AvroSerializer<string>(schemaRegistry))

--- a/examples/AvroSpecific/Program.cs
+++ b/examples/AvroSpecific/Program.cs
@@ -50,10 +50,10 @@ namespace Confluent.Kafka.Examples.AvroSpecific
                 // schema.registry.url property for redundancy (comma separated list). 
                 // The property name is not plural to follow the convention set by
                 // the Java implementation.
-                SchemaRegistryUrl = schemaRegistryUrl,
+                Url = schemaRegistryUrl,
                 // optional schema registry client properties:
-                SchemaRegistryRequestTimeoutMs = 5000,
-                SchemaRegistryMaxCachedSchemas = 10
+                RequestTimeoutMs = 5000,
+                MaxCachedSchemas = 10
             };
 
             var consumerConfig = new ConsumerConfig

--- a/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
+++ b/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
@@ -126,7 +126,7 @@ namespace Confluent.SchemaRegistry
         /// <summary>
         ///     Specifies the configuration property(ies) that provide the basic authentication credentials.
         /// </summary>
-        public AuthCredentialsSource? SchemaRegistryBasicAuthCredentialsSource
+        public AuthCredentialsSource? BasicAuthCredentialsSource
         {
             get
             {
@@ -146,13 +146,47 @@ namespace Confluent.SchemaRegistry
         }
 
         /// <summary>
+        ///     Specifies the configuration property(ies) that provide the basic authentication credentials.
+        /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the BasicAuthCredentialsSource property")]
+        public AuthCredentialsSource? SchemaRegistryBasicAuthCredentialsSource
+        {
+            get => BasicAuthCredentialsSource;
+            set { BasicAuthCredentialsSource = value; }
+        }
+
+
+        /// <summary>
         ///     A comma-separated list of URLs for schema registry instances that are
         ///     used to register or lookup schemas.
         /// </summary>
-        public string SchemaRegistryUrl
+        public string Url
         {
             get { return Get(SchemaRegistryConfig.PropertyNames.SchemaRegistryUrl); } 
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryUrl, value); }
+        }
+
+        /// <summary>
+        ///     A comma-separated list of URLs for schema registry instances that are
+        ///     used to register or lookup schemas.
+        /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the Url property")]
+        public string SchemaRegistryUrl
+        {
+            get => Url;
+            set { Url = value; }
+        }
+
+
+        /// <summary>
+        ///     Specifies the timeout for requests to Confluent Schema Registry.
+        /// 
+        ///     default: 30000
+        /// </summary>
+        public int? RequestTimeoutMs
+        {
+            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryRequestTimeoutMs); }
+            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryRequestTimeoutMs, value.ToString()); }
         }
 
         /// <summary>
@@ -160,10 +194,24 @@ namespace Confluent.SchemaRegistry
         /// 
         ///     default: 30000
         /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the RequestTimeoutMs property")]
         public int? SchemaRegistryRequestTimeoutMs
         {
-            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryRequestTimeoutMs); }
-            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryRequestTimeoutMs, value.ToString()); }
+            get => RequestTimeoutMs;
+            set { RequestTimeoutMs = value; }
+        }
+
+
+        /// <summary>
+        ///     Specifies the maximum number of schemas CachedSchemaRegistryClient
+        ///     should cache locally.
+        /// 
+        ///     default: 1000
+        /// </summary>
+        public int? MaxCachedSchemas
+        {
+            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxCachedSchemas); }
+            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxCachedSchemas, value.ToString()); }
         }
 
         /// <summary>
@@ -172,27 +220,40 @@ namespace Confluent.SchemaRegistry
         /// 
         ///     default: 1000
         /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the MaxCachedSchemas property")]
         public int? SchemaRegistryMaxCachedSchemas
         {
-            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxCachedSchemas); }
-            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxCachedSchemas, value.ToString()); }
+            get => MaxCachedSchemas;
+            set { MaxCachedSchemas = value; }
         }
+
 
         /// <summary>
         ///     Basic auth credentials in the form {username}:{password}.
         /// </summary>
-        public string SchemaRegistryBasicAuthUserInfo
+        public string BasicAuthUserInfo
         {
             get { return Get(SchemaRegistryConfig.PropertyNames.SchemaRegistryBasicAuthUserInfo); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryBasicAuthUserInfo, value); }
         }
 
         /// <summary>
+        ///     Basic auth credentials in the form {username}:{password}.
+        /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the BasicAuthUserInfo property")]
+        public string SchemaRegistryBasicAuthUserInfo
+        {
+            get => BasicAuthUserInfo;
+            set { BasicAuthUserInfo = value; }
+        }
+
+
+        /// <summary>
         ///     Key subject name strategy.
         ///     
         ///     default: SubjectNameStrategy.Topic
         /// </summary>
-        public SubjectNameStrategy? SchemaRegistryKeySubjectNameStrategy
+        public SubjectNameStrategy? KeySubjectNameStrategy
         {
             get
             {
@@ -216,11 +277,24 @@ namespace Confluent.SchemaRegistry
         }
 
         /// <summary>
+        ///     Key subject name strategy.
+        ///     
+        ///     default: SubjectNameStrategy.Topic
+        /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the KeySubjectNameStrategy property")]
+        public SubjectNameStrategy? SchemaRegistryKeySubjectNameStrategy
+        {
+            get => KeySubjectNameStrategy;
+            set { KeySubjectNameStrategy = value; }
+        }
+
+
+        /// <summary>
         ///     Value subject name strategy.
         ///
         ///     default: SubjectNameStrategy.Topic
         /// </summary>
-        public SubjectNameStrategy? SchemaRegistryValueSubjectNameStrategy
+        public SubjectNameStrategy? ValueSubjectNameStrategy
         {
             get
             {
@@ -242,6 +316,19 @@ namespace Confluent.SchemaRegistry
                 else { this.properties[PropertyNames.SchemaRegistryValueSubjectNameStrategy] = value.ToString(); }
             }
         }
+
+        /// <summary>
+        ///     Value subject name strategy.
+        ///     
+        ///     default: SubjectNameStrategy.Topic
+        /// </summary>
+        [Obsolete("This property will be depreciated in a future version of this library in favor of the ValueSubjectNameStrategy property")]
+        public SubjectNameStrategy? SchemaRegistryValueSubjectNameStrategy
+        {
+            get => ValueSubjectNameStrategy;
+            set { ValueSubjectNameStrategy = value; }
+        }
+
 
         /// <summary>
         ///     Set a configuration property using a string key / value pair.

--- a/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
+++ b/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
@@ -148,7 +148,7 @@ namespace Confluent.SchemaRegistry
         /// <summary>
         ///     Specifies the configuration property(ies) that provide the basic authentication credentials.
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the BasicAuthCredentialsSource property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the BasicAuthCredentialsSource property")]
         public AuthCredentialsSource? SchemaRegistryBasicAuthCredentialsSource
         {
             get => BasicAuthCredentialsSource;
@@ -170,7 +170,7 @@ namespace Confluent.SchemaRegistry
         ///     A comma-separated list of URLs for schema registry instances that are
         ///     used to register or lookup schemas.
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the Url property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the Url property")]
         public string SchemaRegistryUrl
         {
             get => Url;
@@ -194,7 +194,7 @@ namespace Confluent.SchemaRegistry
         /// 
         ///     default: 30000
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the RequestTimeoutMs property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the RequestTimeoutMs property")]
         public int? SchemaRegistryRequestTimeoutMs
         {
             get => RequestTimeoutMs;
@@ -220,7 +220,7 @@ namespace Confluent.SchemaRegistry
         /// 
         ///     default: 1000
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the MaxCachedSchemas property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the MaxCachedSchemas property")]
         public int? SchemaRegistryMaxCachedSchemas
         {
             get => MaxCachedSchemas;
@@ -240,7 +240,7 @@ namespace Confluent.SchemaRegistry
         /// <summary>
         ///     Basic auth credentials in the form {username}:{password}.
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the BasicAuthUserInfo property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the BasicAuthUserInfo property")]
         public string SchemaRegistryBasicAuthUserInfo
         {
             get => BasicAuthUserInfo;
@@ -281,7 +281,7 @@ namespace Confluent.SchemaRegistry
         ///     
         ///     default: SubjectNameStrategy.Topic
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the KeySubjectNameStrategy property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the KeySubjectNameStrategy property")]
         public SubjectNameStrategy? SchemaRegistryKeySubjectNameStrategy
         {
             get => KeySubjectNameStrategy;
@@ -322,7 +322,7 @@ namespace Confluent.SchemaRegistry
         ///     
         ///     default: SubjectNameStrategy.Topic
         /// </summary>
-        [Obsolete("This property will be depreciated in a future version of this library in favor of the ValueSubjectNameStrategy property")]
+        [Obsolete("This property will be removed in a future version of this library in favor of the ValueSubjectNameStrategy property")]
         public SubjectNameStrategy? SchemaRegistryValueSubjectNameStrategy
         {
             get => ValueSubjectNameStrategy;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_AutoCommit.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka.IntegrationTests
     {
         /// <summary>
         ///     Test auto commit operates as expected when set to false (that issue #362 is resolved).
-        ///     note that 'default.topic.config' has been depreciated.
+        ///     note that 'default.topic.config' has been deprecated.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
         public void Consumer_AutoCommit(string bootstrapServers)

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/BasicAuth.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/BasicAuth.cs
@@ -38,9 +38,9 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             // 1.1. credentials specified as USER_INFO.
             var conf = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = config.ServerWithAuth,
-                SchemaRegistryBasicAuthCredentialsSource = AuthCredentialsSource.UserInfo,
-                SchemaRegistryBasicAuthUserInfo = $"{config.Username}:{config.Password}"
+                Url = config.ServerWithAuth,
+                BasicAuthCredentialsSource = AuthCredentialsSource.UserInfo,
+                BasicAuthUserInfo = $"{config.Username}:{config.Password}"
             };
 
             // some sanity checking of strongly typed config property name mappings.
@@ -60,8 +60,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             // 1.2. credentials specified as USER_INFO implicitly (and using strongly typed SchemaRegistryConfig)
             var conf2 = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = config.ServerWithAuth,
-                SchemaRegistryBasicAuthUserInfo = $"{config.Username}:{config.Password}"
+                Url = config.ServerWithAuth,
+                BasicAuthUserInfo = $"{config.Username}:{config.Password}"
             };
             using (var sr = new CachedSchemaRegistryClient(conf2))
             {
@@ -90,8 +90,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             }
 
             // 1.4. credentials specified as SASL_INHERIT via strongly typed config.
-            var conf3 = new SchemaRegistryConfig { SchemaRegistryUrl = config.ServerWithAuth };
-            conf3.SchemaRegistryBasicAuthCredentialsSource = AuthCredentialsSource.SaslInherit;
+            var conf3 = new SchemaRegistryConfig { Url = config.ServerWithAuth };
+            conf3.BasicAuthCredentialsSource = AuthCredentialsSource.SaslInherit;
             conf3.Set("sasl.username", config.Username);
             conf3.Set("sasl.password", config.Password);
             using (var sr = new CachedSchemaRegistryClient(conf3))
@@ -138,7 +138,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             // connect to authenticating without credentials. shouldn't work.
             Assert.Throws<HttpRequestException>(() => 
             { 
-                var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.ServerWithAuth });
+                var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.ServerWithAuth });
                 var topicName = Guid.NewGuid().ToString();
                 var subject = sr.ConstructValueSubjectName(topicName);
                 try

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Failover.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Failover.cs
@@ -32,7 +32,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = $"{config.Server},http://localhost:65432" }))
+            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = $"{config.Server},http://localhost:65432" }))
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = sr.ConstructKeySubjectName(topicName);
@@ -41,7 +41,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 Assert.Equal(id, id2);
             }
 
-            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = $"http://localhost:65432,{config.Server}" }))
+            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = $"http://localhost:65432,{config.Server}" }))
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = sr.ConstructKeySubjectName(topicName);
@@ -50,7 +50,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 Assert.Equal(id, id2);
             }
 
-            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = $"http://localhost:65432,http://localhost:65431" }))
+            using (var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = $"http://localhost:65432,http://localhost:65431" }))
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = sr.ConstructKeySubjectName(topicName);

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/FillTheCache.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/FillTheCache.cs
@@ -35,9 +35,9 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var srConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = config.Server,
-                SchemaRegistryRequestTimeoutMs = 3000,
-                SchemaRegistryMaxCachedSchemas = capacity
+                Url = config.Server,
+                RequestTimeoutMs = 3000,
+                MaxCachedSchemas = capacity
             };
 
             var sr = new CachedSchemaRegistryClient(srConfig);

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetAllSubjects.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetAllSubjects.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subjectsBefore = sr.GetAllSubjectsAsync().Result;
 

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetId.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetId.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructKeySubjectName(topicName);
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetLatestSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetLatestSchema.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructValueSubjectName(topicName);
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaById.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaById.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructValueSubjectName(topicName);
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaBySubjectAndVersion.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaBySubjectAndVersion.cs
@@ -32,7 +32,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructValueSubjectName(topicName);
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSubjectVersions.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSubjectVersions.cs
@@ -39,7 +39,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}," +
                 "{\"name\":\"favorite_shape\",\"type\":[\"string\",\"null\"], \"default\": \"square\"}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructValueSubjectName(topicName);
             var id1 = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
@@ -25,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
         public static void IsCompatible_Topic(Config config)
         {
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var testSchema1 = 
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterIncompatibleSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterIncompatibleSchema.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterSameSchemaTwice.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterSameSchemaTwice.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = config.Server });
+            var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = sr.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             Assert.Equal(topicName + "-key", subject);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AutoRegisterSchemaDisabled.cs
@@ -46,7 +46,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 var schemaRegistryConfig = new SchemaRegistryConfig
                 {
-                    SchemaRegistryUrl = schemaRegistryServers
+                    Url = schemaRegistryServers
                 };
 
                 // first a quick check the value case fails.
@@ -126,7 +126,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 }
 
                 // config with avro.serializer.auto.register.schemas == false should work now.
-                using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryServers }))
+                using (var schemaRegistry = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryServers }))
                 using (var producer =
                     new ProducerBuilder<string, int>(producerConfig)
                         .SetKeySerializer(new AvroSerializer<string>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }))

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/AvroAndRegular.cs
@@ -48,7 +48,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 var schemaRegistryConfig = new SchemaRegistryConfig
                 {
-                    SchemaRegistryUrl = schemaRegistryServers
+                    Url = schemaRegistryServers
                 };
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumeIncompatibleTypes.cs
@@ -51,7 +51,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers
+                Url = schemaRegistryServers
             };
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ConsumePartitionEOF.cs
@@ -40,7 +40,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers
+                Url = schemaRegistryServers
             };
 
             using (var topic = new TemporaryTopic(bootstrapServers, 1))

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/PrimitiveTypes.cs
@@ -32,7 +32,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         [Theory, MemberData(nameof(TestParameters))]
         public static void PrimitiveTypes(string bootstrapServers, string schemaRegistryServers)
         {
-            var schemaRegistryConfig = new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryServers };
+            var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
             {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsume.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsume.cs
@@ -46,10 +46,10 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers,
-                // Test SchemaRegistryValueSubjectNameStrategy here,
-                // and SchemaRegistryKeySubjectNameStrategy in ProduceConsumeGeneric.
-                SchemaRegistryValueSubjectNameStrategy = nameStrategy
+                Url = schemaRegistryServers,
+                // Test ValueSubjectNameStrategy here,
+                // and KeySubjectNameStrategy in ProduceConsumeGeneric.
+                ValueSubjectNameStrategy = nameStrategy
             };
 
             var adminClientConfig = new AdminClientConfig

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsumeGeneric.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceConsumeGeneric.cs
@@ -48,10 +48,10 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             var config = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers,
-                // Test SchemaRegistryKeySubjectNameStrategy here,
-                // and SchemaRegistryValueSubjectNameStrategy in ProduceConsume.
-                SchemaRegistryKeySubjectNameStrategy = nameStrategy
+                Url = schemaRegistryServers,
+                // Test KeySubjectNameStrategy here,
+                // and ValueSubjectNameStrategy in ProduceConsume.
+                KeySubjectNameStrategy = nameStrategy
             };
 
             var topic = Guid.NewGuid().ToString();

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceGenericMultipleTopics.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceGenericMultipleTopics.cs
@@ -29,7 +29,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             );
 
             var config = new ProducerConfig { BootstrapServers = bootstrapServers };
-            var schemaRegistryConfig = new SchemaRegistryConfig { SchemaRegistryUrl = schemaRegistryServers };
+            var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
 
             var topic = Guid.NewGuid().ToString();
             var topic2 = Guid.NewGuid().ToString();

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceIncompatibleTypes.cs
@@ -42,7 +42,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers
+                Url = schemaRegistryServers
             };
 
             var topic = Guid.NewGuid().ToString();

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceInvalid.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/ProduceInvalid.cs
@@ -35,8 +35,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             // 1. TopicRecord naming strategy only works with avro record types (value)
             var schemaRegistryConfig1 = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers,
-                SchemaRegistryValueSubjectNameStrategy = SubjectNameStrategy.TopicRecord
+                Url = schemaRegistryServers,
+                ValueSubjectNameStrategy = SubjectNameStrategy.TopicRecord
             };
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig1))
             using (var producer =
@@ -73,8 +73,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             // 2. Record naming strategy only works with avro record types (value)
             var schemaRegistryConfig2 = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers,
-                SchemaRegistryValueSubjectNameStrategy = SubjectNameStrategy.Record
+                Url = schemaRegistryServers,
+                ValueSubjectNameStrategy = SubjectNameStrategy.Record
             };
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig2))
             using (var producer =
@@ -111,8 +111,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             // 3. TopicRecord naming strategy only works with avro record types (key)
             var schemaRegistryConfig3 = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers,
-                SchemaRegistryKeySubjectNameStrategy = SubjectNameStrategy.TopicRecord
+                Url = schemaRegistryServers,
+                KeySubjectNameStrategy = SubjectNameStrategy.TopicRecord
             };
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig3))
             using (var producer =
@@ -149,8 +149,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             // 2. Record naming strategy only works with avro record types (key)
             var schemaRegistryConfig4 = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers,
-                SchemaRegistryKeySubjectNameStrategy = SubjectNameStrategy.Record
+                Url = schemaRegistryServers,
+                KeySubjectNameStrategy = SubjectNameStrategy.Record
             };
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig4))
             using (var producer =

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/SyncOverAsync.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests/SyncOverAsync.cs
@@ -50,7 +50,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = schemaRegistryServers
+                Url = schemaRegistryServers
             };
 
             var topic = Guid.NewGuid().ToString();

--- a/test/Confluent.SchemaRegistry.UnitTests/CachedSchemaRegistryClient.cs
+++ b/test/Confluent.SchemaRegistry.UnitTests/CachedSchemaRegistryClient.cs
@@ -38,7 +38,7 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void InvalidSubjectNameStrategy()
         {
-            var config = new SchemaRegistryConfig { SchemaRegistryUrl = "irrelevanthost:8081" };
+            var config = new SchemaRegistryConfig { Url = "irrelevanthost:8081" };
             config.Set(SchemaRegistryConfig.PropertyNames.SchemaRegistryKeySubjectNameStrategy, "bad_value");
             Assert.Throws<ArgumentException>(() => new CachedSchemaRegistryClient(config));
         }
@@ -46,7 +46,7 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void ConstructKeySubjectName_Topic1()
         {
-            var config = new SchemaRegistryConfig { SchemaRegistryUrl = "irrelevanthost:8081" };
+            var config = new SchemaRegistryConfig { Url = "irrelevanthost:8081" };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("mytopic-key", src.ConstructKeySubjectName("mytopic", "myschemaname"));
         }
@@ -56,8 +56,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         {
             var config = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = "irrelevanthost:8081",
-                SchemaRegistryKeySubjectNameStrategy = SubjectNameStrategy.Topic
+                Url = "irrelevanthost:8081",
+                KeySubjectNameStrategy = SubjectNameStrategy.Topic
             };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("mytopic-key", src.ConstructKeySubjectName("mytopic", "myschemaname"));
@@ -68,8 +68,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         {
             var config = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = "irrelevanthost:8081",
-                SchemaRegistryKeySubjectNameStrategy = SubjectNameStrategy.Record
+                Url = "irrelevanthost:8081",
+                KeySubjectNameStrategy = SubjectNameStrategy.Record
             };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("myschemaname", src.ConstructKeySubjectName("mytopic", "myschemaname"));
@@ -80,8 +80,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         {
             var config = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = "irrelevanthost:8081",
-                SchemaRegistryKeySubjectNameStrategy = SubjectNameStrategy.TopicRecord
+                Url = "irrelevanthost:8081",
+                KeySubjectNameStrategy = SubjectNameStrategy.TopicRecord
             };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("mytopic-myschemaname", src.ConstructKeySubjectName("mytopic", "myschemaname"));
@@ -90,7 +90,7 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void ConstructValueSubjectName_Topic1()
         {
-            var config = new SchemaRegistryConfig { SchemaRegistryUrl = "irrelevanthost:8081" };
+            var config = new SchemaRegistryConfig { Url = "irrelevanthost:8081" };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("mytopic-value", src.ConstructValueSubjectName("mytopic", "myschemaname"));
         }
@@ -100,8 +100,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         {
             var config = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = "irrelevanthost:8081",
-                SchemaRegistryValueSubjectNameStrategy = SubjectNameStrategy.Topic
+                Url = "irrelevanthost:8081",
+                ValueSubjectNameStrategy = SubjectNameStrategy.Topic
             };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("mytopic-value", src.ConstructValueSubjectName("mytopic", "myschemaname"));
@@ -112,8 +112,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         {
             var config = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = "irrelevanthost:8081",
-                SchemaRegistryValueSubjectNameStrategy = SubjectNameStrategy.Record
+                Url = "irrelevanthost:8081",
+                ValueSubjectNameStrategy = SubjectNameStrategy.Record
             };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("myschemaname", src.ConstructValueSubjectName("mytopic", "myschemaname"));
@@ -124,8 +124,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         {
             var config = new SchemaRegistryConfig
             {
-                SchemaRegistryUrl = "irrelevanthost:8081",
-                SchemaRegistryValueSubjectNameStrategy = SubjectNameStrategy.TopicRecord
+                Url = "irrelevanthost:8081",
+                ValueSubjectNameStrategy = SubjectNameStrategy.TopicRecord
             };
             var src = new CachedSchemaRegistryClient(config);
             Assert.Equal("mytopic-myschemaname", src.ConstructValueSubjectName("mytopic", "myschemaname"));


### PR DESCRIPTION
as noted in #1070, the `SchemaRegistry` prefixes on the config property names are redundant / pointless. Retaining them in the underlying property name strings (and their corresponding constants) though.