### PR TITLE
Web Example Authentication Updates

### DIFF
--- a/examples/Web/appsettings.json
+++ b/examples/Web/appsettings.json
@@ -9,16 +9,16 @@
   "Kafka": {
     "ProducerSettings": {
         "BootstrapServers": "<confluent cloud bootstrap servers>",
-        "SaslMechanism": "plain",
-        "SecurityProtocol": "sasl_ssl",
+        "SaslMechanism": "Plain",
+        "SecurityProtocol": "SaslSsl",
         "SaslUsername": "<confluent cloud key>",
         "SaslPassword": "<confluent cloud secret>"
     },
     "ConsumerSettings": {
         "BootstrapServers": "<confluent cloud bootstrap servers>",
         "GroupId": "web-example-group",
-        "SaslMechanism": "plain",
-        "SecurityProtocol": "sasl_ssl",
+        "SaslMechanism": "Plain",
+        "SecurityProtocol": "SaslSsl",
         "SaslUsername": "<confluent cloud key>",
         "SaslPassword": "<confluent cloud secret>"
     },


### PR DESCRIPTION
Updated SecurityProtocol to use C#-specific 'SaslSsl' value instead of librdkafka-specific 'sasl_ssl' value, as the example results in 'System.FormatException: sasl_ssl is not a valid value for SecurityProtocol.' when using the librdkafka value. Additionally, changed SaslMechanism from plain to Plain to align with enum value