### PR TITLE
Move from DateTime to DateTimeOffset

### DIFF
--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -122,7 +122,7 @@ namespace AvroBlogExample
                             var consumeResult = consumer.Consume(cts.Token);
 
                             Console.WriteLine(
-                                consumeResult.Message.Timestamp.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")
+                                consumeResult.Message.Timestamp.DateTimeOffset.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")
                                 + $": [{consumeResult.Message.Value.Severity}] {consumeResult.Message.Value.Message}");
                         }
                         catch (ConsumeException e)

--- a/examples/Transactions/Program.cs
+++ b/examples/Transactions/Program.cs
@@ -230,7 +230,7 @@ namespace Confluent.Kafka.Examples.Transactions
 
             var TxnCommitPeriod = TimeSpan.FromSeconds(10);
 
-            var lastTxnCommit = DateTime.Now;
+            var lastTxnCommit = DateTimeOffset.Now;
             
             // Due to limitations outlined in KIP-447 (which KIP-447 overcomes), it is
             // currently necessary to use a separate producer per input partition. The
@@ -354,7 +354,7 @@ namespace Confluent.Kafka.Examples.Transactions
                         }
 
                         // Commit transactions every TxnCommitPeriod
-                        if (DateTime.Now > lastTxnCommit + TxnCommitPeriod)
+                        if (DateTimeOffset.Now > lastTxnCommit + TxnCommitPeriod)
                         {
                             // Execute the transaction commits for each producer in parallel.
                             var tasks = new List<Task>();
@@ -391,7 +391,7 @@ namespace Confluent.Kafka.Examples.Transactions
                             Task.WaitAll(tasks.ToArray(), ct);
 
                             Console.WriteLine($"Committed MapWords transaction(s) comprising {wCount} words from {lCount} lines.");
-                            lastTxnCommit = DateTime.Now;
+                            lastTxnCommit = DateTimeOffset.Now;
                             wCount = 0;
                             lCount = 0;
                         }
@@ -480,7 +480,7 @@ namespace Confluent.Kafka.Examples.Transactions
 
             ColumnFamilyHandle columnFamily = null;
             
-            var lastTxnCommit = DateTime.Now;
+            var lastTxnCommit = DateTimeOffset.Now;
 
             var producerState = new Dictionary<TopicPartition, ProducerState<string, int>>();
 
@@ -578,7 +578,7 @@ namespace Confluent.Kafka.Examples.Transactions
 
                         wCount += 1;
 
-                        if (DateTime.Now > lastTxnCommit + TxnCommitPeriod)
+                        if (DateTimeOffset.Now > lastTxnCommit + TxnCommitPeriod)
                         {
                             // Execute the transaction commits for each producer in parallel.
                             var tasks = new List<Task>();
@@ -602,7 +602,7 @@ namespace Confluent.Kafka.Examples.Transactions
                             Task.WaitAll(tasks.ToArray(), ct);
 
                             Console.WriteLine($"Committed AggregateWords transaction(s) comprising updates to {wCount} words.");
-                            lastTxnCommit = DateTime.Now;
+                            lastTxnCommit = DateTimeOffset.Now;
                             wCount = 0;
                         }
                     }

--- a/src/Confluent.Kafka/Loggers.cs
+++ b/src/Confluent.Kafka/Loggers.cs
@@ -36,7 +36,7 @@ namespace Confluent.Kafka
         /// </summary>
         public static void ConsoleLogger(LogMessage logInfo)
         {
-            var now = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            var now = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
             Console.Error.WriteLine($"{logInfo.Level}|{now}|{logInfo.Name}|{logInfo.Facility}| {logInfo.Message}");
         }
     }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Consume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Consume.cs
@@ -64,7 +64,7 @@ namespace Confluent.Kafka.IntegrationTests
                     if (record.IsPartitionEOF) { break; }
 
                     Assert.Equal(TimestampType.CreateTime, record.Message.Timestamp.Type);
-                    Assert.True(Math.Abs((DateTime.UtcNow - record.Message.Timestamp.UtcDateTime).TotalMinutes) < 10.0);
+                    Assert.True(Math.Abs((DateTimeOffset.UtcNow - record.Message.Timestamp.DateTimeOffset).TotalMinutes) < 10.0);
                     msgCnt += 1;
                 }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsCommitedHandler.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsCommitedHandler.cs
@@ -64,12 +64,12 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Subscribe(singlePartitionTopic);
 
