### PR TITLE
#864: Added Null Reference Checks to SafeKafkaHandle

### DIFF
--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -1297,7 +1297,7 @@ namespace Confluent.Kafka.Impl
             setOption_RequestTimeout(optionsPtr, options.RequestTimeout);
             setOption_OperationTimeout(optionsPtr, options.OperationTimeout);
             setOption_completionSource(optionsPtr, completionSourcePtr);
-            
+
             IntPtr[] deleteTopicsPtrs = new IntPtr[deleteTopics.Count(t => t != null)];
             int idx = 0;
             foreach (var deleteTopic in deleteTopics)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
@@ -1,0 +1,123 @@
+// Copyright 2016-2017 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+#pragma warning disable xUnit1026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Confluent.Kafka.Admin;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public partial class Tests
+    {
+        /// <summary>
+        ///     Tests the validation of input parameter to guard against uncaught segfaults.
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public void AdminClient_NullReferenceChecks(string bootstrapServers)
+        {
+            LogToFile("start AdminClient_NullReferenceChecks");
+            var topicName1 = Guid.NewGuid().ToString();
+            string nullTopic = null;
+
+            // test creating a null topic throws a related exception
+            using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                try
+                {
+                    adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = nullTopic, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                    Assert.True(false, "Expected exception.");
+                }
+                catch (KafkaException ex)
+                {
+                    Assert.Contains("topic", ex.Message.ToLower());
+                }
+            }
+
+            // test creating a partition with null topic throws exception
+            using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                try
+                {
+                    adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                    adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = nullTopic, IncreaseTo = 2 } }).Wait();
+                    Assert.True(false, "Expected exception.");
+                }
+                catch (NullReferenceException ex)
+                {
+                    Assert.Contains("topic", ex.Message.ToLower());
+                }
+            }
+
+            // test adding a null list of brokers throws null reference exception.
+            using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                try
+                {
+                    adminClient.AddBrokers(null);
+                    Assert.True(false, "Expected exception.");
+                }
+                catch (NullReferenceException ex)
+                {
+                    Assert.Contains("broker", ex.Message.ToLower());
+                }
+            }
+
+            // test retrieving metadata for a null topic
+            using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                try
+                {
+                    adminClient.GetMetadata(null, TimeSpan.FromSeconds(10));
+                    Assert.True(false, "Expected exception.");
+                }
+                catch (ArgumentNullException ex)
+                {
+                    Assert.Contains("value cannot be null", ex.Message.ToLower());
+                }
+            }
+
+            // This test-case completing is the test case
+            // Used to cause a seg-fault.
+            using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                adminClient.DeleteTopicsAsync(new List<string> { topicName1, nullTopic });
+                Assert.True(true);
+            }
+
+            // Asserts existing ListGroup behavior - null group is valid option
+            using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                adminClient.ListGroup(null, TimeSpan.FromSeconds(10));
+                Assert.True(true);
+            }
+
+            Assert.Equal(0, Library.HandleCount);
+            LogToFile("end   AdminClient_NullReferenceChecks");
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Confluent Inc.
+// Copyright 2016-2019 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Partially addresses #864.

I've audited the AdminClient and ProducerClient for segfaults and replaced them with null reference exceptions. I placed the unit tests in their own test-class for null reference checks.