### PR TITLE
Do not calculate statistics json length as it is already provided by librdkafka

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -112,7 +112,7 @@ namespace Confluent.Kafka
             try
             {
                 // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
-                statisticsHandler?.Invoke(Util.Marshal.PtrToStringUTF8(json));
+                statisticsHandler?.Invoke(Util.Marshal.PtrToStringUTF8(json, json_len));
             }
             catch (Exception e)
             {

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -69,6 +69,16 @@ namespace Confluent.Kafka.Internal
                 return Encoding.UTF8.GetString((byte*)strPtr.ToPointer(), length);
             }
 
+            public unsafe static string PtrToStringUTF8(IntPtr strPtr, UIntPtr strLength)
+            {
+                if (strPtr == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                return Encoding.UTF8.GetString((byte*)strPtr.ToPointer(), (int)strLength);
+            }
+
             public static T PtrToStructure<T>(IntPtr ptr)
             {
                 return SystemMarshal.PtrToStructure<T>(ptr);


### PR DESCRIPTION
No need to traverse long strings