### PR TITLE
Removing Misleading / Unnecessary Offset Comment

### DIFF
--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -140,9 +140,6 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 // if you do not intend to use any consumer group functionality.
                 GroupId = new Guid().ToString(),
                 BootstrapServers = brokerList,
-                // partition offsets can be committed to a group even by consumers not
-                // subscribed to the group. in this example, auto commit is disabled
-                // to prevent this from occurring.
                 EnableAutoCommit = true
             };
 


### PR DESCRIPTION
Removed a potentially misleading comment that referred to disabling the `EnableAutoOffset` property despite it being explicitly enabled on the following line per Issue #1167 