### PR TITLE
expose `Consume(int)`

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -654,7 +654,10 @@ namespace Confluent.Kafka
         }
 
 
-        private ConsumeResult<TKey, TValue> ConsumeImpl(int millisecondsTimeout)
+        /// <summary>
+        ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey, TValue}.Consume(int)" />
+        /// </summary>
+        public ConsumeResult<TKey, TValue> Consume(int millisecondsTimeout)
         {
             var msgPtr = kafkaHandle.ConsumerPoll((IntPtr)millisecondsTimeout);
             if (msgPtr == IntPtr.Zero)
@@ -831,7 +834,7 @@ namespace Confluent.Kafka
                 // Note: An alternative to throwing on cancellation is to return null,
                 // but that would be problematic downstream (require null checks).
                 cancellationToken.ThrowIfCancellationRequested();
-                ConsumeResult<TKey, TValue> result = ConsumeImpl(cancellationDelayMaxMs);
+                ConsumeResult<TKey, TValue> result = Consume(cancellationDelayMaxMs);
                 if (result == null)
                 {
                     continue;
@@ -845,6 +848,6 @@ namespace Confluent.Kafka
         ///     Refer to <see cref="Confluent.Kafka.IConsumer{TKey, TValue}.Consume(TimeSpan)" />
         /// </summary>
         public ConsumeResult<TKey, TValue> Consume(TimeSpan timeout)
-            => ConsumeImpl(timeout.TotalMillisecondsAsInt());
+            => Consume(timeout.TotalMillisecondsAsInt());
     }
 }

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -30,6 +30,32 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Poll for new messages / events. Blocks
         ///     until a consume result is available or the
+        ///     timeout period has elapsed.
+        /// </summary>
+        /// <param name="millisecondsTimeout">
+        ///     The maximum period of time (in milliseconds)
+        ///     the call may block.
+        /// </param>
+        /// <returns>
+        ///     The consume result.
+        /// </returns>
+        /// <remarks>
+        ///     The partitions assigned/revoked and offsets
+        ///     committed handlers may be invoked as a
+        ///     side-effect of calling this method (on the
+        ///     same thread).
+        /// </remarks>
+        /// <exception cref="ConsumeException">
+        ///     Thrown
+        ///     when a call to this method is unsuccessful
+        ///     for any reason. Inspect the Error property
+        ///     of the exception for detailed information.
+        /// </exception>
+        ConsumeResult<TKey, TValue> Consume(int millisecondsTimeout);
+
+        /// <summary>
+        ///     Poll for new messages / events. Blocks
+        ///     until a consume result is available or the
         ///     operation has been cancelled.
         /// </summary>
         /// <param name="cancellationToken">


### PR DESCRIPTION
related to #1160

This version just exposes the `Consume(int)` method.

Unfortunately moving the CancellationToken overload to an extension method does not work as it needs access to `cancellationDelayMaxMs` which is pulled from config in the `Consumer` impl. So not available to the extension in a "nice" way.
I did a search in github for  "dotnet.cancellation.delay.max.ms". Only a single hit outside Confluent.Kafka. I haven't seen anyone in "Corp world" use it either. 100ms seems like a reasonable value. We could just expose it as a default param on the method? And remove the config option, leave it up to the dev?

Also the `Consume(TimeStamp)` overload is referred to all over the place in xmldoc. Mostly codegen so probably not that big of a deal.

I do like extensions for this kind of thing. But not as nice as I'd thought in this case.
Keeping it simple for now. I may do another PR with the above changes, just to show what it would look like