### PR TITLE
netcoreapp2.1 -> net5.0

### DIFF
--- a/examples/AdminClient/AdminClient.csproj
+++ b/examples/AdminClient/AdminClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>AdminClient</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/examples/AvroBlogExamples/AvroBlogExamples.csproj
+++ b/examples/AvroBlogExamples/AvroBlogExamples.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/examples/AvroGeneric/AvroGeneric.csproj
+++ b/examples/AvroGeneric/AvroGeneric.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>AvroSpecific</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/examples/AvroSpecific/AvroSpecific.csproj
+++ b/examples/AvroSpecific/AvroSpecific.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>AvroSpecific</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/examples/ConfluentCloud/ConfluentCloud.csproj
+++ b/examples/ConfluentCloud/ConfluentCloud.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Consumer/Consumer.csproj
+++ b/examples/Consumer/Consumer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Consumer</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/ExactlyOnce/ExactlyOnce.csproj
+++ b/examples/ExactlyOnce/ExactlyOnce.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>ExactlyOnce</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/examples/ExactlyOnceOldBroker/ExactlyOnceOldBroker.csproj
+++ b/examples/ExactlyOnceOldBroker/ExactlyOnceOldBroker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>ExactlyOnceOldBroker</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/examples/JsonSerialization/JsonSerialization.csproj
+++ b/examples/JsonSerialization/JsonSerialization.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>JsonSerialization</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>MultiProducer</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/Producer/Producer.csproj
+++ b/examples/Producer/Producer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Producer</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>

--- a/examples/Protobuf/Protobuf.csproj
+++ b/examples/Protobuf/Protobuf.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Protobuf</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/src/ConfigGen/ConfigGen.csproj
+++ b/src/ConfigGen/ConfigGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -13,7 +13,7 @@
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
     <VersionPrefix>1.8.2</VersionPrefix>
-    <TargetFrameworks>net45;net46;netcoreapp2.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net5.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/src/Confluent.Kafka/Internal/Extensions/String.cs
+++ b/src/Confluent.Kafka/Internal/Extensions/String.cs
@@ -14,6 +14,8 @@
 //
 // Refer to LICENSE for more information.
 
+#pragma warning disable SYSLIB0001 // utf7 insecure
+
 using System;
 using System.Text;
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -793,7 +793,7 @@ namespace Confluent.Kafka
                         enableDeliveryReportKey ? message.Key : default(TKey),
                         enableDeliveryReportValue ? message.Value : default(TValue));
 
-                    if (cancellationToken != null && cancellationToken.CanBeCanceled)
+                    if (cancellationToken.CanBeCanceled)
                     {
                         handler.CancellationTokenRegistration
                             = cancellationToken.Register(() => handler.TrySetCanceled());
@@ -955,10 +955,7 @@ namespace Confluent.Kafka
 
             public void HandleDeliveryReport(DeliveryReport<Null, Null> deliveryReport)
             {
-                if (CancellationTokenRegistration != null)
-                {
-                    CancellationTokenRegistration.Dispose();
-                }
+                CancellationTokenRegistration.Dispose();
 
                 if (deliveryReport == null)
                 {

--- a/test/Confluent.Kafka.Benchmark/Confluent.Kafka.Benchmark.csproj
+++ b/test/Confluent.Kafka.Benchmark/Confluent.Kafka.Benchmark.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Confluent.Kafka.Benchmark</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
+++ b/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.Kafka.IntegrationTests</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/test/Confluent.Kafka.SyncOverAsync/Confluent.Kafka.SyncOverAsync.csproj
+++ b/test/Confluent.Kafka.SyncOverAsync/Confluent.Kafka.SyncOverAsync.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Confluent.Kafka.Transactions/Confluent.Kafka.Transactions.csproj
+++ b/test/Confluent.Kafka.Transactions/Confluent.Kafka.Transactions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+++ b/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.Kafka.UnitTests</AssemblyName>
-    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net452;net5.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Confluent.Kafka.UnitTests.snk</AssemblyOriginatorKeyFile>

--- a/test/Confluent.Kafka.VerifiableClient/Confluent.Kafka.VerifiableClient.csproj
+++ b/test/Confluent.Kafka.VerifiableClient/Confluent.Kafka.VerifiableClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Confluent.Kafka.VerifiableClient</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;debian-x64;ubuntu.16.04-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Confluent.SchemaRegistry.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Confluent.SchemaRegistry.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.IntegrationTests</AssemblyName>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.IntegrationTests</AssemblyName>
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>net5.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Confluent.SchemaRegistry.Serdes.UnitTests.snk</AssemblyOriginatorKeyFile>
     <LangVersion>9.0</LangVersion>

--- a/test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>net5.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Confluent.SchemaRegistry.UnitTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
netcoreapp2.1 is now out of long term support.

Moving to net5.0 not net6.0 as one of the test projects hangs on net6.0. This seems to be a problem with the test framework not the tests according to some quick research. Couldn't quickly figure out how to fix it.

Note: This PR does not affect framework compatibility of any of the libraries.

CancellationTokenRegistration and CancellationToken are structs, so the newer compiler warns me, so can't be null.

