### PR TITLE
Adds (optional) JsonSchemaGeneratorSettings to JsonSerializer and JsonDeserializer for custom control over JSON schema generation.

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using NJsonSchema.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -48,6 +49,8 @@ namespace Confluent.SchemaRegistry.Serdes
     public class JsonDeserializer<T> : IAsyncDeserializer<T> where T : class, new()
     {
         private readonly int headerSize =  sizeof(int) + sizeof(byte);
+        
+        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
 
         /// <summary>
         ///     Initialize a new JsonDeserializer instance.
@@ -56,8 +59,13 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     Deserializer configuration properties (refer to
         ///     <see cref="JsonDeserializerConfig" />).
         /// </param>
-        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null)
+        /// <param name="jsonSchemaGeneratorSettings">
+        ///     JSON schema generator settings.
+        /// </param>
+        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
         {
+            this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
+
             if (config == null) { return; }
 
             if (config.Count() > 0)
@@ -107,7 +115,7 @@ namespace Confluent.SchemaRegistry.Serdes
                 using (var stream = new MemoryStream(array, headerSize, array.Length - headerSize))
                 using (var sr = new System.IO.StreamReader(stream, Encoding.UTF8))
                 {
-                    return Task.FromResult(Newtonsoft.Json.JsonConvert.DeserializeObject<T>(sr.ReadToEnd()));
+                    return Task.FromResult(Newtonsoft.Json.JsonConvert.DeserializeObject<T>(sr.ReadToEnd(), this.jsonSchemaGeneratorSettings?.ActualSerializerSettings));
                 }
             }
             catch (AggregateException e)

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
@@ -17,11 +17,17 @@
 // ConstructValueSubjectName is still used a an internal implementation detail.
 #pragma warning disable CS0618
 
+using Confluent.Kafka;
 using Moq;
-using Xunit;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NJsonSchema.Generation;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Confluent.Kafka;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
 
 
 namespace Confluent.SchemaRegistry.Serdes.UnitTests
@@ -31,6 +37,47 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         public class UInt32Value
         {
             public int Value { get; set; }
+        }
+
+        private class UInt32ValueMultiplyConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                var newValue = ((UInt32Value) value).Value * 2;
+                writer.WriteStartObject();
+                writer.WritePropertyName("Value");
+                writer.WriteValue(newValue);
+                writer.WriteEndObject();
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.StartObject)
+                {
+                    reader.Read();
+                }
+
+                var value = reader.ReadAsInt32() ?? 0;
+                reader.Read();
+                return new UInt32Value
+                {
+                    Value = value / 2
+                };
+            }
+
+            public override bool CanConvert(Type objectType) => objectType == typeof(UInt32Value);
+        }
+
+        public enum EnumType
+        {
+            None,
+            EnumValue = 1234,
+            OtherValue = 5678
+        }
+
+        public class EnumObject
+        {
+            public EnumType Value { get; set; }
         }
 
         private ISchemaRegistryClient schemaRegistryClient;
@@ -72,6 +119,60 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var v = new UInt32Value { Value = 1234 };
             var bytes = jsonSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(v.Value, jsonDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result.Value);
+        }
+
+        [Fact]
+        public async Task WithJsonSerializerSettingsSerDe()
+        {
+            const int value = 1234;
+            var expectedJson = $"{{\"Value\":{value * 2}}}";
+            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            {
+                SerializerSettings = new JsonSerializerSettings
+                {
+                    Converters = new List<JsonConverter>
+                    {
+                        new UInt32ValueMultiplyConverter()
+                    },
+                    ContractResolver = new DefaultContractResolver()
+                }
+            };
+
+            var jsonSerializer = new JsonSerializer<UInt32Value>(schemaRegistryClient, jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings);
+            var jsonDeserializer = new JsonDeserializer<UInt32Value>(jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings);
+
+            var v = new UInt32Value { Value = value };
+            var bytes = await jsonSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.NotNull(bytes);
+            Assert.Equal(expectedJson, Encoding.UTF8.GetString(bytes.AsSpan().Slice(5)));
+
+            var actual = await jsonDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.NotNull(actual);
+            Assert.Equal(v.Value, actual.Value);
+        }
+
+        [Theory]
+        [InlineData(EnumHandling.CamelCaseString, EnumType.EnumValue, "{\"Value\":\"enumValue\"}")]
+        [InlineData(EnumHandling.String, EnumType.None, "{\"Value\":\"None\"}")]
+        [InlineData(EnumHandling.Integer, EnumType.OtherValue, "{\"Value\":5678}")]
+        public async Task WithJsonSchemaGeneratorSettingsSerDe(EnumHandling enumHandling, EnumType value, string expectedJson)
+        {
+            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            {
+                DefaultEnumHandling = enumHandling
+            };
+
+            var jsonSerializer = new JsonSerializer<EnumObject>(schemaRegistryClient, jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings);
+            var jsonDeserializer = new JsonDeserializer<EnumObject>(jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings);
+
+            var v = new EnumObject { Value = value };
+            var bytes = await jsonSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.NotNull(bytes);
+            Assert.Equal(expectedJson, Encoding.UTF8.GetString(bytes.AsSpan().Slice(5)));
+
+            var actual = await jsonDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.NotNull(actual);
+            Assert.Equal(actual.Value, value);
         }
     }
 }


### PR DESCRIPTION
I've encountered issues validating schemas for contracts that rely for example on a JSON converter, or when it is necessary to use a different contract resolver. I dislike having to use `JsonConvert.DefaultSettings` for this as this can easily be changed mistakenly for other use cases, and thus breaking schema validation.

This PR makes it possible to pass `JsonSchemaGeneratorSettings` to the JSON (de)serializer.