### PR TITLE
Made message convenience properties on ConsumeResult obsolete

### DIFF
--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -17,10 +17,7 @@
 // Refer to LICENSE for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 
 

--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -123,7 +123,7 @@ namespace AvroBlogExample
 
                             Console.WriteLine(
                                 consumeResult.Message.Timestamp.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")
-                                + $": [{consumeResult.Value.Severity}] {consumeResult.Value.Message}");
+                                + $": [{consumeResult.Message.Value.Severity}] {consumeResult.Message.Value.Message}");
                         }
                         catch (ConsumeException e)
                         {

--- a/examples/AvroGeneric/Program.cs
+++ b/examples/AvroGeneric/Program.cs
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.Examples.AvroGeneric
                             {
                                 var consumeResult = consumer.Consume(cts.Token);
 
-                                Console.WriteLine($"Key: {consumeResult.Message.Key}\nValue: {consumeResult.Value}");
+                                Console.WriteLine($"Key: {consumeResult.Message.Key}\nValue: {consumeResult.Message.Value}");
                             }
                             catch (ConsumeException e)
                             {

--- a/examples/AvroSpecific/Program.cs
+++ b/examples/AvroSpecific/Program.cs
@@ -84,7 +84,7 @@ namespace Confluent.Kafka.Examples.AvroSpecific
                             try
                             {
                                 var consumeResult = consumer.Consume(cts.Token);
-                                Console.WriteLine($"user name: {consumeResult.Message.Key}, favorite color: {consumeResult.Value.favorite_color}, hourly_rate: {consumeResult.Value.hourly_rate}");
+                                Console.WriteLine($"user name: {consumeResult.Message.Key}, favorite color: {consumeResult.Message.Value.favorite_color}, hourly_rate: {consumeResult.Message.Value.hourly_rate}");
                             }
                             catch (ConsumeException e)
                             {

--- a/examples/ConfluentCloud/Program.cs
+++ b/examples/ConfluentCloud/Program.cs
@@ -79,7 +79,7 @@ namespace ConfluentCloudExample
                 try
                 {
                     var consumeResult = consumer.Consume();
-                    Console.WriteLine($"consumed: {consumeResult.Value}");
+                    Console.WriteLine($"consumed: {consumeResult.Message.Value}");
                 }
                 catch (ConsumeException e)
                 {

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -92,7 +92,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                                 continue;
                             }
 
-                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: {consumeResult.Value}");
+                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: {consumeResult.Message.Value}");
 
                             if (consumeResult.Offset % commitPeriod == 0)
                             {
@@ -163,7 +163,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                             // Note: End of partition notification has not been enabled, so
                             // it is guaranteed that the ConsumeResult instance corresponds
                             // to a Message, and not a PartitionEOF event.
-                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: ${consumeResult.Value}");
+                            Console.WriteLine($"Received message at {consumeResult.TopicPartitionOffset}: ${consumeResult.Message.Value}");
                         }
                         catch (ConsumeException e)
                         {

--- a/examples/Protobuf/Program.cs
+++ b/examples/Protobuf/Program.cs
@@ -81,7 +81,7 @@ namespace Confluent.Kafka.Examples.Protobuf
                             try
                             {
                                 var consumeResult = consumer.Consume(cts.Token);
-                                Console.WriteLine($"user name: {consumeResult.Message.Key}, favorite color: {consumeResult.Value.FavoriteColor}");
+                                Console.WriteLine($"user name: {consumeResult.Message.Key}, favorite color: {consumeResult.Message.Value.FavoriteColor}");
                             }
                             catch (ConsumeException e)
                             {

--- a/examples/Transactions/Program.cs
+++ b/examples/Transactions/Program.cs
@@ -323,7 +323,7 @@ namespace Confluent.Kafka.Examples.Transactions
 
                         producerState[cr.TopicPartition].Offset = cr.Offset;
 
-                        var words = Regex.Split(cr.Value.ToLower(), @"[^a-zA-Z_]").Where(s => s != String.Empty);
+                        var words = Regex.Split(cr.Message.Value.ToLower(), @"[^a-zA-Z_]").Where(s => s != String.Empty);
                         foreach (var w in words)
                         {
                             while (true)
@@ -444,7 +444,7 @@ namespace Confluent.Kafka.Examples.Transactions
                     else
                     {
                         msgCount += 1;
-                        db.Put(Encoding.UTF8.GetBytes(cr.Key), BitConverter.GetBytes(cr.Value), columnFamily);
+                        db.Put(Encoding.UTF8.GetBytes(cr.Message.Key), BitConverter.GetBytes(cr.Message.Value), columnFamily);
                     }
                 }
             }
@@ -550,7 +550,7 @@ namespace Confluent.Kafka.Examples.Transactions
                         var cr = consumer.Consume(ct);
                         producerState[cr.TopicPartition].Offset = cr.Offset;
 
-                        var kBytes = Encoding.UTF8.GetBytes(cr.Key);
+                        var kBytes = Encoding.UTF8.GetBytes(cr.Message.Key);
                         var vBytes = db.Get(kBytes, columnFamily);
                         var v = vBytes == null ? 0 : BitConverter.ToInt32(vBytes);
                         var updatedV = v+1;
@@ -562,7 +562,7 @@ namespace Confluent.Kafka.Examples.Transactions
                             try
                             {
                                 producerState[cr.TopicPartition].Producer.Produce(
-                                    Topic_Counts, new Message<string, int> { Key = cr.Key, Value = updatedV });
+                                    Topic_Counts, new Message<string, int> { Key = cr.Message.Key, Value = updatedV });
                             }
                             catch (KafkaException e)
                             {

--- a/src/Confluent.Kafka/ConsumeResult.cs
+++ b/src/Confluent.Kafka/ConsumeResult.cs
@@ -16,6 +16,8 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
+
 
 namespace Confluent.Kafka
 {
@@ -71,6 +73,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The Kafka message Key.
         /// </summary>
+        [Obsolete("Please access the message Key via .Message.Key.")]
         public TKey Key
         {
             get
@@ -87,6 +90,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The Kafka message Value.
         /// </summary>
+        [Obsolete("Please access the message Value via .Message.Value.")]
         public TValue Value
         {
             get
@@ -103,6 +107,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The Kafka message timestamp.
         /// </summary>
+        [Obsolete("Please access the message Timestamp via .Message.Timestamp.")]
         public Timestamp Timestamp
         {
             get
@@ -119,6 +124,7 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The Kafka message headers.
         /// </summary>
+        [Obsolete("Please access the message Headers via .Message.Headers.")]
         public Headers Headers
         {
             get

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -63,7 +63,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new List<TopicPartitionOffset>() { new TopicPartitionOffset(dr.TopicPartition, dr.Offset) });
                 var cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 consumer.Commit();
-                Assert.Equal(cr.Value, testString);
+                Assert.Equal(cr.Message.Value, testString);
                 
                 // Determine offset to consume from automatically.
                 consumer.Assign(new List<TopicPartition>() { dr.TopicPartition });
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new TopicPartitionOffset(dr.TopicPartition, dr3.Offset));
                 cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 consumer.Commit();
-                Assert.Equal(cr.Value, testString3);
+                Assert.Equal(cr.Message.Value, testString3);
 
                 // Determine offset to consume from automatically.
                 consumer.Assign(dr.TopicPartition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -123,8 +123,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 c.Assign(dr.TopicPartitionOffset);
                 var cr = c.Consume(TimeSpan.FromSeconds(10));
-                Assert.Equal("abc", cr.Key);
-                Assert.Equal("123", cr.Value);
+                Assert.Equal("abc", cr.Message.Key);
+                Assert.Equal("123", cr.Message.Value);
             }
 
             using (var c = new ConsumerBuilder<byte[], byte[]>(consumerConfig).Build())
@@ -132,8 +132,8 @@ namespace Confluent.Kafka.IntegrationTests
                 c.Assign(dr.TopicPartitionOffset);
                 var cr = c.Consume(TimeSpan.FromSeconds(10));
                 // check that each character is serialized into 4 bytes.
-                Assert.Equal(3*4, cr.Key.Length);
-                Assert.Equal(3*4, cr.Value.Length);
+                Assert.Equal(3*4, cr.Message.Key.Length);
+                Assert.Equal(3*4, cr.Message.Value.Length);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -64,8 +64,8 @@ namespace Confluent.Kafka.IntegrationTests
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Null(record.Message.Headers);
-                Assert.NotEqual(TimestampType.NotAvailable, record.Timestamp.Type);
-                Assert.NotEqual(0, record.Timestamp.UnixTimestampMs);
+                Assert.NotEqual(TimestampType.NotAvailable, record.Message.Timestamp.Type);
+                Assert.NotEqual(0, record.Message.Timestamp.UnixTimestampMs);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -64,8 +64,8 @@ namespace Confluent.Kafka.IntegrationTests
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.NotNull(record.Message.Headers);
-                Assert.Equal(TimestampType.NotAvailable, record.Timestamp.Type);
-                Assert.Equal(0, record.Timestamp.UnixTimestampMs);
+                Assert.Equal(TimestampType.NotAvailable, record.Message.Timestamp.Type);
+                Assert.Equal(0, record.Message.Timestamp.UnixTimestampMs);
             }
             
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -318,7 +318,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Assign(new TopicPartitionOffset(singlePartitionTopic, 0, nulldr.Offset));
                 var cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(cr?.Message);
-                Assert.Single(cr.Headers);
+                Assert.Single(cr.Message.Headers);
                 Assert.Equal("my-header", cr.Message.Headers[0].Key);
                 Assert.Null(cr.Message.Headers[0].GetValueBytes());
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -73,10 +73,10 @@ namespace Confluent.Kafka.IntegrationTests
 
                 ConsumeResult<Ignore, byte[]> record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
-                Assert.Null(record.Key);
-                Assert.NotNull(record.Value);
-                Assert.Equal(42, record.Value[0]);
-                Assert.Equal(240, record.Value[1]);
+                Assert.Null(record.Message.Key);
+                Assert.NotNull(record.Message.Value);
+                Assert.Equal(42, record.Message.Value[0]);
+                Assert.Equal(240, record.Message.Value[1]);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
@@ -87,8 +87,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
                     var r1 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(new byte[] { 42 }, r1.Key);
-                    Assert.Equal(new byte[] { 33 }, r1.Value);
+                    Assert.Equal(new byte[] { 42 }, r1.Message.Key);
+                    Assert.Equal(new byte[] { 33 }, r1.Message.Value);
                     Assert.Equal(0, r1.Offset);
                 }
 
@@ -96,8 +96,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 1));
                     var r2 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal("hello", r2.Key);
-                    Assert.Equal("world", r2.Value);
+                    Assert.Equal("hello", r2.Message.Key);
+                    Assert.Equal("world", r2.Message.Value);
                     Assert.Equal(1, r2.Offset);
                 }
 
@@ -105,8 +105,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 2));
                     var r3 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(new byte[] { 40 }, r3.Key);
