### PR TITLE
Improve serialization memory management

### DIFF
--- a/src/Confluent.Kafka/ArrayPoolBufferWriter.cs
+++ b/src/Confluent.Kafka/ArrayPoolBufferWriter.cs
@@ -1,0 +1,135 @@
+﻿// Copyright 2016-2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Buffers;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    /// Implements a <see cref="IBufferWriter{Byte}"/> using <see cref="ArrayPool{Byte}.Shared"/> for memory allocation.
+    /// </summary>
+    internal sealed class ArrayPoolBufferWriter : ISerializationBuffer
+    {
+        /// <summary>
+        /// The default buffer size to use to expand empty arrays.
+        /// </summary>
+        private const int DefaultInitialBufferSize = 256;
+
+        private readonly ArrayPool<byte> pool;
+        private int index;
+        private byte[] array;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArrayPoolBufferWriter"/> class.
+        /// </summary>
+        public ArrayPoolBufferWriter()
+        {
+            this.pool = ArrayPool<byte>.Shared;
+            this.array = pool.Rent(DefaultInitialBufferSize);
+            this.index = 0;
+        }
+
+        /// <summary>
+        /// Returns the memory allocation on finialization if not explicitly disposed in user code.
+        /// </summary>
+        ~ArrayPoolBufferWriter() => Dispose();
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            byte[] array = this.array;
+
+            if (array is null)
+            {
+                throw new ObjectDisposedException(nameof(ArrayPoolBufferWriter));
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("Count must be greater than 0");
+            }
+
+            if (this.index > array.Length - count)
+            {
+                throw new ArgumentOutOfRangeException("Cannot advance further than current capacity");
+            }
+
+            this.index += count;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (this.array != null)
+            {
+                this.pool.Return(this.array, true);
+                this.array = null;
+            }
+        }
+
+     
+        public ArraySegment<byte> GetComitted(int offset = 0)
+        {
+            return new ArraySegment<byte>(this.array, offset, this.index);
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return this.array.AsMemory(this.index);
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return this.array.AsSpan(this.index);
+        }
+
+        private void EnsureCapacity(int sizeHint)
+        {
+            var array = this.array;
+
+            if (array is null)
+            {
+                throw new ObjectDisposedException(nameof(ArrayPoolBufferWriter));
+            }
+
+            if (sizeHint < 0)
+            {
+                throw new ArgumentOutOfRangeException("Cannot advance further than current capacity");
+            }
+
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (sizeHint > array.Length - this.index)
+            {
+                int minimumSize = this.index + sizeHint;
+                var newArray = pool.Rent(minimumSize);
+
+                Array.Copy(array, 0, newArray, 0, this.index);
+                pool.Return(array, true);
+                array = newArray;
+            }
+        }
+    }
+}

--- a/src/Confluent.Kafka/BufferWriterExtensions.cs
+++ b/src/Confluent.Kafka/BufferWriterExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2016-2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Buffers;
+using System.IO;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    /// Extends a <see cref="IBufferWriter{Byte}"/> with a <see cref="Stream"/> adapter.
+    /// </summary>
+    public static class BufferWriterExtensions
+    {
+        /// <summary>
+        /// Gets a <see cref="Stream"/> adapting implementation working on a <see cref="IBufferWriter{Byte}"/> as underlying memory.
+        /// </summary>
+        /// <param name="bufferWriter">The <see cref="IBufferWriter{Byte}"/> used for underlying memory.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">Thrown if the provises <paramref name="bufferWriter"/> is null.</exception>
+        public static Stream AsStream(this IBufferWriter<byte> bufferWriter)
+        {
+            if (bufferWriter is null)
+            {
+                throw new ArgumentNullException(nameof(bufferWriter));
+            }
+
+            return new BufferWriterStream(bufferWriter);
+        }
+    }
+}

