### PR TITLE
-> v1.7.0-RC4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 1.7.0-RC4
+
+## Enhancements
+
+- References librdkafka.redist 1.7.0-RC4. Refer to the [release notes](https://github.com/edenhill/librdkafka/releases/tag/v1.7.0-RC4) for more information.
+
+
+## Fixes
+
+- Resolved a schema caching bug ([#1587](https://github.com/confluentinc/confluent-kafka-dotnet/pull/1587)) in `CachedSchemaRegistryClient.GetSchemaIdAsync` ([jeremy001181](https://github.com/jeremy001181)).
+- Fixed a configuration error in the Web example ([cjgalione](https://github.com/cjgalione)).
+
+## Security
+
+- Updated `System.Net.Http` dependency to v4.3.4 ([CVE-2018-8292](https://github.com/advisories/GHSA-7jgj-8wvc-jh57))
+
+
 # 1.6.3
 
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ confluent-kafka-dotnet is distributed via NuGet. We provide five packages:
 To install Confluent.Kafka from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
 
 ```
-Install-Package Confluent.Kafka -Version 1.6.3
+Install-Package Confluent.Kafka -Version 1.7.0-RC4
 ```
 
 To add a reference to a dotnet core project, execute the following at the command line:
 
 ```
-dotnet add package -v 1.6.3 Confluent.Kafka
+dotnet add package -v 1.7.0-RC4 Confluent.Kafka
 ```
 
 Note: `Confluent.Kafka` depends on the `librdkafka.redist` package which provides a number of different builds of `librdkafka` that are compatible with [common platforms](https://github.com/edenhill/librdkafka/wiki/librdkafka.redist-NuGet-package-runtime-libraries). If you are on one of these platforms this will all work seamlessly (and you don't need to explicitly reference `librdkafka.redist`). If you are on a different platform, you may need to [build librdkafka](https://github.com/edenhill/librdkafka#building) manually (or acquire it via other means) and load it using the [Library.Load](https://docs.confluent.io/current/clients/confluent-kafka-dotnet/api/Confluent.Kafka.Library.html#Confluent_Kafka_Library_Load_System_String_) method.

--- a/examples/AdminClient/AdminClient.csproj
+++ b/examples/AdminClient/AdminClient.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/AvroBlogExamples/AvroBlogExamples.csproj
+++ b/examples/AvroBlogExamples/AvroBlogExamples.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
   </ItemGroup>
 

--- a/examples/AvroGeneric/AvroGeneric.csproj
+++ b/examples/AvroGeneric/AvroGeneric.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
   </ItemGroup>
 

--- a/examples/AvroSpecific/AvroSpecific.csproj
+++ b/examples/AvroSpecific/AvroSpecific.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
   </ItemGroup>
 

--- a/examples/ConfluentCloud/ConfluentCloud.csproj
+++ b/examples/ConfluentCloud/ConfluentCloud.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Consumer/Consumer.csproj
+++ b/examples/Consumer/Consumer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -65,7 +65,12 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 {
                     // Since a cooperative assignor (CooperativeSticky) has been configured, the
                     // partition assignment is incremental (adds partitions to any existing assignment).
-                    Console.WriteLine($"Incremental partition assignment: [{string.Join(", ", partitions)}]");
+                    Console.WriteLine(
+                        "Partitions incrementally assigned: [" +
+                        string.Join(',', partitions.Select(p => p.Partition.Value)) +
+                        "], all: [" +
+                        string.Join(',', c.Assignment.Concat(partitions).Select(p => p.Partition.Value)) +
+                        "]");
 
                     // Possibly manually specify start offsets by returning a list of topic/partition/offsets
                     // to assign to, e.g.:
@@ -75,7 +80,13 @@ namespace Confluent.Kafka.Examples.ConsumerExample
                 {
                     // Since a cooperative assignor (CooperativeSticky) has been configured, the revoked
                     // assignment is incremental (may remove only some partitions of the current assignment).
-                    Console.WriteLine($"Incremental partition revokation: [{string.Join(", ", partitions)}]");
+                    var remaining = c.Assignment.Where(atp => partitions.Where(rtp => rtp.TopicPartition == atp).Count() == 0);
+                    Console.WriteLine(
+                        "Partitions incrementally revoked: [" +
+                        string.Join(',', partitions.Select(p => p.Partition.Value)) +
+                        "], remaining: [" +
+                        string.Join(',', remaining.Select(p => p.Partition.Value)) +
+                        "]");
                 })
                 .SetPartitionsLostHandler((c, partitions) =>
                 {

--- a/examples/ExactlyOnce/ExactlyOnce.csproj
+++ b/examples/ExactlyOnce/ExactlyOnce.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
     <PackageReference Include="Microsoft.FASTER.Core" Version="1.8.0" />
   </ItemGroup>

--- a/examples/ExactlyOnceOldBroker/ExactlyOnceOldBroker.csproj
+++ b/examples/ExactlyOnceOldBroker/ExactlyOnceOldBroker.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
     <PackageReference Include="RocksDbNative" Version="6.2.2" />

--- a/examples/JsonSerialization/JsonSerialization.csproj
+++ b/examples/JsonSerialization/JsonSerialization.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj" />
   </ItemGroup>
 

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Producer/Producer.csproj
+++ b/examples/Producer/Producer.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
   

--- a/examples/Protobuf/Protobuf.csproj
+++ b/examples/Protobuf/Protobuf.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.6.3" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.7.0-RC4" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj" />
   </ItemGroup>
 

--- a/examples/Web/Web.csproj
+++ b/examples/Web/Web.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.6.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.7.0-RC4" />
   </ItemGroup>
 
 </Project>

--- a/src/ConfigGen/ConfigGen.csproj
+++ b/src/ConfigGen/ConfigGen.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -12,7 +12,7 @@
     <PackageId>Confluent.Kafka</PackageId>
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
-    <VersionPrefix>1.6.3</VersionPrefix>
+    <VersionPrefix>1.7.0-RC4</VersionPrefix>
     <TargetFrameworks>net45;net46;netcoreapp2.1;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="1.6.1">
+    <PackageReference Include="librdkafka.redist" Version="1.7.0-RC4">
         <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Memory" Version="4.5.0" />

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
@@ -13,7 +13,7 @@
     <PackageId>Confluent.SchemaRegistry.Serdes.Avro</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Avro</Title>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.Avro</AssemblyName>
-    <VersionPrefix>1.6.3</VersionPrefix>
+    <VersionPrefix>1.7.0-RC4</VersionPrefix>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -13,7 +13,7 @@
     <PackageId>Confluent.SchemaRegistry.Serdes.Json</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Json</Title>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.Json</AssemblyName>
-    <VersionPrefix>1.6.3</VersionPrefix>
+    <VersionPrefix>1.7.0-RC4</VersionPrefix>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
@@ -13,7 +13,7 @@
     <PackageId>Confluent.SchemaRegistry.Serdes.Protobuf</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Protobuf</Title>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.Protobuf</AssemblyName>
-    <VersionPrefix>1.6.3</VersionPrefix>
+    <VersionPrefix>1.7.0-RC4</VersionPrefix>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
+++ b/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
@@ -13,7 +13,7 @@
     <PackageId>Confluent.SchemaRegistry</PackageId>
     <Title>Confluent.SchemaRegistry</Title>
     <AssemblyName>Confluent.SchemaRegistry</AssemblyName>
-    <VersionPrefix>1.6.3</VersionPrefix>
+    <VersionPrefix>1.7.0-RC4</VersionPrefix>
     <TargetFrameworks>netstandard1.4;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
-> 1.7.0-RC4. Also updated `System.Net.Http to v4.3.4 (CVE-2018-8292). Also improved rebalance console output in the consumer example, which I have been using to observe partition shuffling.