### PR TITLE
[AdminClient] Allow AdminClient to be authenticated

### DIFF
--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -506,6 +506,7 @@ namespace Confluent.Kafka
             if (builder.LogHandler != null) { producerBuilder.SetLogHandler((_, logMessage) => builder.LogHandler(this, logMessage)); }
             if (builder.ErrorHandler != null) { producerBuilder.SetErrorHandler((_, error) => builder.ErrorHandler(this, error)); }
             if (builder.StatisticsHandler != null) { producerBuilder.SetStatisticsHandler((_, stats) => builder.StatisticsHandler(this, stats)); }
+            if (builder.OAuthBearerTokenRefreshHandler != null) { producerBuilder.SetOAuthBearerTokenRefreshHandler(builder.OAuthBearerTokenRefreshHandler); }
             this.ownedClient = producerBuilder.Build();
             
             this.handle = new Handle

--- a/src/Confluent.Kafka/AdminClientBuilder.cs
+++ b/src/Confluent.Kafka/AdminClientBuilder.cs
@@ -46,6 +46,11 @@ namespace Confluent.Kafka
         internal protected Action<IAdminClient, string> StatisticsHandler { get; set; }
 
         /// <summary>
+        ///     The configured OAuthBearer Token Refresh handler.
+        /// </summary>
+        public Action<IProducer<Null, Null>, string> OAuthBearerTokenRefreshHandler { get; set; }
+
+        /// <summary>
         ///     Initialize a new <see cref="AdminClientBuilder" /> instance.
         /// </summary>
         /// <param name="config">
@@ -126,6 +131,39 @@ namespace Confluent.Kafka
                 throw new InvalidOperationException("Log handler may not be specified more than once.");
             }
             this.LogHandler = logHandler;
+            return this;
+        }
+
+        /// <summary>
+        ///     Set SASL/OAUTHBEARER token refresh callback in provided
+        ///     conf object. The SASL/OAUTHBEARER token refresh callback
+        ///     is triggered via <see cref="IAdminClient"/>'s admin methods
+        ///     (or any of its overloads) whenever OAUTHBEARER is the SASL
+        ///     mechanism and a token needs to be retrieved, typically
+        ///     based on the configuration defined in
+        ///     sasl.oauthbearer.config. The callback should invoke
+        ///     <see cref="ClientExtensions.OAuthBearerSetToken"/>
+        ///     or <see cref="ClientExtensions.OAuthBearerSetTokenFailure"/>
+        ///     to indicate success or failure, respectively.
+        ///
+        ///     An unsecured JWT refresh handler is provided by librdkafka
+        ///     for development and testing purposes, it is enabled by
+        ///     setting the enable.sasl.oauthbearer.unsecure.jwt property
+        ///     to true and is mutually exclusive to using a refresh callback.
+        /// </summary>
+        /// <param name="oAuthBearerTokenRefreshHandler">
+        ///     the callback to set; callback function arguments:
+        ///     IProducer - instance of the admin client's inner producer instance
+        ///     which should be used to set token or token failure string - Value of configuration
+        ///     property sasl.oauthbearer.config
+        /// </param>
+        public AdminClientBuilder SetOAuthBearerTokenRefreshHandler(Action<IProducer<Null, Null>, string> oAuthBearerTokenRefreshHandler)
+        {
+            if (this.OAuthBearerTokenRefreshHandler != null)
+            {
+                throw new InvalidOperationException("OAuthBearer token refresh handler may not be specified more than once.");
+            }
+            this.OAuthBearerTokenRefreshHandler = oAuthBearerTokenRefreshHandler;
             return this;
         }
 


### PR DESCRIPTION
We realised that we could not use the AdminClient in an authenticated fashion.
This PR should address that.