### PR TITLE
Support using array segments for serializers

### DIFF
--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -37,23 +37,23 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The configured key serializer.
         /// </summary>
-        public ISerializer<TKey> KeySerializer { get; set; }
+        public ISegmentSerializer<TKey> KeySerializer { get; set; }
 
         /// <summary>
         ///     The configured value serializer.
         /// </summary>
-        public ISerializer<TValue> ValueSerializer { get; set; }
-
+        public ISegmentSerializer<TValue> ValueSerializer { get; set; }
+        
+      
         /// <summary>
         ///     The configured async key serializer.
         /// </summary>
-        public IAsyncSerializer<TKey> AsyncKeySerializer { get; set; }
+        public IAsyncSegmentSerializer<TKey> AsyncKeySerializer { get; set; }
 
         /// <summary>
         ///     The configured async value serializer.
         /// </summary>
-        public IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
-
+        public IAsyncSegmentSerializer<TValue> AsyncValueSerializer { get; set; }
 
         /// <summary>
         ///     An underlying librdkafka client handle that the Producer will use to 
@@ -70,7 +70,7 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetKeySerializer(ISerializer<TKey> serializer)
         {
-            this.KeySerializer = serializer;
+            this.KeySerializer = new WrappedSyncSegmentSerializer<TKey>(serializer);
             return this;
         }
 
@@ -79,7 +79,7 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
         {
-            this.ValueSerializer = serializer;
+            this.ValueSerializer = new WrappedSyncSegmentSerializer<TValue>(serializer);
             return this;
         }
 
@@ -88,7 +88,7 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSerializer<TKey> serializer)
         {
-            this.AsyncKeySerializer = serializer;
+            this.AsyncKeySerializer = new WrappedAsyncSyncSegmentSerializer<TKey>(serializer);
             return this;
         }
 
@@ -97,7 +97,43 @@ namespace Confluent.Kafka
         /// </summary>
         public DependentProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
+            this.AsyncValueSerializer = new WrappedAsyncSyncSegmentSerializer<TValue>(serializer);
+            return this;
+        }
+        
+        /// <summary>
+        ///     The async serializer to use to serialize keys. This uses the array segment API
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSegmentSerializer<TKey> serializer)
+        {
+            this.AsyncKeySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The async serializer to use to serialize values. This uses the array segment API
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSegmentSerializer<TValue> serializer)
+        {
             this.AsyncValueSerializer = serializer;
+            return this;
+        }
+        
+        /// <summary>
+        ///     The async serializer to use to serialize keys. This uses the array segment API
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetKeySerializer(ISegmentSerializer<TKey> serializer)
+        {
+            this.KeySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The async serializer to use to serialize values. This uses the array segment API
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetValueSerializer(ISegmentSerializer<TValue> serializer)
+        {
+            this.ValueSerializer = serializer;
             return this;
         }
 

--- a/src/Confluent.Kafka/IAsyncSegmentSerializer.cs
+++ b/src/Confluent.Kafka/IAsyncSegmentSerializer.cs
@@ -1,0 +1,49 @@
+// Copyright 2016-2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Defines a serializer for use with <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
+    /// </summary>
+    public interface IAsyncSegmentSerializer<T>
+    {
+        /// <summary>
+        ///     Serialize the key or value of a <see cref="Message{TKey,TValue}" />
+        ///     instance.
+        /// </summary>
+        /// <param name="data">
+        ///     The value to serialize.
+        /// </param>
+        /// <param name="context">
+        ///     Context relevant to the serialize operation.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="System.Threading.Tasks.Task" /> that
+        ///     completes with the serialized data.
+        /// </returns>
+        Task<ArraySegment<byte>> SerializeAsync(T data, SerializationContext context);
+
+        /// <summary>
+        ///     Release resources associated with the array segment
+        /// </summary>
+        /// <param name="segment">The segment that was created in the <see cref="SerializeAsync"/> call.</param>
+        void Release(ref ArraySegment<byte> segment);
+    }
+}

--- a/src/Confluent.Kafka/ISegmentSerializer.cs
+++ b/src/Confluent.Kafka/ISegmentSerializer.cs
@@ -1,0 +1,48 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+
+using System;
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Defines a serializer for use with <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
+    /// </summary>
+    public interface ISegmentSerializer<T>
+    {
+        /// <summary>
+        ///     Serialize the key or value of a <see cref="Message{TKey,TValue}" />
+        ///     instance.
+        /// </summary>
+        /// <param name="data">
+        ///     The value to serialize.
+        /// </param>
+        /// <param name="context">
+        ///     Context relevant to the serialize operation.
+        /// </param>
+        /// <returns>
+        ///     The serialized value.
+        /// </returns>
+        ArraySegment<byte> Serialize(T data, SerializationContext context);
+        
+        /// <summary>
+        ///     Release resources associated with the array segment
+        /// </summary>
+        /// <param name="segment">The segment that was created in the <see cref="Serialize"/> call.</param>
+        void Release(ref ArraySegment<byte> segment);
+    }
+}

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -97,22 +97,22 @@ namespace Confluent.Kafka
         /// <summary>
         ///     The configured key serializer.
         /// </summary>
