### PR TITLE
progress on nullable avro values [WIP, not for review]

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Avro/AvroDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/AvroDeserializer.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.Serdes
     ///       bytes 1-4:        Unique global id of the Avro schema that was used for encoding (as registered in Confluent Schema Registry), big endian.
     ///       following bytes:  The serialized data.
     /// </remarks>
-    public class AvroDeserializer<T> : IAsyncDeserializer<T>
+    public class AvroDeserializer<T> : IAsyncDeserializer<T> where T : class
     {
         private IAvroDeserializerImpl<T> deserializerImpl;
 

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/AvroSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/AvroSerializer.cs
@@ -35,7 +35,7 @@ namespace Confluent.SchemaRegistry.Serdes
     ///       bytes 1-4:        Unique global id of the Avro schema that was used for encoding (as registered in Confluent Schema Registry), big endian.
     ///       following bytes:  The serialized data.
     /// </remarks>
-    public class AvroSerializer<T> : IAsyncSerializer<T>
+    public class AvroSerializer<T> : IAsyncSerializer<T> where T : class
     {
         private bool autoRegisterSchema = true;
         private int initialBufferSize = DefaultInitialBufferSize;

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificDeserializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificDeserializerImpl.cs
@@ -29,7 +29,7 @@ using Confluent.Kafka;
 
 namespace Confluent.SchemaRegistry.Serdes
 {
-    internal class SpecificDeserializerImpl<T> : IAvroDeserializerImpl<T>
+    internal class SpecificDeserializerImpl<T> : IAvroDeserializerImpl<T> where T : class
     {
         /// <remarks>
         ///     A datum reader cache (one corresponding to each write schema that's been seen) 
@@ -103,6 +103,11 @@ namespace Confluent.SchemaRegistry.Serdes
             {
                 // Note: topic is not necessary for deserialization (or knowing if it's a key 
                 // or value) only the schema id is needed.
+
+                if (array == null)
+                {
+                    return null;
+                }
 
                 if (array.Length < 5)
                 {

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
@@ -31,7 +31,7 @@ using Confluent.Kafka;
 
 namespace Confluent.SchemaRegistry.Serdes
 {
-    internal class SpecificSerializerImpl<T> : IAvroSerializerImpl<T>
+    internal class SpecificSerializerImpl<T> : IAvroSerializerImpl<T> where T : class
     {
         private ISchemaRegistryClient schemaRegistryClient;
         private bool autoRegisterSchema;
@@ -153,6 +153,11 @@ namespace Confluent.SchemaRegistry.Serdes
                 finally
                 {
                     serializeMutex.Release();
+                }
+
+                if (data == null)
+                {
+                    return null;
                 }
 
                 using (var stream = new MemoryStream(initialBufferSize))


### PR DESCRIPTION
I just set out to add support for nullable avro values. unfortunately this is a little awkward because the generic type on the serdes can currently be int, bool etc (this is in fact explicitly supported) which aren't nullable. so we can't return a null value from the deserializer - the type system in C# isn't powerful enough. the best solution is probably to discontinue support for int, bool, and instead provide support for int?, bool?. This is all good except it's not backwards compatible (changes to code required). We could alternatively provide different serdes side by side.

this issues does not apply to the json and protobuf serdes, they can handle null values.