--- a/src/Confluent.Kafka/BufferWriterStream.cs
+++ b/src/Confluent.Kafka/BufferWriterStream.cs
@@ -1,0 +1,158 @@
+﻿// Copyright 2016-2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    /// A <see cref="Stream"/> implementation wrapping an <see cref="IBufferWriter{Byte}"/> instance.
+    /// </summary>
+    internal sealed class BufferWriterStream : Stream
+    {
+        private readonly IBufferWriter<byte> bufferWriter;
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferWriterStream"/> class.
+        /// </summary>
+        /// <param name="bufferWriter">The target <see cref="IBufferWriter{Byte}"/> instance to use.</param>
+        public BufferWriterStream(IBufferWriter<byte> bufferWriter)
+        {
+            this.bufferWriter = bufferWriter ?? throw new ArgumentNullException(nameof(bufferWriter));
+        }
+
+        /// <inheritdoc/>
+        public override bool CanRead => false;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override bool CanWrite
+        {
+            get => !this.disposed;
+        }
+
+        /// <inheritdoc/>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void Flush()
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(true);
+        }
+
+        /// <inheritdoc/>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Write(buffer, offset, count);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(true);
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override int ReadByte()
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(BufferWriterStream));
+            }
+
+            var source = buffer.AsSpan(offset, count);
+            var destination = this.bufferWriter.GetSpan(count);
+
+            source.CopyTo(destination);
+
+            this.bufferWriter.Advance(count);
+        }
+
+        /// <inheritdoc/>
+        public override void WriteByte(byte value)
+        {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(BufferWriterStream));
+            }
+
+            this.bufferWriter.GetSpan(1)[0] = value;
+
+            this.bufferWriter.Advance(1);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            this.disposed = true;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="librdkafka.redist" Version="1.8.2">
         <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Confluent.Kafka/DefaultSerializationBufferProvider.cs
+++ b/src/Confluent.Kafka/DefaultSerializationBufferProvider.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Confluent Inc.
+﻿// Copyright 2018 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,29 +14,30 @@
 //
 // Refer to LICENSE for more information.
 
-
 using System.Buffers;
+
 
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     Defines a serializer for use with <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
+    /// The default <see cref="ISerializationBufferProvider"/>. Creates buffers using <see cref="ArrayPool{Byte}"/> internal memory.
     /// </summary>
-    public interface ISerializer<T>
+    public sealed class DefaultSerializationBufferProvider : ISerializationBufferProvider
     {
         /// <summary>
-        ///     Serialize the key or value of a <see cref="Message{TKey,TValue}" />
-        ///     instance.
+        /// Gets a singleton instance of the <see cref="DefaultSerializationBufferProvider "/>
         /// </summary>
-        /// <param name="data">
-        ///     The value to serialize.
-        /// </param>
-        /// <param name="context">
-        ///     Context relevant to the serialize operation.
-        /// </param>
-        /// <param name="bufferWriter">
-        ///     The <see cref="IBufferWriter{Byte}"/> to serialize the binary representation to.
-        /// </param>
-        void Serialize(T data, SerializationContext context, IBufferWriter<byte> bufferWriter);
+        public static DefaultSerializationBufferProvider Instance { get; } = new DefaultSerializationBufferProvider();
+
+        private DefaultSerializationBufferProvider()
+        {
+
+        }
+
+        /// <inheritdoc />
+        public ISerializationBuffer Create()
+        {
+            return new ArrayPoolBufferWriter();
+        }
     }
 }

--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -54,6 +54,10 @@ namespace Confluent.Kafka
         /// </summary>
         public IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
 
+        /// <summary>
+        ///     The configured serialization buffer provider.
+        /// </summary>
+        public ISerializationBufferProvider SerializationBufferProvider { get; set; }
 
         /// <summary>
         ///     An underlying librdkafka client handle that the Producer will use to 
@@ -98,6 +102,15 @@ namespace Confluent.Kafka
         public DependentProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
             this.AsyncValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serialization buffer provider.
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetSerializationBufferProvider(ISerializationBufferProvider serializationBufferProvider)
+        {
+            this.SerializationBufferProvider = serializationBufferProvider;
             return this;
         }
 

--- a/src/Confluent.Kafka/IAsyncSerializer.cs
+++ b/src/Confluent.Kafka/IAsyncSerializer.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers;
 using System.Threading.Tasks;
 
 
@@ -35,10 +36,13 @@ namespace Confluent.Kafka
         /// <param name="context">
         ///     Context relevant to the serialize operation.
         /// </param>
+        /// <param name="bufferWriter">
+        ///     The <see cref="IBufferWriter{T}"/> to serialize the binary representation to.
+        /// </param>
         /// <returns>
         ///     A <see cref="System.Threading.Tasks.Task" /> that
         ///     completes with the serialized data.
         /// </returns>
-        Task<byte[]> SerializeAsync(T data, SerializationContext context);
+        Task SerializeAsync(T data, SerializationContext context, IBufferWriter<byte> bufferWriter);
     }
 }

