### PR TITLE
Add a new config GetDouble function. Fix LingerMs

### DIFF
--- a/src/ConfigGen/Program.cs
+++ b/src/ConfigGen/Program.cs
@@ -352,6 +352,9 @@ namespace Confluent.Kafka
                     case "bool":
                         codeText += $"GetBool(\"{prop.Name}\")";
                         break;
+                    case "double":
+                        codeText += $"GetDouble(\"{prop.Name}\")";
+                        break;
                     default:
                         codeText += $"({nullableType})GetEnum(typeof({type}), \"{prop.Name}\")";
                         break;

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -125,19 +125,35 @@ namespace Confluent.Kafka
             return bool.Parse(result);
         }
 
-        /// <summary>
-        ///     Gets a configuration property enum value given a key.
-        /// </summary>
-        /// <param name="key">
-        ///     The configuration property to get.
-        /// </param>
-        /// <param name="type">
-        ///     The enum type of the configuration property.
-        /// </param>
-        /// <returns>
-        ///     The configuration property value.
-        /// </returns>
-        protected object GetEnum(Type type, string key)
+		/// <summary>
+		///     Gets a configuration property double? value given a key.
+		/// </summary>
+		/// <param name="key">
+		///     The configuration property to get.
+		/// </param>
+		/// <returns>
+		///     The configuration property value.
+		/// </returns>
+		protected double? GetDouble(string key)
+		{
+			var result = Get(key);
+			if (result == null) { return null; }
+			return double.Parse(result);
+		}
+
+		/// <summary>
+		///     Gets a configuration property enum value given a key.
+		/// </summary>
+		/// <param name="key">
+		///     The configuration property to get.
+		/// </param>
+		/// <param name="type">
+		///     The enum type of the configuration property.
+		/// </param>
+		/// <returns>
+		///     The configuration property value.
+		/// </returns>
+		protected object GetEnum(Type type, string key)
         {
             var result = Get(key);
             if (result == null) { return null; }

--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -125,35 +125,35 @@ namespace Confluent.Kafka
             return bool.Parse(result);
         }
 
-		/// <summary>
-		///     Gets a configuration property double? value given a key.
-		/// </summary>
-		/// <param name="key">
-		///     The configuration property to get.
-		/// </param>
-		/// <returns>
-		///     The configuration property value.
-		/// </returns>
-		protected double? GetDouble(string key)
-		{
-			var result = Get(key);
-			if (result == null) { return null; }
-			return double.Parse(result);
-		}
+        /// <summary>
+        ///     Gets a configuration property double? value given a key.
+        /// </summary>
+        /// <param name="key">
+        ///     The configuration property to get.
+        /// </param>
+        /// <returns>
+        ///     The configuration property value.
+        /// </returns>
+        protected double? GetDouble(string key)
+        {
+            var result = Get(key);
+            if (result == null) { return null; }
+            return double.Parse(result);
+        }
 
