### PR TITLE
Feature/custom reference name strategy

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
@@ -209,26 +209,21 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     
         ///     default: ReferenceSubjectNameStrategy.ReferenceName
         /// </summary>
-        public ReferenceSubjectNameStrategy? ReferenceSubjectNameStrategy
+        public Type ReferenceSubjectNameStrategy
         {
             get
             {
                 var r = Get(PropertyNames.ReferenceSubjectNameStrategy);
-                if (r == null) { return null; }
+                if (r == null) { return typeof(DefaultReferenceSubjectNameStrategy); }
                 else
                 {
-                    ReferenceSubjectNameStrategy result;
-                    if (!Enum.TryParse<ReferenceSubjectNameStrategy>(r, out result))
-                        throw new ArgumentException(
-                            $"Unknown ${PropertyNames.ReferenceSubjectNameStrategy} value: {r}.");
-                    else
-                        return result;
+                    return Type.GetType(r);
                 }
             }
             set
             {
                 if (value == null) { this.properties.Remove(PropertyNames.ReferenceSubjectNameStrategy); }
-                else { this.properties[PropertyNames.ReferenceSubjectNameStrategy] = value.ToString(); }
+                else { this.properties[PropertyNames.ReferenceSubjectNameStrategy] = value.AssemblyQualifiedName; }
             }
         }
 

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
@@ -217,7 +217,13 @@ namespace Confluent.SchemaRegistry.Serdes
                 if (r == null) { return typeof(DefaultReferenceSubjectNameStrategy); }
                 else
                 {
-                    return Type.GetType(r);
+                    var type = Type.GetType(r);
+                    if (typeof(IReferenceSubjectNameStrategy).IsAssignableFrom(type)) { return type; }
+                    else
+                    {
+                        throw new ArgumentException(
+                            $"Provided type for {nameof(ReferenceSubjectNameStrategy)} does not implement interface {nameof(IReferenceSubjectNameStrategy)}");
+                    }
                 }
             }
             set

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
@@ -206,8 +206,8 @@ namespace Confluent.SchemaRegistry.Serdes
 
         /// <summary>
         ///     Reference subject name strategy.
-        ///     
-        ///     default: ReferenceSubjectNameStrategy.ReferenceName
+        ///     The provided type must be an implementation of <see cref="IReferenceSubjectNameStrategy" />
+        ///     default: <see cref="DefaultReferenceSubjectNameStrategy" />
         /// </summary>
         public Type ReferenceSubjectNameStrategy
         {

--- a/src/Confluent.SchemaRegistry/ReferenceSubjectNameStrategy.cs
+++ b/src/Confluent.SchemaRegistry/ReferenceSubjectNameStrategy.cs
@@ -19,40 +19,16 @@ using Confluent.Kafka;
 
 namespace Confluent.SchemaRegistry
 {
-    /// <summary>
-    ///     Construct the subject name under which a referenced schema
-    ///     should be registered in Schema Registry.
-    /// </summary>
-    /// <param name="context">
-    ///     The serialization context.
-    /// </param>
-    /// <param name="referenceName">
-    ///     The name used to reference the schema.
-    /// </param>
-    public delegate string ReferenceSubjectNameStrategyDelegate(SerializationContext context, string referenceName);
-
-
-    /// <summary>
-    ///     Subject name strategy for referenced schemas.
-    /// </summary>
-    public enum ReferenceSubjectNameStrategy
+    public interface IReferenceSubjectNameStrategy
     {
-        /// <summary>
-        ///     (default): Use the reference name as the subject name.
-        /// </summary>
-        ReferenceName
+        string GetSubjectName(SerializationContext context, string referenceName);
     }
-    
 
-    /// <summary>
-    ///     Extension methods for the ReferenceSubjectNameStrategy type.
-    /// </summary>
-    public static class ReferenceSubjectNameStrategyExtensions
+    public class DefaultReferenceSubjectNameStrategy : IReferenceSubjectNameStrategy
     {
-        /// <summary>
-        ///     Provide a functional implementation corresponding to the enum value.
-        /// </summary>
-        public static ReferenceSubjectNameStrategyDelegate ToDelegate(this ReferenceSubjectNameStrategy strategy)
-            => (context, referenceName) => referenceName;
+        public string GetSubjectName(SerializationContext context, string referenceName)
+        {
+            return referenceName;
+        }
     }
 }

--- a/src/Confluent.SchemaRegistry/ReferenceSubjectNameStrategy.cs
+++ b/src/Confluent.SchemaRegistry/ReferenceSubjectNameStrategy.cs
@@ -19,13 +19,31 @@ using Confluent.Kafka;
 
 namespace Confluent.SchemaRegistry
 {
+    ///<summary>
+    /// This interface is used by the serializer to determine the subject name under which
+    /// the referenced schema should be registered in the schema registry.
+    /// </summary>
     public interface IReferenceSubjectNameStrategy
     {
+        /// <summary>
+        /// For a given reference name and serialization context, returns the subject name under which the
+        /// referenced schema should be registered in the schema registry.
+        /// </summary>
+        /// <param name="context">Context relevant to the serialization operation.</param>
+        /// <param name="referenceName">The name of the reference.</param>
+        /// <returns></returns>
         string GetSubjectName(SerializationContext context, string referenceName);
     }
 
+    /// <summary>
+    /// The default strategy used by serializer that uses the reference name as the subject name
+    /// under which the referenced schema should be registered in schema registry.
+    /// </summary>
     public class DefaultReferenceSubjectNameStrategy : IReferenceSubjectNameStrategy
     {
+        /// <summary>
+        /// <inheritdoc />
+        /// </summary>
         public string GetSubjectName(SerializationContext context, string referenceName)
         {
             return referenceName;


### PR DESCRIPTION
# Description
This feature allows producers to specify a custom subject name strategy for protobuf references. It is done by allowing the callers of the API to provide a Type object for a class that implements IReferenceSubjectNameStrategy. If no such class is provided, the serializer falls back to the current implementation that uses reference name as subject name.

## Background
Currently the serializer can only use the reference name from the protobuf schema as subject name in Schema Registry. This is while Schema Registry allows registering schemas with custom subject names for references. There are cases where this feature is handy specially when auto registration of schemas is disabled. For example in Confluent Cloud where the Schema Registry is shared between all clusters in the environment and isolation of schemas is desirable. With this change clients are able to implement and use their own strategy. For example a strategy that contacts schema registry to find subject names under which references are registered.

## Alternative designs considered
An alternative design is to add another value to the strategy enum for "custom" and add an extra property for a type that provides the subject name resolution. However this means introducing a new config value and diverging more from how Java client works.

## Backward compatability
The default behavior (when no strategy is specified) has stayed intact. This change will break old code only if it explicitly specifies the reference subject name strategy. Considering the fact that there was only one option (default) the chances of this happening is very slim. 

## Other information
This change is related to Confluent Cloud support request 67865 tied to internal ticket FF-548.