--- a/src/Confluent.Kafka/ISerializationBuffer.cs
+++ b/src/Confluent.Kafka/ISerializationBuffer.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Confluent Inc.
+﻿// Copyright 2018 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,29 +14,25 @@
 //
 // Refer to LICENSE for more information.
 
-
+using System;
 using System.Buffers;
 
 namespace Confluent.Kafka
 {
     /// <summary>
-    ///     Defines a serializer for use with <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
+    /// Defines a buffer used to serialize keys and value. This buffer is disposed when no longer used.
     /// </summary>
-    public interface ISerializer<T>
+    public interface ISerializationBuffer : IBufferWriter<byte>, IDisposable
     {
         /// <summary>
-        ///     Serialize the key or value of a <see cref="Message{TKey,TValue}" />
-        ///     instance.
+        ///     Gets an <see cref="ArraySegment{Byte}"/> representing the currently comitted memory.
         /// </summary>
-        /// <param name="data">
-        ///     The value to serialize.
+        /// <param name="offset">
+        ///     An optional offset into the comitted memory.
         /// </param>
-        /// <param name="context">
-        ///     Context relevant to the serialize operation.
-        /// </param>
-        /// <param name="bufferWriter">
-        ///     The <see cref="IBufferWriter{Byte}"/> to serialize the binary representation to.
-        /// </param>
-        void Serialize(T data, SerializationContext context, IBufferWriter<byte> bufferWriter);
+        /// <returns>
+        ///     Returns a <see cref="ArraySegment{Byte}"/> representing the commited memory with an initial offset as requested.
+        /// </returns>
+        ArraySegment<byte> GetComitted(int offset = 0);
     }
 }

--- a/src/Confluent.Kafka/ISerializationBufferProvider.cs
+++ b/src/Confluent.Kafka/ISerializationBufferProvider.cs
@@ -14,14 +14,23 @@
 //
 // Refer to LICENSE for more information.
 
+using System;
 using System.Buffers;
-using System.Threading.Tasks;
+using System.Collections.Generic;
 
-
-namespace Confluent.SchemaRegistry.Serdes
+namespace Confluent.Kafka
 {
-    internal interface IAvroSerializerImpl<T>
+    /// <summary>
+    /// Defines a factory for creating a <see cref="IBufferWriter{Byte}"/> used for key and value serialization.
+    /// </summary>
+    public interface ISerializationBufferProvider
     {
-        Task Serialize(string topic, T data, bool isKey, IBufferWriter<byte> bufferWriter);
+        /// <summary>
+        ///     Creates a new <see cref="IBufferWriter{Byte}"/>.
+        /// </summary>
+        /// <returns>
+        ///     Returns a <see cref="IBufferWriter{Byte}"/>.
+        /// </returns>
+        ISerializationBuffer Create();
     }
 }

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 
@@ -113,6 +114,11 @@ namespace Confluent.Kafka
         ///     The configured async value serializer.
         /// </summary>
         internal protected IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
+
+        /// <summary>
+        ///     The configured serialization buffer provider.
+        /// </summary>
+        internal protected ISerializationBufferProvider SerializationBufferProvider { get; set; }
 
         internal Producer<TKey,TValue>.Config ConstructBaseConfig(Producer<TKey, TValue> producer)
         {
@@ -364,6 +370,20 @@ namespace Confluent.Kafka
                 throw new InvalidOperationException("Value serializer may not be specified more than once.");
             }
             this.AsyncValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The <see cref="ISerializationBufferProvider"/> to use to when serializing keys and values.
+        /// </summary>
+        public ProducerBuilder<TKey, TValue> SetSerializationBufferProvider(ISerializationBufferProvider serializationBufferProvider)
+        {
+            if (this.SerializationBufferProvider != null)
+            {
+                throw new InvalidOperationException("Serialization buffer provider may not be specified more than once.");
+            }
+
+            this.SerializationBufferProvider = serializationBufferProvider ?? throw new ArgumentNullException(nameof(serializationBufferProvider));
             return this;
         }
 

