### PR TITLE
add IsInvalid property to Handle class

### DIFF
--- a/src/Confluent.Kafka/Handle.cs
+++ b/src/Confluent.Kafka/Handle.cs
@@ -25,6 +25,14 @@ namespace Confluent.Kafka
     /// </summary>
     public class Handle
     {
+        /// <summary>
+        ///     Gets a value indicating whether the encapsulated librdkafka handle is invalid.
+        /// </summary>
+        /// <value>
+        ///     <b>true</b> if the encapsulated librdkafka handle is invalid; otherwise, <b>false</b>.
+        /// </value>
+        public bool IsInvalid => this.LibrdkafkaHandle == null || this.LibrdkafkaHandle.IsInvalid;
+
         internal IClient Owner { get; set; }
 
         internal SafeKafkaHandle LibrdkafkaHandle { get; set; }


### PR DESCRIPTION
Reason for change:
The ConsumerBuilder starts logging messages to LogHandler from within Build method with partially constructed IConsumer object (Kafka library handle is null). There is no way to determine whether the IConsumer properties can be accessed without triggering an exception.

This property will allow to check whether Handle property in IConsumer interface is valid and therefore other properties and methods could be called.