-        internal protected ISerializer<TKey> KeySerializer { get; set; }
+        internal protected ISegmentSerializer<TKey> KeySerializer { get; set; }
 
         /// <summary>
         ///     The configured value serializer.
         /// </summary>
-        internal protected ISerializer<TValue> ValueSerializer { get; set; }
+        internal protected ISegmentSerializer<TValue> ValueSerializer { get; set; }
 
         /// <summary>
         ///     The configured async key serializer.
         /// </summary>
-        internal protected IAsyncSerializer<TKey> AsyncKeySerializer { get; set; }
+        internal protected IAsyncSegmentSerializer<TKey> AsyncKeySerializer { get; set; }
 
         /// <summary>
         ///     The configured async value serializer.
         /// </summary>
-        internal protected IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
+        internal protected IAsyncSegmentSerializer<TValue> AsyncValueSerializer { get; set; }
 
         internal Producer<TKey,TValue>.Config ConstructBaseConfig(Producer<TKey, TValue> producer)
         {
@@ -306,7 +306,7 @@ namespace Confluent.Kafka
             {
                 throw new InvalidOperationException("Key serializer may not be specified more than once.");
             }
-            this.KeySerializer = serializer;
+            this.KeySerializer = new WrappedSyncSegmentSerializer<TKey>(serializer);
             return this;
         }
 
@@ -325,7 +325,7 @@ namespace Confluent.Kafka
             {
                 throw new InvalidOperationException("Value serializer may not be specified more than once.");
             }
-            this.ValueSerializer = serializer;
+            this.ValueSerializer = new WrappedSyncSegmentSerializer<TValue>(serializer);
             return this;
         }
 
@@ -344,7 +344,7 @@ namespace Confluent.Kafka
             {
                 throw new InvalidOperationException("Key serializer may not be specified more than once.");
             }
-            this.AsyncKeySerializer = serializer;
+            this.AsyncKeySerializer = new WrappedAsyncSyncSegmentSerializer<TKey>(serializer);
             return this;
         }
 