--- a/src/Confluent.Kafka/SyncOverAsyncSerializer.cs
+++ b/src/Confluent.Kafka/SyncOverAsyncSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 
 namespace Confluent.Kafka.SyncOverAsync
 {
@@ -66,11 +67,11 @@ namespace Confluent.Kafka.SyncOverAsync
         /// <param name="context">
         ///     Context relevant to the serialize operation.
         /// </param>
-        /// <returns>
-        ///     the serialized data.
-        /// </returns>
-        public byte[] Serialize(T data, SerializationContext context)
-            => asyncSerializer.SerializeAsync(data, context)
+        /// <param name="bufferWriter">
+        ///     The <see cref="IBufferWriter{Byte}"/> to serialize the binary representation to.
+        /// </param>
+        public void Serialize(T data, SerializationContext context, IBufferWriter<byte> bufferWriter)
+            => asyncSerializer.SerializeAsync(data, context, bufferWriter)
                 .ConfigureAwait(continueOnCapturedContext: false)
                 .GetAwaiter()
                 .GetResult();

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/AvroSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/AvroSerializer.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -133,11 +134,14 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="context">
         ///     Context relevant to the serialize operation.
         /// </param>
+        /// <param name="bufferWriter">
+        ///     The <see cref="IBufferWriter{Byte}"/> to serialize the binary representation to.
+        /// </param>
         /// <returns>
         ///     A <see cref="System.Threading.Tasks.Task" /> that completes with 
         ///     <paramref name="value" /> serialized as a byte array.
         /// </returns>
-        public async Task<byte[]> SerializeAsync(T value, SerializationContext context)
+        public async Task SerializeAsync(T value, SerializationContext context, IBufferWriter<byte> bufferWriter)
         { 
             try
             {
@@ -148,7 +152,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         : new SpecificSerializerImpl<T>(schemaRegistryClient, autoRegisterSchema, useLatestVersion, initialBufferSize, subjectNameStrategy);
                 }
 
-                return await serializerImpl.Serialize(context.Topic, value, context.Component == MessageComponentType.Key).ConfigureAwait(continueOnCapturedContext: false);
+                await serializerImpl.Serialize(context.Topic, value, context.Component == MessageComponentType.Key, bufferWriter).ConfigureAwait(continueOnCapturedContext: false);
             }
             catch (AggregateException e)
             {

--- a/test/Confluent.Kafka.IntegrationTests/Serdes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Serdes.cs
@@ -14,6 +14,7 @@
 //
 // Refer to LICENSE for more information.
 
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
@@ -23,10 +24,10 @@ namespace Confluent.Kafka.IntegrationTests
 {
     class SimpleAsyncSerializer : IAsyncSerializer<string>
     {
-        public async Task<byte[]> SerializeAsync(string data, SerializationContext context)
+        public async Task SerializeAsync(string data, SerializationContext context, IBufferWriter<byte> bufferWriter)
         {
             await Task.Delay(500).ConfigureAwait(false);
-            return Serializers.Utf8.Serialize(data, context);
+            Serializers.Utf8.Serialize(data, context, bufferWriter);
         }
 
         public ISerializer<string> SyncOverAsync()
@@ -37,10 +38,10 @@ namespace Confluent.Kafka.IntegrationTests
 
     class SimpleSyncSerializer : ISerializer<string>
     {
-        public byte[] Serialize(string data, SerializationContext context)
+        public void Serialize(string data, SerializationContext context, IBufferWriter<byte> bufferWriter)
         {
             Thread.Sleep(500);
-            return Serializers.Utf8.Serialize(data, context);
+            Serializers.Utf8.Serialize(data, context, bufferWriter);
         }
     }
 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -47,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<Null, byte[]> dr;
             using (var producer = new ProducerBuilder<Null, byte[]>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, byte[]> { Value = Serializers.Utf8.ToByteArray(testString, SerializationContext.Empty) }).Result;
                 Assert.True(dr.Offset >= 0);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -20,7 +20,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using Xunit;
-
+using System.Buffers;
 
 namespace Confluent.Kafka.IntegrationTests
 {
@@ -35,9 +35,11 @@ namespace Confluent.Kafka.IntegrationTests
         {
             class Utf32Serializer : ISerializer<string>
             {
-                public byte[] Serialize(string data, SerializationContext context)
+                public void Serialize(string data, SerializationContext context, IBufferWriter<byte> bufferWriter)
                 {
-                    return Encoding.UTF32.GetBytes(data);
+                    var size = Encoding.UTF32.GetByteCount(data);
+                    var buffer = bufferWriter.GetSpan(size);
+                    Encoding.UTF32.GetBytes(data).CopyTo(buffer);
                 }
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -48,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
                     singlePartitionTopic,
                     new Message<byte[], byte[]>
                     {
-                        Value = Serializers.Utf8.Serialize("my-value", SerializationContext.Empty),
+                        Value = Serializers.Utf8.ToByteArray("my-value", SerializationContext.Empty),
                         Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
                     }
                 ).Result;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -48,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
                     singlePartitionTopic,
                     new Message<byte[], byte[]>
                     {
-                        Value = Serializers.Utf8.Serialize("my-value", SerializationContext.Empty),
+                        Value = Serializers.Utf8.ToByteArray("my-value", SerializationContext.Empty),
                         Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
                     }
                 ).Result;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -130,8 +130,8 @@ namespace Confluent.Kafka.IntegrationTests
                         new TopicPartition(topic, partition),
                         new Message<byte[], byte[]>
                         { 
-                            Key = Serializers.Utf8.Serialize($"test key {index}", SerializationContext.Empty),
-                            Value = Serializers.Utf8.Serialize($"test val {index}", SerializationContext.Empty),
+                            Key = Serializers.Utf8.ToByteArray($"test key {index}", SerializationContext.Empty),
+                            Value = Serializers.Utf8.ToByteArray($"test val {index}", SerializationContext.Empty),
                             Timestamp = new Timestamp(baseTime + index*1000, TimestampType.CreateTime),
                             Headers = null
                         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -61,13 +61,13 @@ namespace Confluent.Kafka.IntegrationTests
                 ConsumeResult<byte[], byte[]> record = consumer.Consume(TimeSpan.FromSeconds(2));
                 Assert.Null(record);
 
-                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("test value", SerializationContext.Empty) }).Wait();
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record?.Message);
                 Assert.Equal(0, record?.Offset);
 
                 consumer.Pause(assignment);
-                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value 2", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("test value 2", SerializationContext.Empty) }).Wait();
                 record = consumer.Consume(TimeSpan.FromSeconds(2));
                 Assert.Null(record);
                 consumer.Resume(assignment);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
@@ -49,9 +49,9 @@ namespace Confluent.Kafka.IntegrationTests
                     .Build())
             {
                 const string checkValue = "check value";
-                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(checkValue, SerializationContext.Empty) }).Result;
-                var dr2 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("second value", SerializationContext.Empty) }).Result;
-                var dr3 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("third value", SerializationContext.Empty) }).Result;
+                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray(checkValue, SerializationContext.Empty) }).Result;
+                var dr2 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("second value", SerializationContext.Empty) }).Result;
+                var dr3 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("third value", SerializationContext.Empty) }).Result;
 
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
@@ -64,7 +64,7 @@ namespace Confluent.Kafka.IntegrationTests
                 ConsumeResult<Null, string> record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.Null(record);
 
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test store offset value", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("test store offset value", SerializationContext.Empty) }).Wait();
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record?.Message);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -52,7 +52,7 @@ namespace Confluent.Kafka.IntegrationTests
                 DeliveryResult<byte[], byte[]> dr;
                 using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
                 {
-                    dr = producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }).Result;
+                    dr = producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray(testString, SerializationContext.Empty) }).Result;
                     Assert.NotNull(dr);
                     producer.Flush(TimeSpan.FromSeconds(10));
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -40,7 +40,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("test string", SerializationContext.Empty) }).Wait();
             }
 
             using (var consumer = new ConsumerBuilder<byte[], byte[]>(consumerConfig).Build())

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -60,7 +60,7 @@ namespace Confluent.Kafka.IntegrationTests
                     .SetLogHandler((_, m) => logCount += 1)
                     .Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("test value", SerializationContext.Empty) }).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
             // Producing onto the topic to make sure it exists.
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }).Result;
+                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.ToByteArray("test string", SerializationContext.Empty) }).Result;
                 Assert.NotEqual(Offset.Unset, dr.Offset);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SerializationExtensions.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SerializationExtensions.cs
