### PR TITLE
Json serialization

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -46,7 +46,7 @@ namespace Confluent.SchemaRegistry.Serdes
     ///     integration of System.Text.Json and JSON Schema, so this
     ///     is not yet supported by the deserializer.
     /// </remarks>
-    public class JsonDeserializer<T> : IAsyncDeserializer<T> where T : class, new()
+    public class JsonDeserializer<T> : IAsyncDeserializer<T> where T : class
     {
         private readonly int headerSize =  sizeof(int) + sizeof(byte);
         

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -53,7 +53,7 @@ namespace Confluent.SchemaRegistry.Serdes
     ///     integration of System.Text.Json and JSON Schema, so this
     ///     is not yet supported by the serializer.
     /// </remarks>
-    public class JsonSerializer<T> : IAsyncSerializer<T>
+    public class JsonSerializer<T> : IAsyncSerializer<T> where T : class
     {
         private const int DefaultInitialBufferSize = 1024;
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -53,7 +53,7 @@ namespace Confluent.SchemaRegistry.Serdes
     ///     integration of System.Text.Json and JSON Schema, so this
     ///     is not yet supported by the serializer.
     /// </remarks>
-    public class JsonSerializer<T> : IAsyncSerializer<T>  where T : new()
+    public class JsonSerializer<T> : IAsyncSerializer<T>
     {
         private const int DefaultInitialBufferSize = 1024;
 


### PR DESCRIPTION
Parameterless constructor restriction removed. No need to restrict/forced to create contracts with a parameterless constructor. Since Newtonsoft Json is used, the library is perfectly capable of (de)serializing contracts with private setters and constructor parameters following a naming convention, parameter names names correspond to prop names.

This change will allow serialization of contracts with private setters (immutable) and parameterized constructors. 