### PR TITLE
Producer.Produce improve error handling

### DIFF
--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -831,8 +831,8 @@ namespace Confluent.Kafka
                     {
                         Message = message,
                         TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset),
-                    }
-                );
+                    },
+                    ex);
             }
 
             byte[] valBytes;
@@ -850,8 +850,8 @@ namespace Confluent.Kafka
                     {
                         Message = message,
                         TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset),
-                    }
-                );
+                    },
+                    ex);
             }
 
             try


### PR DESCRIPTION
In `Producer.ProduceAsync` method inner exception is included when creating `ProduceException` exception
```csharp
catch (Exception ex)
{
    throw new ProduceException<TKey, TValue>(
        new Error(ErrorCode.Local_KeySerialization),
        new DeliveryResult<TKey, TValue>
        {
            Message = message,
            TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
        },
        ex); // <-- inner exception is included
}
```
But in synchronous version `Producer.Produce` it is not.

This change makes both methods to handle exception in same way.