@@ -14,14 +14,20 @@
 //
 // Refer to LICENSE for more information.
 
-using System.Buffers;
-using System.Threading.Tasks;
+#pragma warning disable xUnit1026
 
 
-namespace Confluent.SchemaRegistry.Serdes
+namespace Confluent.Kafka.IntegrationTests
 {
-    internal interface IAvroSerializerImpl<T>
+    public static class SerializationExtensions
     {
-        Task Serialize(string topic, T data, bool isKey, IBufferWriter<byte> bufferWriter);
+        public static byte[] ToByteArray<T>(this ISerializer<T> serializer, T value, SerializationContext serializationContext)
+        {
+            using (var buffer = DefaultSerializationBufferProvider.Instance.Create())
+            {
+                serializer.Serialize(value, serializationContext, buffer);
+                return buffer.GetComitted().ToArray();
+            }
+        }
     }
 }

--- a/test/Confluent.Kafka.SyncOverAsync/Program.cs
+++ b/test/Confluent.Kafka.SyncOverAsync/Program.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,10 +34,10 @@ namespace Confluent.Kafka.SyncOverAsync
 {
     class SimpleAsyncSerializer : IAsyncSerializer<string>
     {
-        public async Task<byte[]> SerializeAsync(string data, SerializationContext context)
+        public async Task SerializeAsync(string data, SerializationContext context, IBufferWriter<byte> bufferWriter)
         {
             await Task.Delay(500);
-            return Serializers.Utf8.Serialize(data, context);
+            Serializers.Utf8.Serialize(data, context, bufferWriter);
         }
 
         public ISerializer<string> SyncOverAsync()
@@ -47,10 +48,10 @@ namespace Confluent.Kafka.SyncOverAsync
 
     class SimpleSyncSerializer : ISerializer<string>
     {
-        public byte[] Serialize(string data, SerializationContext context)
+        public void Serialize(string data, SerializationContext context, IBufferWriter<byte> bufferWriter)
         {
             Thread.Sleep(500);
-            return Serializers.Utf8.Serialize(data, context);
+            Serializers.Utf8.Serialize(data, context, bufferWriter);
         }
     }
 

--- a/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/ByteArray.cs
@@ -27,13 +27,13 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [InlineData(new byte[] { 1, 2, 3, 4, 5 })]
         public void CanReconstructByteArray(byte[] values)
         {
-            Assert.Equal(values, Deserializers.ByteArray.Deserialize(Serializers.ByteArray.Serialize(values, SerializationContext.Empty), false, SerializationContext.Empty));
+            Assert.Equal(values, Deserializers.ByteArray.Deserialize(Serializers.ByteArray.ToByteArray(values, SerializationContext.Empty), false, SerializationContext.Empty));
         }
 
         [Fact]
         public void CanReconstructByteArrayNull()
         {
-            Assert.Null(Deserializers.ByteArray.Deserialize(Serializers.ByteArray.Serialize(null, SerializationContext.Empty), true, SerializationContext.Empty));
+            Assert.Null(Deserializers.ByteArray.Deserialize(Serializers.ByteArray.ToByteArray(null, SerializationContext.Empty), true, SerializationContext.Empty));
         }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Double.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             foreach (var value in TestData)
             {
-                Assert.Equal(value, Deserializers.Double.Deserialize(Serializers.Double.Serialize(value, SerializationContext.Empty), false, SerializationContext.Empty));
+                Assert.Equal(value, Deserializers.Double.Deserialize(Serializers.Double.ToByteArray(value, SerializationContext.Empty), false, SerializationContext.Empty));
             }
         }
 
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             var buffer = new byte[] { 23, 0, 0, 0, 0, 0, 0, 0 };
             var value = BitConverter.ToDouble(buffer, 0);
-            var data = Serializers.Double.Serialize(value, SerializationContext.Empty);
+            var data = Serializers.Double.ToByteArray(value, SerializationContext.Empty);
             Assert.Equal(23, data[7]);
             Assert.Equal(0, data[0]);
         }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Float.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             foreach (var value in TestData)
             {
-                Assert.Equal(value, Deserializers.Single.Deserialize(Serializers.Single.Serialize(value, SerializationContext.Empty), false, SerializationContext.Empty));
+                Assert.Equal(value, Deserializers.Single.Deserialize(Serializers.Single.ToByteArray(value, SerializationContext.Empty), false, SerializationContext.Empty));
             }
         }
 
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             var buffer = new byte[] { 23, 0, 0, 0 };
             var value = BitConverter.ToSingle(buffer, 0);
