### PR TITLE
fix schema reference order on schema registration

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -65,7 +65,7 @@ namespace Confluent.SchemaRegistry.Serdes
         
         private HashSet<string> subjectsRegistered = new HashSet<string>();
         private SemaphoreSlim serializeMutex = new SemaphoreSlim(1);
-        private readonly List<SchemaReference> EmptyReferencesList = new List<SchemaReference>();
+        private readonly SortedSet<SchemaReference> EmptyReferencesList = new SortedSet<SchemaReference>();
 
         private JsonSchemaValidator validator = new JsonSchemaValidator();
 

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
@@ -166,9 +166,9 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <remarks>
         ///     note: protobuf does not support circular file references, so this possibility isn't considered.
         /// </remarks>
-        private async Task<List<SchemaReference>> RegisterOrGetReferences(FileDescriptor fd, SerializationContext context, bool autoRegisterSchema)
+        private async Task<SortedSet<SchemaReference>> RegisterOrGetReferences(FileDescriptor fd, SerializationContext context, bool autoRegisterSchema)
         {
-            var result = new List<SchemaReference>();
+            var result = new SortedSet<SchemaReference>();
 
             var tasks = new Task[fd.Dependencies.Count];
             for (int i=0; i<fd.Dependencies.Count; ++i)
@@ -187,7 +187,7 @@ namespace Confluent.SchemaRegistry.Serdes
                 tasks[i] = t();
             }
             await Task.WhenAll(tasks.ToArray()).ConfigureAwait(continueOnCapturedContext: false);
-
+            
             return result;
         }
 