-                    Assert.Equal(new byte[] { 31 }, r3.Value);
+                    Assert.Equal(new byte[] { 40 }, r3.Message.Key);
+                    Assert.Equal(new byte[] { 31 }, r3.Message.Value);
                     Assert.Equal(2, r3.Offset);
                 }
 
@@ -114,8 +114,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 3));
                     var r4 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(42, r4.Key);
-                    Assert.Equal("mellow world", r4.Value);
+                    Assert.Equal(42, r4.Message.Key);
+                    Assert.Equal("mellow world", r4.Message.Value);
                     Assert.Equal(3, r4.Offset);
                 }
 
@@ -123,8 +123,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 4));
                     var r5 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(int.MaxValue, r5.Key);
-                    Assert.Equal(int.MinValue, r5.Value);
+                    Assert.Equal(int.MaxValue, r5.Message.Key);
+                    Assert.Equal(int.MinValue, r5.Message.Value);
                     Assert.Equal(4, r5.Offset);
                 }
 
@@ -132,8 +132,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 5));
                     var r6 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal("yellow mould", r6.Key);
-                    Assert.Equal(new byte[] { 69 }, r6.Value);
+                    Assert.Equal("yellow mould", r6.Message.Key);
+                    Assert.Equal(new byte[] { 69 }, r6.Message.Value);
                     Assert.Equal(5, r6.Offset);
                 }
 
