### PR TITLE
Added IDisposable to Web example KafkaClientHandle

### DIFF
--- a/examples/Web/KafkaClientHandle.cs
+++ b/examples/Web/KafkaClientHandle.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using Confluent.Kafka;
 using Microsoft.Extensions.Configuration;
 
@@ -33,7 +34,7 @@ namespace Web
     ///     Confluent.Kafka.IProducer instances for each Message type you wish to
     ///     produce.
     /// </summary>
-    public class KafkaClientHandle
+    public class KafkaClientHandle : IDisposable
     {
         IProducer<byte[], byte[]> kafkaProducer;
 


### PR DESCRIPTION
I wrote the `Dispose` method, but forgot to mark the class as `IDisposable`, which means the framework won't pick up the class as being disposable and won't call the `Dispose` method.

This arguably highlights a flaw (some would say tradeoff) in the framework design imo. The type system should pick up on things like this.