-            var data = Serializers.Single.Serialize(value, SerializationContext.Empty);
+            var data = Serializers.Single.ToByteArray(value, SerializationContext.Empty);
             Assert.Equal(23, data[3]);
             Assert.Equal(0, data[0]);
         }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Int.cs
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [Fact]
         public void IsBigEndian()
         {
-            var bytes = Serializers.Int32.Serialize(42, SerializationContext.Empty);
+            var bytes = Serializers.Int32.ToByteArray(42, SerializationContext.Empty);
             Assert.Equal(4, bytes.Length);
             // most significant byte in smallest address.
             Assert.Equal(0, bytes[0]);
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
                 int networkOrder = System.Net.IPAddress.HostToNetworkOrder(theInt);
                 var bytes1 = BitConverter.GetBytes(networkOrder);
 
-                var bytes2 = Serializers.Int32.Serialize(theInt, SerializationContext.Empty);
+                var bytes2 = Serializers.Int32.ToByteArray(theInt, SerializationContext.Empty);
 
                 Assert.Equal(bytes1.Length, bytes2.Length);
 
@@ -65,7 +65,7 @@ namespace Confluent.Kafka.UnitTests.Serialization
         {
             foreach (int theInt in toTest)
             {
-                var reconstructed = Deserializers.Int32.Deserialize(Serializers.Int32.Serialize(theInt, SerializationContext.Empty), false, SerializationContext.Empty);
+                var reconstructed = Deserializers.Int32.Deserialize(Serializers.Int32.ToByteArray(theInt, SerializationContext.Empty), false, SerializationContext.Empty);
                 Assert.Equal(theInt, reconstructed);
             }
         }

--- a/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/Long.cs
@@ -26,13 +26,13 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [MemberData(nameof(TestData))]
         public void CanReconstructLong(long value)
         {
-            Assert.Equal(value, Deserializers.Int64.Deserialize(Serializers.Int64.Serialize(value, SerializationContext.Empty), false, SerializationContext.Empty));
+            Assert.Equal(value, Deserializers.Int64.Deserialize(Serializers.Int64.ToByteArray(value, SerializationContext.Empty), false, SerializationContext.Empty));
         }
 
         [Fact]
         public void IsBigEndian()
         {
-            var data = Serializers.Int64.Serialize(23L, SerializationContext.Empty);
+            var data = Serializers.Int64.ToByteArray(23L, SerializationContext.Empty);
             Assert.Equal(23, data[7]);
             Assert.Equal(0, data[0]);
         }

--- a/test/Confluent.Kafka.UnitTests/Serialization/SerializationExtensions.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/SerializationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Confluent Inc.
+﻿// Copyright 2016-2017 Confluent Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,20 @@
 //
 // Refer to LICENSE for more information.
 
-using System.Buffers;
-using System.Threading.Tasks;
+using System.Linq;
 
 
-namespace Confluent.SchemaRegistry.Serdes
+namespace Confluent.Kafka.UnitTests.Serialization
 {
-    internal interface IAvroSerializerImpl<T>
+    public static class SerializationExtensions
     {
-        Task Serialize(string topic, T data, bool isKey, IBufferWriter<byte> bufferWriter);
+        public static byte[] ToByteArray<T>(this ISerializer<T> serializer, T value, SerializationContext serializationContext)
+        {
+            using (var buffer = DefaultSerializationBufferProvider.Instance.Create())
+            {
+                serializer.Serialize(value, serializationContext, buffer);
+                return buffer.GetComitted().ToArray();
+            }
+        }
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Serialization/String.cs
+++ b/test/Confluent.Kafka.UnitTests/Serialization/String.cs
@@ -28,10 +28,10 @@ namespace Confluent.Kafka.UnitTests.Serialization
         [Fact]
         public void SerializeDeserialize()
         {
-            Assert.Equal("hello world", Deserializers.Utf8.Deserialize(Serializers.Utf8.Serialize("hello world", SerializationContext.Empty), false, SerializationContext.Empty));
-            Assert.Equal("ឆ្មាត្រូវបានហែលទឹក", Deserializers.Utf8.Deserialize(Serializers.Utf8.Serialize("ឆ្មាត្រូវបានហែលទឹក", SerializationContext.Empty), false, SerializationContext.Empty));
-            Assert.Equal("вы не банан", Deserializers.Utf8.Deserialize(Serializers.Utf8.Serialize("вы не банан", SerializationContext.Empty), false, SerializationContext.Empty));
-            Assert.Null(Deserializers.Utf8.Deserialize(Serializers.Utf8.Serialize(null, SerializationContext.Empty), true, SerializationContext.Empty));
+            Assert.Equal("hello world", Deserializers.Utf8.Deserialize(Serializers.Utf8.ToByteArray("hello world", SerializationContext.Empty), false, SerializationContext.Empty));
+            Assert.Equal("ឆ្មាត្រូវបានហែលទឹក", Deserializers.Utf8.Deserialize(Serializers.Utf8.ToByteArray("ឆ្មាត្រូវបានហែលទឹក", SerializationContext.Empty), false, SerializationContext.Empty));
+            Assert.Equal("вы не банан", Deserializers.Utf8.Deserialize(Serializers.Utf8.ToByteArray("вы не банан", SerializationContext.Empty), false, SerializationContext.Empty));
+            Assert.Null(Deserializers.Utf8.Deserialize(Serializers.Utf8.ToByteArray(null, SerializationContext.Empty), true, SerializationContext.Empty));
 
             // TODO: check some serialize / deserialize operations that are not expected to work, including some
             //       cases where Deserialize can be expected to throw an exception.

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
@@ -52,7 +52,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var protoSerializer = new ProtobufSerializer<UInt32Value>(schemaRegistryClient);
             var protoDeserializer = new ProtobufDeserializer<UInt32Value>();
 
-            var bytes = protoSerializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = protoSerializer.ToByteArray(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Null(bytes);
             Assert.Null(protoDeserializer.DeserializeAsync(bytes, true, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
@@ -64,7 +64,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var protoDeserializer = new ProtobufDeserializer<UInt32Value>();
 
             var v = new UInt32Value { Value = 1234 };
-            var bytes = protoSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = protoSerializer.ToByteArray(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(v.Value, protoDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result.Value);
         }
 

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/SerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/SerializeDeserialize.cs
@@ -54,7 +54,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<int>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<int>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(1234, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(1234, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(1234, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -64,7 +64,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<long>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<long>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(123, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(123, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(123, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -74,7 +74,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<bool>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<bool>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(true, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(true, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(true, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -84,7 +84,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<string>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<string>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync("abc", new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray("abc", new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal("abc", avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -94,7 +94,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<double>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<double>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(123d, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(123d, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(123d, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -104,7 +104,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<float>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<float>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(123f, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(123f, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(123f, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -114,7 +114,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<byte[]>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<byte[]>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(new byte[] { 2, 3, 4 }, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(new byte[] { 2, 3, 4 }, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(new byte[] { 2, 3, 4 }, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -124,7 +124,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var avroSerializer = new AvroSerializer<Null>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<Null>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = avroSerializer.ToByteArray(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Equal(null, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
 
@@ -141,7 +141,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = serializer.ToByteArray(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
 
             Assert.Equal(user.name, result.name);
@@ -169,7 +169,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "great_brand"
             };
 
-            var bytesUser = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytesUser = serializer.ToByteArray(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             var resultUser = deserializerUser.DeserializeAsync(bytesUser, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result as User;
 
             Assert.NotNull(resultUser);
@@ -177,7 +177,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             Assert.Equal(user.favorite_color, resultUser.favorite_color);
             Assert.Equal(user.favorite_number, resultUser.favorite_number);
 
-            var bytesCar = serializer.SerializeAsync(car, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytesCar = serializer.ToByteArray(car, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             var resultCar = deserializerCar.DeserializeAsync(bytesCar, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result as Car;
 
             Assert.NotNull(resultCar);
@@ -189,7 +189,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         public void Poco_Serialize()
         {
             var serializer = new AvroSerializer<Dictionary<string, string>>(schemaRegistryClient);
-            Assert.Throws<System.InvalidOperationException>(() => serializer.SerializeAsync(new Dictionary<string, string> { { "cat", "dog" } }, new SerializationContext(MessageComponentType.Key, testTopic)).GetAwaiter().GetResult());
+            Assert.Throws<System.InvalidOperationException>(() => serializer.ToByteArray(new Dictionary<string, string> { { "cat", "dog" } }, new SerializationContext(MessageComponentType.Key, testTopic)).GetAwaiter().GetResult());
         }
 
         [Fact]
@@ -204,7 +204,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         {
             var avroSerializer = new AvroSerializer<string>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<int>(schemaRegistryClient);
-            var bytes = avroSerializer.SerializeAsync("hello world", new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = avroSerializer.ToByteArray("hello world", new SerializationContext(MessageComponentType.Value, testTopic)).Result;
             Assert.Throws<System.AggregateException>(() => avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
         }
     }


### PR DESCRIPTION
Currently, the `ISerializer` and `IAsyncSerializer` interfaces force an implementation to return a byte array with exact size. This approach effectively makes pooling impossible and often requires expensive memory copies and additional allocations in serializer implementations. See ProtobufSerializer as an example.

This PR changes the memory management for serialization. Instead of relying on serializer implementations to return a byte array, they are given an IBufferWriter<byte> to write to.

`void Serialize(T data, SerializationContext context, IBufferWriter<byte> bufferWriter);`

The producer implementation will then supply a buffer writer implementation that internally uses ArrayPool<byte> to allocate the memory. Users can overwrite this implementation by setting a custom ISerializationBufferProvider.