@@ -141,8 +141,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 6));
                     var r7 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Equal(44.0, r7.Key);
-                    Assert.Equal(234.4, r7.Value);
+                    Assert.Equal(44.0, r7.Message.Key);
+                    Assert.Equal(234.4, r7.Message.Value);
                     Assert.Equal(6, r7.Offset);
                 }
             }

--- a/test/Confluent.Kafka.Transactions/TestConsumer.cs
+++ b/test/Confluent.Kafka.Transactions/TestConsumer.cs
@@ -39,11 +39,11 @@ namespace Confluent.Kafka.Transactions
                 {
                     var cr = consumer.Consume();
 
-                    if (!lasts.ContainsKey(cr.Key)) { lasts.Add(cr.Key, -1); }
-                    if (cr.Value == lasts[cr.Key] + 1) { Console.Write("."); }
-                    else { Console.Write($"[producer {cr.Key} expected seq {lasts[cr.Key]+1} but got {cr.Value}]"); break; }
+                    if (!lasts.ContainsKey(cr.Message.Key)) { lasts.Add(cr.Message.Key, -1); }
+                    if (cr.Message.Value == lasts[cr.Message.Key] + 1) { Console.Write("."); }
+                    else { Console.Write($"[producer {cr.Message.Key} expected seq {lasts[cr.Message.Key]+1} but got {cr.Message.Value}]"); break; }
                     Console.Out.Flush();
-                    lasts[cr.Key] = cr.Value;
+                    lasts[cr.Message.Key] = cr.Message.Value;
                 }
             }
             catch (Exception e)

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AvroAndRegular.cs
@@ -112,8 +112,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     {
                         consumer.Assign(new TopicPartitionOffset(topic1.Name, 0, 0));
                         var cr = consumer.Consume();
-                        Assert.Equal("hello", cr.Key);
-                        Assert.Equal("world", cr.Value);
+                        Assert.Equal("hello", cr.Message.Key);
+                        Assert.Equal("world", cr.Message.Value);
                     }
 
                     using (var consumer =
@@ -123,8 +123,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     {
                         consumer.Assign(new TopicPartitionOffset(topic2.Name, 0, 0));
                         var cr = consumer.Consume();
-                        Assert.Equal("hello", cr.Key);
-                        Assert.Equal("world", cr.Value);
+                        Assert.Equal("hello", cr.Message.Key);
+                        Assert.Equal("world", cr.Message.Value);
                     }
 
                     using (var consumer =

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/PrimitiveTypes.cs
@@ -244,8 +244,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     consumer.Assign(new List<TopicPartitionOffset> { new TopicPartitionOffset(nullTopic, 0, 0) });
                     var result8 = consumer.Consume(TimeSpan.FromSeconds(10));
-                    Assert.Null(result8.Key);
-                    Assert.Null(result8.Value);
+                    Assert.Null(result8.Message.Key);
+                    Assert.Null(result8.Message.Value);
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Configuration.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Configuration.cs
@@ -33,7 +33,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         {
             testTopic = "topic";
             var schemaRegistryMock = new Mock<ISchemaRegistryClient>();
-            schemaRegistryMock.Setup(x => x.RegisterSchemaAsync(testTopic + "-value", It.IsAny<string>())).ReturnsAsync(
+            schemaRegistryMock.Setup(x => x.RegisterSchemaAsync(testTopic + "-value", It.IsAny<Schema>())).ReturnsAsync(
                 (string topic, string schema) => store.TryGetValue(schema, out int id) ? id : store[schema] = store.Count + 1
             );
             schemaRegistryMock.Setup(x => x.GetSchemaAsync(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync(


### PR DESCRIPTION
The message convenience properties on `ConsumeResult` were added at a time when it was never the case that `ConsumeResult.Message` could be `null`. Soon after, this became possible but the properties were never removed. They're a recurring source of confusion, so i'm marking them as obsolete.

@edenhill 