-                var startTime = DateTime.MinValue;
-                while (startTime == DateTime.MinValue || DateTime.Now - startTime < TimeSpan.FromSeconds(6))
+                var startTime = DateTimeOffset.MinValue;
+                while (startTime == DateTimeOffset.MinValue || DateTimeOffset.Now - startTime < TimeSpan.FromSeconds(6))
                 {
                     var cr = consumer.Consume(TimeSpan.FromMilliseconds(100));
                     if (cr == null) { continue; }
-                    if (startTime == DateTime.MinValue) { startTime = DateTime.Now; }
+                    if (startTime == DateTimeOffset.MinValue) { startTime = DateTimeOffset.Now; }
                 }
 
                 Assert.True(committedCount > 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -77,7 +77,7 @@ namespace Confluent.Kafka.IntegrationTests
                     Assert.Equal(result[0].Offset, lastMessage.Offset);
 
                     // Getting the offset for a timestamp that is very far in the past.
-                    var unixTimeEpoch = Timestamp.UnixTimeEpoch;
+                    var unixTimeEpoch = Timestamp.UnixTimeEpochDateTimeOffset;
                     result = consumer.OffsetsForTimes(
                             new[] { new TopicPartitionTimestamp(new TopicPartition(topic.Name, Partition), new Timestamp(100, TimestampType.CreateTime)) },
                             timeout)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
@@ -54,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal($"test key {count}", dr.Message.Key);
                 Assert.Equal($"test val {count}", dr.Message.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
                 count += 1;
             };
 
@@ -87,7 +87,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal($"test key {count + 42}", Encoding.UTF8.GetString(dr.Message.Key));
                 Assert.Equal($"test val {count + 42}", Encoding.UTF8.GetString(dr.Message.Value));
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
                 count += 1;
             };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
@@ -59,7 +59,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Message.Key);
                 Assert.Null(dr.Message.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
             }
 
             Assert.Equal((Partition)0, drs[0].Result.Partition);
@@ -84,7 +84,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Message.Key);
                 Assert.Null(dr.Message.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
             }
             
             Assert.Equal((Partition)1, drs2[0].Result.Partition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -63,7 +63,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal($"test key {i}", dr.Message.Key);
                 Assert.Equal($"test val {i}", dr.Message.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
             }
 
             Assert.Equal((Partition)1, drs[0].Result.Partition);
@@ -92,7 +92,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal($"test key {i+2}", Encoding.UTF8.GetString(dr.Message.Key));
                 Assert.Equal($"test val {i+2}", Encoding.UTF8.GetString(dr.Message.Value));
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
             }
 
             Assert.Equal((Partition)1, drs2[0].Result.Partition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_Null.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_Null.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Message.Key);
                 Assert.Null(dr.Message.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
                 count += 1;
             };
 
@@ -75,7 +75,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Null(dr.Message.Key);
                 Assert.Null(dr.Message.Value);
                 Assert.Equal(TimestampType.CreateTime, dr.Message.Timestamp.Type);
-                Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+                Assert.True(Math.Abs((DateTimeOffset.UtcNow - dr.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
                 count += 1;
             };
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -86,7 +86,7 @@ namespace Confluent.Kafka.IntegrationTests
             Assert.Equal(topic, result.Topic);
             Assert.NotEqual<long>(result.Offset, Offset.Unset);
             Assert.Equal(TimestampType.CreateTime, result.Message.Timestamp.Type);
-            Assert.True(Math.Abs((DateTime.UtcNow - result.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
+            Assert.True(Math.Abs((DateTimeOffset.UtcNow - result.Message.Timestamp.DateTimeOffset).TotalMinutes) < 1.0);
             Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             return result;
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
@@ -61,7 +61,7 @@ namespace Confluent.Kafka.IntegrationTests
                     new Message<Null, string> 
                     { 
                         Value = "test-value", 
-                        Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc))
+                        Timestamp = new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero))
                     }).Result);
 
                 // TimestampType: CreateTime (default)
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
                         new Message<Null, string>
                         {
                             Value = "test-value", 
-                            Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) 
+                            Timestamp = new Timestamp(DateTimeOffset.Now, TimestampType.LogAppendTime) 
                         }).Result);
 
                 // TimestampType: NotAvailable
@@ -105,7 +105,7 @@ namespace Confluent.Kafka.IntegrationTests
                     new Message<Null, string> 
                     { 
                         Value = "test-value", 
-                        Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc))
+                        Timestamp = new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero))
                     },
                     dh);
 
@@ -121,7 +121,7 @@ namespace Confluent.Kafka.IntegrationTests
                     new Message<Null, string> 
                     { 
                         Value = "test-value", 
-                        Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime)
+                        Timestamp = new Timestamp(DateTimeOffset.Now, TimestampType.LogAppendTime)
                     }, 
                     dh));
 
@@ -151,7 +151,7 @@ namespace Confluent.Kafka.IntegrationTests
                 // TimestampType: CreateTime
                 drs2_task.Add(producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)) }).Result);
