### PR TITLE
add noauth SR instance to docker-compose file

### DIFF
--- a/test/Confluent.SchemaRegistry.IntegrationTests/README.md
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/README.md
@@ -1,2 +1,3 @@
-The supplied `docker-compose.yaml` can be used to start a schema registry instance
-with basic authentication enabled.
+The supplied `docker-compose.yaml` can be used to start two schema registry instances
+suitable for use with the integration tests, one with no auth (port 8081) and one with
+basic auth (port 8082).

--- a/test/Confluent.SchemaRegistry.IntegrationTests/docker-compose.yaml
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/docker-compose.yaml
@@ -4,6 +4,10 @@ services:
     image: confluentinc/cp-zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
+  zookeeper_2:
+    image: confluentinc/cp-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
     image: confluentinc/cp-kafka
     depends_on:
@@ -13,6 +17,16 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092, PLAINTEXT_HOST://localhost:29092
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  kafka_2:
+    image: confluentinc/cp-kafka
+    depends_on:
+      - zookeeper_2
+    environment:
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT, PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka_2:9092, PLAINTEXT_HOST://localhost:29092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper_2:2181
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
   schema-registry:
     image: confluentinc/cp-schema-registry
@@ -32,3 +46,15 @@ services:
       SCHEMA_REGISTRY_AUTHENTICATION_REALM: SchemaRegistry
       SCHEMA_REGISTRY_AUTHENTICATION_ROLES: Testers
       SCHEMA_REGISTRY_OPTS: -Djava.security.auth.login.config=/conf/schema-registry/schema-registry.jaas
+  schema-registry_2:
+    image: confluentinc/cp-schema-registry
+    depends_on:
+      - zookeeper_2
+      - kafka_2
+    ports:
+      - 8081:8081
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka_2:9092
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper_2:2181


### PR DESCRIPTION
afaik it's not necessary to have separate zookeeper/kafka instances to drive two schema registry instances, but I failed to get it working, don't want to dwell on it, and doing it this way is not a big deal so please lgtm thks.