@@ -358,6 +358,82 @@ namespace Confluent.Kafka
         ///     Produce or ProduceAsync.
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
+        {
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
+            {
+                throw new InvalidOperationException("Value serializer may not be specified more than once.");
+            }
+            this.AsyncValueSerializer = new WrappedAsyncSyncSegmentSerializer<TValue>(serializer);
+            return this;
+        }
+        
+        /// <summary>
+        ///     The serializer to use to serialize keys.
+        /// </summary>
+        /// <remarks>
+        ///     If your key serializer throws an exception, this will be
+        ///     wrapped in a ProduceException with ErrorCode
+        ///     Local_KeySerialization and thrown by the initiating call to
+        ///     Produce or ProduceAsync.
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetKeySerializer(ISegmentSerializer<TKey> serializer)
+        {
+            if (this.KeySerializer != null || this.AsyncKeySerializer != null)
+            {
+                throw new InvalidOperationException("Key serializer may not be specified more than once.");
+            }
+            this.KeySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        /// <remarks>
+        ///     If your value serializer throws an exception, this will be
+        ///     wrapped in a ProduceException with ErrorCode
+        ///     Local_ValueSerialization and thrown by the initiating call to
+        ///     Produce or ProduceAsync.
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetValueSerializer(ISegmentSerializer<TValue> serializer)
+        {
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
+            {
+                throw new InvalidOperationException("Value serializer may not be specified more than once.");
+            }
+            this.ValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize keys.
+        /// </summary>
+        /// <remarks>
+        ///     If your key serializer throws an exception, this will be
+        ///     wrapped in a ProduceException with ErrorCode
+        ///     Local_KeySerialization and thrown by the initiating call to
+        ///     Produce or ProduceAsync.
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetKeySerializer(IAsyncSegmentSerializer<TKey> serializer)
+        {
+            if (this.KeySerializer != null || this.AsyncKeySerializer != null)
+            {
+                throw new InvalidOperationException("Key serializer may not be specified more than once.");
+            }
+            this.AsyncKeySerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        /// <remarks>
+        ///     If your value serializer throws an exception, this will be
+        ///     wrapped in a ProduceException with ErrorCode
+        ///     Local_ValueSerialization and thrown by the initiating call to
+        ///     Produce or ProduceAsync.
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSegmentSerializer<TValue> serializer)
         {
             if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
             {

--- a/src/Confluent.Kafka/WrappedAsyncSegmentSerializer.cs
+++ b/src/Confluent.Kafka/WrappedAsyncSegmentSerializer.cs
@@ -1,0 +1,56 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+
+using System;
+using System.Threading.Tasks;
+
+namespace Confluent.Kafka
+{
+    
+    /// <summary>
+    ///     A wrapped segment serializer to facilitate up-casting to the segment based API
+    /// </summary>
+    /// <typeparam name="T">The type of the value that can be serialized by this serializer</typeparam>
+    public class WrappedAsyncSyncSegmentSerializer<T> : IAsyncSegmentSerializer<T>
+    {
+        private readonly IAsyncSerializer<T> serializer;
+
+        /// <summary>
+        ///     Created a <see cref="WrappedAsyncSyncSegmentSerializer{T}"/> using an inner <see cref="IAsyncSerializer{T}"/>.
+        ///     This just decorates the returned byte array in an array segment wrapper using the length of the
+        ///     returned array to establish bounds. This does require awaiting on the returned task.
+        /// </summary>
+        /// <param name="innerSerializer">The inner serializer to use</param>
+        public WrappedAsyncSyncSegmentSerializer(IAsyncSerializer<T> innerSerializer)
+        {
+            serializer = innerSerializer;
+        }
+        
+        /// <inheritdoc cref="IAsyncSegmentSerializer{T}.SerializeAsync"/>
+        public async Task<ArraySegment<byte>> SerializeAsync(T data, SerializationContext context)
+        {
+            byte[] result = await serializer.SerializeAsync(data, context).ConfigureAwait(false);
+            return new ArraySegment<byte>(result);
+        }
+        
+        /// <inheritdoc cref="IAsyncSegmentSerializer{T}.Release"/>
+        public void Release(ref ArraySegment<byte> segment)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/src/Confluent.Kafka/WrappedSyncSegmentSerializer.cs
+++ b/src/Confluent.Kafka/WrappedSyncSegmentSerializer.cs
@@ -1,0 +1,53 @@
+// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka
+{
+    
+    /// <summary>
+    ///     A wrapped segment serializer to facilitate up-casting to the segment based API
+    /// </summary>
+    /// <typeparam name="T">The type of the value that can be serialized by this serializer</typeparam>
+    public class WrappedSyncSegmentSerializer<T> : ISegmentSerializer<T>
+    {
+        private readonly ISerializer<T> serializer;
+
+        /// <summary>
+        ///     Created a <see cref="WrappedSyncSegmentSerializer{T}"/> using an inner <see cref="ISerializer{T}"/>.
+        ///     This just decorates the returned byte array in an array segment wrapper using the length of the
+        ///     returned array to establish bounds.
+        /// </summary>
+        /// <param name="innerSerializer">The inner serializer to use</param>
+        public WrappedSyncSegmentSerializer(ISerializer<T> innerSerializer)
+        {
+            serializer = innerSerializer;
+        }
+        
+        /// <inheritdoc cref="ISegmentSerializer{T}.Serialize"/>
+        public ArraySegment<byte> Serialize(T data, SerializationContext context)
+        {
+            return new ArraySegment<byte>(serializer.Serialize(data, context));
+        }
+
+        /// <inheritdoc cref="ISegmentSerializer{T}.Release"/>
+        public void Release(ref ArraySegment<byte> segment)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     if (KeySerializer == null && AsyncKeySerializer == null)
                     {
-                        this.KeySerializer = (ISerializer<K>)(new Utf32Serializer());
+                        this.KeySerializer = new WrappedSyncSegmentSerializer<K>((ISerializer<K>)new Utf32Serializer());
                     }
                 }
 
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     if (ValueSerializer == null && AsyncValueSerializer == null)
                     {
-                        this.ValueSerializer = (ISerializer<V>)(new Utf32Serializer());
+                        this.ValueSerializer = new WrappedSyncSegmentSerializer<V>((ISerializer<V>)new Utf32Serializer());
                     }
                 }
                 


### PR DESCRIPTION
Adjusts the primary serializer interface to return an ArraySegment-wrapped byte array in favor of the byte array itself. It then uses the resulting count and offset fields to be passed into the produce call. The new interface also supports a Release hook which can be used after the produce call has happened.

The primary use case is to allow for pooled arrays to be written to, or recycled streams' internal buffers. This helps a lot when writing data greater than 85K which would ordinary require LOH allocations and greatly impact the performance of the service. 

I made the adjustment so there should be no breaking changes - the builder interfaces just "upgrade" the old variant serializers by wrapping them. The producer class internally uses the new interfaces only. The release methods are no-op on the wrapped serializers. 