+                    new Message<byte[], byte[]> { Timestamp = new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero)) }).Result);
 
                 // TimestampType: CreateTime (default)
                 drs2_task.Add(producer.ProduceAsync(
@@ -162,7 +162,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         singlePartitionTopic,
-                        new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) }).Result);
+                        new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTimeOffset.Now, TimestampType.LogAppendTime) }).Result);
 
                 // TimestampType: NotAvailable
                 Assert.Throws<AggregateException>(() =>
@@ -181,7 +181,7 @@ namespace Confluent.Kafka.IntegrationTests
                 // TimestampType: CreateTime
                 producer.Produce(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)) },
+                    new Message<byte[], byte[]> { Timestamp = new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero)) },
                     dh);
 
                 // TimestampType: CreateTime (default)
@@ -193,7 +193,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Throws<ArgumentException>(() =>
                     producer.Produce(
                         singlePartitionTopic,
-                        new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) }, dh));
+                        new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTimeOffset.Now, TimestampType.LogAppendTime) }, dh));
 
                 // TimestampType: NotAvailable
                 Assert.Throws<ArgumentException>(() =>
@@ -213,7 +213,7 @@ namespace Confluent.Kafka.IntegrationTests
                 var record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Equal(TimestampType.CreateTime, record.Message.Timestamp.Type);
-                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero)));
 
                 assertCloseToNow(consumer, drs_task[2].TopicPartitionOffset);
 
@@ -225,7 +225,7 @@ namespace Confluent.Kafka.IntegrationTests
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Equal(TimestampType.CreateTime, record.Message.Timestamp.Type);
-                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero)));
 
                 assertCloseToNow(consumer, drs_produce[2].TopicPartitionOffset);
             }
@@ -242,7 +242,7 @@ namespace Confluent.Kafka.IntegrationTests
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Equal(TimestampType.CreateTime, record.Message.Timestamp.Type);
-                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero)));
 
                 assertCloseToNow_byte(consumer, drs2_task[2].TopicPartitionOffset);
 
@@ -254,7 +254,7 @@ namespace Confluent.Kafka.IntegrationTests
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Equal(TimestampType.CreateTime, record.Message.Timestamp.Type);
-                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)));
+                Assert.Equal(record.Message.Timestamp, new Timestamp(new DateTimeOffset(2008, 11, 12, 0, 0, 0, TimeSpan.Zero)));
 
                 assertCloseToNow_byte(consumer, drs2_produce[2].TopicPartitionOffset);
             }
@@ -269,7 +269,7 @@ namespace Confluent.Kafka.IntegrationTests
             var cr = consumer.Consume(TimeSpan.FromSeconds(10));
             Assert.NotNull(cr.Message);
             Assert.Equal(TimestampType.CreateTime, cr.Message.Timestamp.Type);
-            Assert.True(Math.Abs((cr.Message.Timestamp.UtcDateTime - DateTime.UtcNow).TotalSeconds) < 120);
+            Assert.True(Math.Abs((cr.Message.Timestamp.DateTimeOffset - DateTimeOffset.UtcNow).TotalSeconds) < 120);
         }
 
         private static void assertCloseToNow_byte(IConsumer<byte[], byte[]> consumer, TopicPartitionOffset tpo)
@@ -278,7 +278,7 @@ namespace Confluent.Kafka.IntegrationTests
             var cr = consumer.Consume(TimeSpan.FromSeconds(10));
             Assert.NotNull(cr.Message);
             Assert.Equal(TimestampType.CreateTime, cr.Message.Timestamp.Type);
-            Assert.True(Math.Abs((cr.Message.Timestamp.UtcDateTime - DateTime.UtcNow).TotalSeconds) < 120);
+            Assert.True(Math.Abs((cr.Message.Timestamp.DateTimeOffset - DateTimeOffset.UtcNow).TotalSeconds) < 120);
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Timestamp.cs
+++ b/test/Confluent.Kafka.UnitTests/Timestamp.cs
@@ -41,12 +41,13 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal(TimestampType.CreateTime, ts1.Type);
             Assert.Equal(TimestampType.LogAppendTime, ts2.Type);
         }