--- a/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
@@ -50,7 +50,7 @@ namespace Confluent.SchemaRegistry
     /// </summary>
     public class CachedSchemaRegistryClient : ISchemaRegistryClient, IDisposable
     {
-        private readonly List<SchemaReference> EmptyReferencesList = new List<SchemaReference>();
+        private readonly SortedSet<SchemaReference> EmptyReferencesList = new SortedSet<SchemaReference>();
 
         private IRestService restService;
         private int identityMapCapacity;

--- a/src/Confluent.SchemaRegistry/Rest/DataContracts/RegisteredSchema.cs
+++ b/src/Confluent.SchemaRegistry/Rest/DataContracts/RegisteredSchema.cs
@@ -93,7 +93,7 @@ namespace Confluent.SchemaRegistry
         /// <param name="references">
         ///     A list of schemas referenced by this schema.
         /// </param>
-        public RegisteredSchema(string subject, int version, int id, string schemaString, SchemaType schemaType, List<SchemaReference> references)
+        public RegisteredSchema(string subject, int version, int id, string schemaString, SchemaType schemaType, SortedSet<SchemaReference> references)
         {
             if (string.IsNullOrEmpty(schemaString))
             {

--- a/src/Confluent.SchemaRegistry/Rest/DataContracts/Schema.cs
+++ b/src/Confluent.SchemaRegistry/Rest/DataContracts/Schema.cs
@@ -102,7 +102,7 @@ namespace  Confluent.SchemaRegistry
         ///     A list of schemas referenced by this schema.
         /// </summary>
         [DataMember(Name = "references")]
-        public List<SchemaReference> References { get; set; }
+        public SortedSet<SchemaReference> References { get; set; }
 
         [DataMember(Name = "schemaType")]
         internal string SchemaType_String { get; set; }
@@ -156,7 +156,7 @@ namespace  Confluent.SchemaRegistry
         /// <param name="references">
         ///     A list of schemas referenced by this schema.
         /// </param>
-        public Schema(string schemaString, List<SchemaReference> references, SchemaType schemaType)
+        public Schema(string schemaString, SortedSet<SchemaReference> references, SchemaType schemaType)
         {
             SchemaString = schemaString;
             References = references;
@@ -175,7 +175,7 @@ namespace  Confluent.SchemaRegistry
         public Schema(string schemaString, SchemaType schemaType)
         {
             SchemaString = schemaString;
-            References = new List<SchemaReference>();
+            References = new SortedSet<SchemaReference>();
             SchemaType = schemaType;
         }
 

--- a/src/Confluent.SchemaRegistry/Rest/RestService.cs
+++ b/src/Confluent.SchemaRegistry/Rest/RestService.cs
@@ -34,7 +34,7 @@ namespace Confluent.SchemaRegistry
     /// </remarks>
     internal class RestService : IRestService
     {
-        private readonly List<SchemaReference> EmptyReferencesList = new List<SchemaReference>();
+        private readonly SortedSet<SchemaReference> EmptyReferencesList = new SortedSet<SchemaReference>();
 
         private static readonly string acceptHeader = string.Join(", ", Versions.PreferredResponseTypes);
 

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/JsonWithReferences.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/JsonWithReferences.cs
@@ -113,7 +113,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             // Test there are no errors (exceptions) registering a schema that references another.
             var id1 = srInitial.RegisterSchemaAsync(subject1, new Schema(S1, SchemaType.Json)).Result;
             var s1 = srInitial.GetLatestSchemaAsync(subject1).Result;
-            var refs = new List<SchemaReference> { new SchemaReference("https://example.com/geographical-location.schema.json", subject1, s1.Version) };
+            var refs = new SortedSet<SchemaReference> { new SchemaReference("https://example.com/geographical-location.schema.json", subject1, s1.Version) };
             var id2 = srInitial.RegisterSchemaAsync(subject2, new Schema(S2, refs, SchemaType.Json)).Result;
 
             // In fact, it seems references are not checked server side.

--- a/test/Confluent.SchemaRegistry.UnitTests/RegisteredSchema.cs
+++ b/test/Confluent.SchemaRegistry.UnitTests/RegisteredSchema.cs
@@ -25,7 +25,7 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void Construct()
         {
-            var schema = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.Equal("test-key", schema.Subject);
             Assert.Equal(1, schema.Version);
             Assert.Equal(42, schema.Id);
@@ -37,7 +37,7 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void Construct2()
         {
-            var schema = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Protobuf, new List<SchemaReference> { new SchemaReference("schema-name", "subj", 4) });
+            var schema = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Protobuf, new SortedSet<SchemaReference> { new SchemaReference("schema-name", "subj", 4) });
             Assert.Equal("test-key", schema.Subject);
             Assert.Equal(1, schema.Version);
             Assert.Equal(42, schema.Id);
@@ -49,7 +49,7 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void ToStringTest()
         {
-            var schema = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.Contains("test-key", schema.ToString());
             Assert.Contains("1", schema.ToString());
             Assert.Contains("42", schema.ToString());
@@ -58,8 +58,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void GetHashCodeTest()
         {
-            var schema1 = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Json, new List<SchemaReference> { new SchemaReference("a", "b", 3) });
-            var schema2 = new RegisteredSchema("test-value", 1, 42, "test-schema-string", SchemaType.Json, new List<SchemaReference> { new SchemaReference("a", "b", 3) });
+            var schema1 = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Json, new SortedSet<SchemaReference> { new SchemaReference("a", "b", 3) });
+            var schema2 = new RegisteredSchema("test-value", 1, 42, "test-schema-string", SchemaType.Json, new SortedSet<SchemaReference> { new SchemaReference("a", "b", 3) });
             // (very unlikely)
             Assert.NotEqual(schema1.GetHashCode(), schema2.GetHashCode());
         }
@@ -67,8 +67,8 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void CompareTo_Same()
         {
-            var schema1 = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Protobuf, new List<SchemaReference>());
-            var schema2 = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Protobuf, new List<SchemaReference>());
+            var schema1 = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Protobuf, new SortedSet<SchemaReference>());
+            var schema2 = new RegisteredSchema("test-key", 1, 42, "test-schema-string", SchemaType.Protobuf, new SortedSet<SchemaReference>());
 
             Assert.Equal(0, schema1.CompareTo(schema2));
         }
@@ -79,24 +79,24 @@ namespace Confluent.SchemaRegistry.UnitTests
             // Note: the id and schema strings are not valid, however checking this
             // is considered outside the scope of the CompareTo function.
 
-            var schema1 = new RegisteredSchema("test-a", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
-            var schema2 = new RegisteredSchema("test-b", 2, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema1 = new RegisteredSchema("test-a", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema2 = new RegisteredSchema("test-b", 2, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.True(schema1.CompareTo(schema2) < 0);
             Assert.True(schema2.CompareTo(schema1) > 0);
 
-            var schema3 = new RegisteredSchema("test-c", 4, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
-            var schema4 = new RegisteredSchema("test-d", 3, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema3 = new RegisteredSchema("test-c", 4, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema4 = new RegisteredSchema("test-d", 3, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.True(schema3.CompareTo(schema4) < 0);
             Assert.True(schema4.CompareTo(schema3) > 0);
 
-            var schema5 = new RegisteredSchema("test-b", 2, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema5 = new RegisteredSchema("test-b", 2, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.Equal(0, schema2.CompareTo(schema5));
 
-            var schema6 = new RegisteredSchema("test-a", 2, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema6 = new RegisteredSchema("test-a", 2, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.True(schema1.CompareTo(schema6) < 0);
             Assert.True(schema6.CompareTo(schema1) > 0);
 
-            var schema7 = new RegisteredSchema("test-b", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema7 = new RegisteredSchema("test-b", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
             Assert.True(schema1.CompareTo(schema7) < 0);
             Assert.True(schema7.CompareTo(schema1) > 0);
         }
@@ -104,12 +104,12 @@ namespace Confluent.SchemaRegistry.UnitTests
         [Fact]
         public void EqualsTests()
         {
-            var schema1 = new RegisteredSchema("test-a", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
-            var schema2 = new RegisteredSchema("test-b", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
-            var schema3 = new RegisteredSchema("test-a", 2, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
-            var schema4 = new RegisteredSchema("test-a", 1, 44, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
-            var schema5 = new RegisteredSchema("test-a", 1, 42, "test-schema-string2", SchemaType.Avro, new List<SchemaReference>());
-            var schema6 = new RegisteredSchema("test-a", 1, 42, "test-schema-string", SchemaType.Avro, new List<SchemaReference>());
+            var schema1 = new RegisteredSchema("test-a", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema2 = new RegisteredSchema("test-b", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema3 = new RegisteredSchema("test-a", 2, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema4 = new RegisteredSchema("test-a", 1, 44, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema5 = new RegisteredSchema("test-a", 1, 42, "test-schema-string2", SchemaType.Avro, new SortedSet<SchemaReference>());
+            var schema6 = new RegisteredSchema("test-a", 1, 42, "test-schema-string", SchemaType.Avro, new SortedSet<SchemaReference>());
 
             Assert.NotEqual(schema1, schema2);
             Assert.NotEqual(schema1, schema3);


### PR DESCRIPTION
There is an issue in schema reference registration when we have few dependencies in schema. Currently all references are registering asynchronously and are adding to result list without strict sequence. The fix just orders the resulting sequence so it will be the same on every schema registration.