-		/// <summary>
-		///     Gets a configuration property enum value given a key.
-		/// </summary>
-		/// <param name="key">
-		///     The configuration property to get.
-		/// </param>
-		/// <param name="type">
-		///     The enum type of the configuration property.
-		/// </param>
-		/// <returns>
-		///     The configuration property value.
-		/// </returns>
-		protected object GetEnum(Type type, string key)
+        /// <summary>
+        ///     Gets a configuration property enum value given a key.
+        /// </summary>
+        /// <param name="key">
+        ///     The configuration property to get.
+        /// </param>
+        /// <param name="type">
+        ///     The enum type of the configuration property.
+        /// </param>
+        /// <returns>
+        ///     The configuration property value.
+        /// </returns>
+        protected object GetEnum(Type type, string key)
         {
             var result = Get(key);
             if (result == null) { return null; }

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -937,21 +937,21 @@ namespace Confluent.Kafka
         /// </summary>
         public int? QueueBufferingMaxKbytes { get { return GetInt("queue.buffering.max.kbytes"); } set { this.SetObject("queue.buffering.max.kbytes", value); } }
 
-        /// <summary>
-        ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
-        ///
-        ///     default: 0.5
-        ///     importance: high
-        /// </summary>
-        public double? LingerMs { get { return (double?)GetEnum(typeof(double), "linger.ms"); } set { this.SetObject("linger.ms", value); } }
+		/// <summary>
+		///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
+		///
+		///     default: 0.5
+		///     importance: high
+		/// </summary>
+		public double? LingerMs { get { return (double?)GetDouble("linger.ms"); } set { this.SetObject("linger.ms", value); } }
 
-        /// <summary>
-        ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
-        ///
-        ///     default: 2
-        ///     importance: high
-        /// </summary>
-        public int? MessageSendMaxRetries { get { return GetInt("message.send.max.retries"); } set { this.SetObject("message.send.max.retries", value); } }
+		/// <summary>
+		///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
+		///
+		///     default: 2
+		///     importance: high
+		/// </summary>
+		public int? MessageSendMaxRetries { get { return GetInt("message.send.max.retries"); } set { this.SetObject("message.send.max.retries", value); } }
 
         /// <summary>
         ///     The backoff time in milliseconds before retrying a protocol request.

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -1,4 +1,4 @@
-// *** Auto-generated from librdkafka 7632802d315b1a10f27e957400a3ec74f12ffbe8 *** - do not modify manually.
+// *** Auto-generated from librdkafka v1.2.1 *** - do not modify manually.
 //
 // Copyright 2018 Confluent Inc.
 //
@@ -943,7 +943,7 @@ namespace Confluent.Kafka
         ///     default: 0.5
         ///     importance: high
         /// </summary>
-        public double? LingerMs { get { return (double?)GetDouble("linger.ms"); } set { this.SetObject("linger.ms", value); } }
+        public double? LingerMs { get { return GetDouble("linger.ms"); } set { this.SetObject("linger.ms", value); } }
 
         /// <summary>
         ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
@@ -1174,7 +1174,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Controls how to read messages written transactionally: `read_committed` - only return transactional messages which have been committed. `read_uncommitted` - return all messages, even transactional messages which have been aborted.
         ///
-        ///     default: read_uncommitted
+        ///     default: read_committed
         ///     importance: high
         /// </summary>
         public IsolationLevel? IsolationLevel { get { return (IsolationLevel?)GetEnum(typeof(IsolationLevel), "isolation.level"); } set { this.SetObject("isolation.level", value); } }

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -937,21 +937,21 @@ namespace Confluent.Kafka
         /// </summary>
         public int? QueueBufferingMaxKbytes { get { return GetInt("queue.buffering.max.kbytes"); } set { this.SetObject("queue.buffering.max.kbytes", value); } }
 
-		/// <summary>
-		///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
-		///
-		///     default: 0.5
-		///     importance: high
-		/// </summary>
-		public double? LingerMs { get { return (double?)GetDouble("linger.ms"); } set { this.SetObject("linger.ms", value); } }
+        /// <summary>
+        ///     Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
+        ///
+        ///     default: 0.5
+        ///     importance: high
+        /// </summary>
+        public double? LingerMs { get { return (double?)GetDouble("linger.ms"); } set { this.SetObject("linger.ms", value); } }
 
-		/// <summary>
-		///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
-		///
-		///     default: 2
-		///     importance: high
-		/// </summary>
-		public int? MessageSendMaxRetries { get { return GetInt("message.send.max.retries"); } set { this.SetObject("message.send.max.retries", value); } }
+        /// <summary>
+        ///     How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.
+        ///
+        ///     default: 2
+        ///     importance: high
+        /// </summary>
+        public int? MessageSendMaxRetries { get { return GetInt("message.send.max.retries"); } set { this.SetObject("message.send.max.retries", value); } }
 
         /// <summary>
         ///     The backoff time in milliseconds before retrying a protocol request.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
@@ -36,7 +36,8 @@ namespace Confluent.Kafka.IntegrationTests
             var producerConfig = new ProducerConfig
             { 
                 BootstrapServers = bootstrapServers,
-                EnableIdempotence = true
+                EnableIdempotence = true,
+                LingerMs = 1.5
             };
 
 


### PR DESCRIPTION
Added a  new GetDouble function and replaced GetEnum on LingerMs getter.
GetEnum throws an exception of ArgumentException when it tries System.Enum.Parse(typeof(double), "3.5", ignoreCase: true); ("3.5" is just used as an example). 