-
+#pragma warning disable CS0618 // Type or member is obsolete
         [Fact]
         public void ConstructorDateTime()
         {
             var dt1 = new DateTime(2008, 1, 1, 0, 0, 0, DateTimeKind.Local);
             var dt2 = new DateTime(2008, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
 
             var ts1 = new Timestamp(dt1, TimestampType.CreateTime);
             var ts2 = new Timestamp(dt2, TimestampType.LogAppendTime);
@@ -64,6 +65,7 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal(ts3.UnixTimestampMs + utcOffsetMs, ts4.UnixTimestampMs);
         }
 
+
         [Fact]
         public void ConstructorDateTimeOffset()
         {
@@ -80,6 +82,7 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal(ts3.UnixTimestampMs, ts2.UnixTimestampMs);
         }
 
+#pragma warning restore CS0618 // Type or member is obsolete
         [Fact]
         public void Equality()
         {
@@ -108,27 +111,41 @@ namespace Confluent.Kafka.UnitTests
         public void Conversion()
         {
             // check is to millisecond accuracy.
-            var ts = new DateTime(2012, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
-            var unixTime = Timestamp.DateTimeToUnixTimestampMs(ts);
-            var ts2 = Timestamp.UnixTimestampMsToDateTime(unixTime);
+            var ts = new DateTimeOffset(2012, 5, 6, 12, 4, 3, 220, TimeSpan.Zero);
+            var unixTime = Timestamp.DateTimeOffsetToUnixTimestampMs(ts);
+            var ts2 = Timestamp.UnixTimestampMsToDateTimeOffset(unixTime);
             Assert.Equal(1336305843220, unixTime);
             Assert.Equal(ts, ts2);
-            Assert.Equal(DateTimeKind.Utc, ts2.Kind);
         }
 
         [Fact]
         public void UnixTimeEpoch()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Equal(0, Timestamp.DateTimeToUnixTimestampMs(Timestamp.UnixTimeEpoch));
-            Assert.Equal(DateTimeKind.Utc, Timestamp.UnixTimeEpoch.Kind);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
-        
+
+        [Fact]
+        public void UnixTimeEpochDateTimeOffset()
+        {
+            Assert.Equal(0, Timestamp.DateTimeOffsetToUnixTimestampMs(Timestamp.UnixTimeEpochDateTimeOffset));
+        }
+
         [Fact]
         public void DateTimeProperties()
         {
-            var ts = new Timestamp(1, TimestampType.CreateTime);            
-            Assert.Equal(DateTimeKind.Utc, ts.UtcDateTime.Kind);
+            var ts = new Timestamp(1, TimestampType.CreateTime);
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Equal(1, (ts.UtcDateTime - Timestamp.UnixTimeEpoch).TotalMilliseconds);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void DateTimeOffsetProperties()
+        {
+            var ts = new Timestamp(1, TimestampType.CreateTime);
+            Assert.Equal(1, (ts.DateTimeOffset - Timestamp.UnixTimeEpochDateTimeOffset).TotalMilliseconds);
         }
 
         [Fact]
@@ -136,17 +153,17 @@ namespace Confluent.Kafka.UnitTests
         {
             // check is to millisecond accuracy, rounding down the value
             
-            var dateTimeAfterEpoch = new DateTime(2012, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
-            var dateTimeBeforeEpoch = new DateTime(1950, 5, 6, 12, 4, 3, 220, DateTimeKind.Utc);
+            var dateTimeAfterEpoch = new DateTimeOffset(2012, 5, 6, 12, 4, 3, 220, TimeSpan.Zero);
+            var dateTimeBeforeEpoch = new DateTimeOffset(1950, 5, 6, 12, 4, 3, 220, TimeSpan.Zero);
 
             foreach (var datetime in new[] { dateTimeAfterEpoch, dateTimeBeforeEpoch })
             {
-                var unixTime1 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(1));
-                var unixTime2 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(TimeSpan.TicksPerMillisecond - 1));
-                var unixTime3 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(TimeSpan.TicksPerMillisecond));
-                var unixTime4 = Timestamp.DateTimeToUnixTimestampMs(datetime.AddTicks(-1));
+                var unixTime1 = Timestamp.DateTimeOffsetToUnixTimestampMs(datetime.AddTicks(1));
+                var unixTime2 = Timestamp.DateTimeOffsetToUnixTimestampMs(datetime.AddTicks(TimeSpan.TicksPerMillisecond - 1));
+                var unixTime3 = Timestamp.DateTimeOffsetToUnixTimestampMs(datetime.AddTicks(TimeSpan.TicksPerMillisecond));
+                var unixTime4 = Timestamp.DateTimeOffsetToUnixTimestampMs(datetime.AddTicks(-1));
 
-                var expectedUnixTime = Timestamp.DateTimeToUnixTimestampMs(datetime);
+                var expectedUnixTime = Timestamp.DateTimeOffsetToUnixTimestampMs(datetime);
                 
                 Assert.Equal(expectedUnixTime, unixTime1);
                 Assert.Equal(expectedUnixTime, unixTime2);


### PR DESCRIPTION
DateTime is a weird type, and DateTimeOffset provides a much nicer experience. The PR is mainly about the Timestamp type, but I changed in other places as well. Perhaps the places where "Now" is used to keep track of elapsed time should use other constructs instead, such as Stopwatch or CancellationTokens with scheduled set time.