### PR TITLE
ReadOnlySpan for internal Produce methods

### DIFF
--- a/src/Confluent.Kafka/Headers.cs
+++ b/src/Confluent.Kafka/Headers.cs
@@ -27,7 +27,7 @@ namespace Confluent.Kafka
     /// <remarks>
     ///     Message headers are supported by v0.11 brokers and above.
     /// </remarks>
-    public class Headers : IEnumerable<IHeader>
+    public class Headers : IReadOnlyCollection<IHeader>
     {
         private readonly List<IHeader> headers = new List<IHeader>();
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -283,7 +283,7 @@ namespace Confluent.Kafka
             ReadOnlySpan<byte> key,
             Timestamp timestamp,
             Partition partition,
-            IEnumerable<IHeader> headers,
+            IReadOnlyCollection<IHeader> headers,
             IDeliveryHandler deliveryHandler)
         {
             if (timestamp.Type != TimestampType.CreateTime)

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -279,8 +279,8 @@ namespace Confluent.Kafka
 
         private void ProduceImpl(
             string topic,
-            byte[] val, int valOffset, int valLength,
-            byte[] key, int keyOffset, int keyLength,
+            ReadOnlySpan<byte> val,
+            ReadOnlySpan<byte> key,
             Timestamp timestamp,
             Partition partition,
             IEnumerable<IHeader> headers,
@@ -308,8 +308,8 @@ namespace Confluent.Kafka
 
                 err = KafkaHandle.Produce(
                     topic,
-                    val, valOffset, valLength,
-                    key, keyOffset, keyLength,
+                    val,
+                    key,
                     partition.Value,
                     timestamp.UnixTimestampMs,
                     headers,
@@ -325,8 +325,8 @@ namespace Confluent.Kafka
             {
                 err = KafkaHandle.Produce(
                     topic,
-                    val, valOffset, valLength,
-                    key, keyOffset, keyLength,
+                    val,
+                    key,
                     partition.Value,
                     timestamp.UnixTimestampMs,
                     headers,
@@ -801,8 +801,8 @@ namespace Confluent.Kafka
 
                     ProduceImpl(
                         topicPartition.Topic,
-                        valBytes, 0, valBytes == null ? 0 : valBytes.Length,
-                        keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length,
+                        valBytes,
+                        keyBytes,
                         message.Timestamp, topicPartition.Partition, headers,
                         handler);
 
@@ -812,8 +812,8 @@ namespace Confluent.Kafka
                 {
                     ProduceImpl(
                         topicPartition.Topic, 
-                        valBytes, 0, valBytes == null ? 0 : valBytes.Length, 
-                        keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, 
+                        valBytes,
+                        keyBytes,
                         message.Timestamp, topicPartition.Partition, headers, 
                         null);
 
@@ -911,8 +911,8 @@ namespace Confluent.Kafka
             {
                 ProduceImpl(
                     topicPartition.Topic,
-                    valBytes, 0, valBytes == null ? 0 : valBytes.Length, 
-                    keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, 
+                    valBytes,
+                    keyBytes,
                     message.Timestamp, topicPartition.Partition, 
                     headers,
                     new TypedDeliveryHandlerShim_Action(


### PR DESCRIPTION
The first step to low-level producer without serializers. 
Proposed producer interface can looks like
```        
Task<DeliveryResult> ProduceAsync(
            string topic,
            ReadOnlySpan<byte> key,
            ReadOnlySpan<byte> value,
            Headers headers = null,
            Timestamp timestamp = default,
            CancellationToken cancellationToken = default(CancellationToken));
``` 
If you are interested in such changes, I can prepare a pull request with an implementation. 

PS: Thank you for great library :)