### PR TITLE
Reduce the number of creation times of TypedDeliveryHandlerShim_Action

### DIFF
--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -911,15 +911,17 @@ namespace Confluent.Kafka
             {
                 ProduceImpl(
                     topicPartition.Topic,
-                    valBytes, 0, valBytes == null ? 0 : valBytes.Length, 
-                    keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, 
-                    message.Timestamp, topicPartition.Partition, 
+                    valBytes, 0, valBytes == null ? 0 : valBytes.Length,
+                    keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length,
+                    message.Timestamp, topicPartition.Partition,
                     headers,
-                    new TypedDeliveryHandlerShim_Action(
-                        topicPartition.Topic,
-                        enableDeliveryReportKey ? message.Key : default(TKey),
-                        enableDeliveryReportValue ? message.Value : default(TValue),
-                        deliveryHandler));
+                    deliveryHandler == null
+                        ? null
+                        : new TypedDeliveryHandlerShim_Action(
+                            topicPartition.Topic,
+                            enableDeliveryReportKey ? message.Key : default(TKey),
+                            enableDeliveryReportValue ? message.Value : default(TValue),
+                            deliveryHandler));
             }
             catch (KafkaException ex)
             {


### PR DESCRIPTION
## **Inputs:**
 - **EnableDeliveryReports** is set to `false` in producer configuration
 - no delivery handler callback is specified during the call to `producer.Produce(...)` method (aka the delivery handler is `null`)

## **Observed behavior:**

- during the call to **produce1**

  _pass the delivery handler as is to **produce2**_

- during the call to **produce2**

  _**ProduceImpl** is being called with a newly created instance of `TypedDeliveryHandlerShim_Action`_

- during the call to **ProduceImpl**

  _after the check `if (this.enableDeliveryReports && deliveryHandler != null)` the control flow follows the **else** branch of the **if** statement and calls `KafkaHandle.Produce` method with an `IntPtr.Zero` value for delivery handler thus effectively discarding the passed value for delivery handler => **we have made the unnecessary allocation of the new object of type `TypedDeliveryHandlerShim_Action` which is created only for being collected by the GC**_

## **Proposed change**
Do not create a new instance of `TypedDeliveryHandlerShim_Action` when the delivery handler callback is `null` inside [**produce2**](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/src/Confluent.Kafka/Producer.cs#L860) method.
This will reduce the pressure on the garbage collector then the `Produce` method will be called at a high rate.
```csharp
ProduceImpl(
    topicPartition.Topic,
    valBytes, 0, valBytes == null ? 0 : valBytes.Length,
    keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length,
    message.Timestamp, topicPartition.Partition,
    headers,
    deliveryHandler == null
        ? null
        : new TypedDeliveryHandlerShim_Action(
            topicPartition.Topic,
            enableDeliveryReportKey ? message.Key : default(TKey),
            enableDeliveryReportValue ? message.Value : default(TValue),
            deliveryHandler));
```

## **How will the change affect the existing behavior?**
---
### **ProduceImpl** method behavior

| enableDeliveryReports | deliveryHandler | existing behavior | behavior after change |
|---|---|---|---|
| `false` | `null` | `IntPtr.Zero` value will be used | the same |
| `false` | not `null` | `IntPtr.Zero` value will be used | the same |
| `true` | `null` | `IntPtr.Zero` value will be used | the same |
| `true` | not `null` | a pointer to `deliveryHandler` will be used | the same |

---

### **produce2** method behavior

| enableDeliveryReports | deliveryHandler | existing behavior | behavior after change | any changes for the callers of produce2 method |
|---|---|---|---|---|
| `false` | `null` | A newly created instance of `TypedDeliveryHandlerShim_Action` **(which will be discarded in **ProduceImpl** method)** will be used for parameter `IDeliveryHandler deliveryHandler` | `null` will be used for parameter `IDeliveryHandler deliveryHandler` in **ProduceImpl** method | no |
| `false` | not `null` | An `InvalidOperationException` will be thrown | the same | no |
| `true` | `null` | A newly created instance of `TypedDeliveryHandlerShim_Action` **(which will be discarded in **ProduceImpl** method)** will be used for parameter `IDeliveryHandler deliveryHandler` | `null` will be used for parameter `IDeliveryHandler deliveryHandler` in **ProduceImpl** method | no |
| `true` | not `null` | A newly created instance of `TypedDeliveryHandlerShim_Action` **(which will actually be used in **ProduceImpl** method)** will be used for parameter `IDeliveryHandler deliveryHandler` | the same | no |

---

### **produce1** method behavior

Same as for **produce2** method

&nbsp;

---

### **Legend:**
 - [**produce1** is an alias for method](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/src/Confluent.Kafka/Producer.cs#L851)
   ```csharp
   public void Produce(
        string topic,
        Message<TKey, TValue> message,
        Action<DeliveryReport<TKey, TValue>> deliveryHandler = null
    ){...}
   ```

- [**produce2** is an alias for method ](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/src/Confluent.Kafka/Producer.cs#L860)
  ```csharp
  public void Produce(
        TopicPartition topicPartition,
        Message<TKey, TValue> message,
        Action<DeliveryReport<TKey, TValue>> deliveryHandler = null
        ){...}
  ```

- [**ProduceImpl** is an alias for method](https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/src/Confluent.Kafka/Producer.cs#L280)
  ```csharp
  private void ProduceImpl(
    string topic,
    byte[] val, int valOffset, int valLength,
    byte[] key, int keyOffset, int keyLength,
    Timestamp timestamp,
    Partition partition,
    IEnumerable<IHeader> headers,
    IDeliveryHandler deliveryHandler
  ){...}
  ```