### PR TITLE
Expose client name and version to brokers

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -540,9 +540,8 @@ namespace Confluent.Kafka
                 throw new ArgumentException("'group.id' configuration parameter is required and was not specified.");
             }
 
-            var modifiedConfig = config
-                .Where(prop => prop.Key != ConfigPropertyNames.Consumer.ConsumeResultFields)
-                .Concat(Library.NameAndVersionConfig)
+            var modifiedConfig = Library.NameAndVersionConfig
+                .Concat(config.Where(prop => prop.Key != ConfigPropertyNames.Consumer.ConsumeResultFields))
                 .ToList();
 
             var enabledFieldsObj = config.FirstOrDefault(prop => prop.Key == ConfigPropertyNames.Consumer.ConsumeResultFields).Value;

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -541,7 +541,9 @@ namespace Confluent.Kafka
             }
 
             var modifiedConfig = config
-                .Where(prop => prop.Key != ConfigPropertyNames.Consumer.ConsumeResultFields);
+                .Where(prop => prop.Key != ConfigPropertyNames.Consumer.ConsumeResultFields)
+                .Concat(Library.NameAndVersionConfig)
+                .ToList();
 
             var enabledFieldsObj = config.FirstOrDefault(prop => prop.Key == ConfigPropertyNames.Consumer.ConsumeResultFields).Value;
             if (enabledFieldsObj != null)
@@ -571,10 +573,10 @@ namespace Confluent.Kafka
             }
 
             var configHandle = SafeConfigHandle.Create();
-            modifiedConfig
-                .ToList()
-                .ForEach((kvp) => {
-                    if (kvp.Value == null) throw new ArgumentNullException($"'{kvp.Key}' configuration parameter must not be null.");
+
+            modifiedConfig.ForEach((kvp) =>
+                {
+                    if (kvp.Value == null) { throw new ArgumentNullException($"'{kvp.Key}' configuration parameter must not be null."); }
                     configHandle.Set(kvp.Key, kvp.Value);
                 });
 

--- a/src/Confluent.Kafka/Library.cs
+++ b/src/Confluent.Kafka/Library.cs
@@ -17,6 +17,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Confluent.Kafka.Internal;
 using Confluent.Kafka.Impl;
@@ -125,5 +126,17 @@ namespace Confluent.Kafka
         /// </summary>
         public static int HandleCount
             => kafkaHandleCreateCount - kafkaHandleDestroyCount;
+
+        internal static List<KeyValuePair<string, string>> NameAndVersionConfig
+        {
+            get
+            {
+                return new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>( "client.software.name", "confluent-kafka-dotnet"),
+                    new KeyValuePair<string, string>( "client.software.version", VersionString )
+                };
+            }
+        }
     }
 }

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -556,7 +556,9 @@ namespace Confluent.Kafka
                 .Where(prop => 
                     prop.Key != ConfigPropertyNames.Producer.EnableBackgroundPoll &&
                     prop.Key != ConfigPropertyNames.Producer.EnableDeliveryReports &&
-                    prop.Key != ConfigPropertyNames.Producer.DeliveryReportFields);
+                    prop.Key != ConfigPropertyNames.Producer.DeliveryReportFields)
+                .Concat(Library.NameAndVersionConfig)
+                .ToList();
 
             if (modifiedConfig.Where(obj => obj.Key == "delivery.report.only.error").Count() > 0)
             {
@@ -612,10 +614,11 @@ namespace Confluent.Kafka
 
             var configHandle = SafeConfigHandle.Create();
 
-            modifiedConfig.ToList().ForEach((kvp) => {
-                if (kvp.Value == null) throw new ArgumentNullException($"'{kvp.Key}' configuration parameter must not be null.");
-                configHandle.Set(kvp.Key, kvp.Value);
-            });
+            modifiedConfig.ForEach((kvp) =>
+                {
+                    if (kvp.Value == null) { throw new ArgumentNullException($"'{kvp.Key}' configuration parameter must not be null."); }
+                    configHandle.Set(kvp.Key, kvp.Value);
+                });
 
 
             IntPtr configPtr = configHandle.DangerousGetHandle();

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -552,12 +552,12 @@ namespace Confluent.Kafka
 
             Librdkafka.Initialize(null);
 
-            var modifiedConfig = config
-                .Where(prop => 
-                    prop.Key != ConfigPropertyNames.Producer.EnableBackgroundPoll &&
-                    prop.Key != ConfigPropertyNames.Producer.EnableDeliveryReports &&
-                    prop.Key != ConfigPropertyNames.Producer.DeliveryReportFields)
-                .Concat(Library.NameAndVersionConfig)
+            var modifiedConfig = Library.NameAndVersionConfig
+                .Concat(config
+                    .Where(prop =>
+                        prop.Key != ConfigPropertyNames.Producer.EnableBackgroundPoll &&
+                        prop.Key != ConfigPropertyNames.Producer.EnableDeliveryReports &&
+                        prop.Key != ConfigPropertyNames.Producer.DeliveryReportFields))
                 .ToList();
 
             if (modifiedConfig.Where(obj => obj.Key == "delivery.report.only.error").Count() > 0)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ClientNameVersion.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ClientNameVersion.cs
@@ -1,0 +1,63 @@
+// Copyright 2020 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+#pragma warning disable xUnit1026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public partial class Tests
+    {
+        /// <summary>
+        ///     Tests that setting client.software.name + client.software.version
+        ///     in producer and consumer config does not result in an exception.
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public void ClientNameVersion(string bootstrapServers)
+        {
+            LogToFile("start ClientNameVersion");
+
+            var producerConfig = new ProducerConfig
+            {
+                BootstrapServers = bootstrapServers
+            };
+            producerConfig.Set("client.software.name", "test");
+            producerConfig.Set("client.software.version", "1.0");
+
+            var consumerConfig = new ConsumerConfig
+            {
+                GroupId = Guid.NewGuid().ToString(),
+                BootstrapServers = bootstrapServers,
+                SessionTimeoutMs = 6000
+            };
+            consumerConfig.Set("client.software.name", "test");
+            consumerConfig.Set("client.software.version", "1.0");
+
+
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
+            using (var consumer = new ConsumerBuilder<byte[], byte[]>(consumerConfig).Build())
+            { }
+
+            Assert.Equal(0, Library.HandleCount);
+            LogToFile("end   ClientNameVersion");
+        }
+    }
+}


### PR DESCRIPTION
note: `AdminClient` utilizes a producer instance under the covers and doesn't need to be explicitly updated.
