### PR TITLE
Distributed Tracing: Producer OpenTelemetry instrumentation

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -13,7 +13,7 @@
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
     <VersionPrefix>1.8.2</VersionPrefix>
-    <TargetFrameworks>net462;net6.0;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -13,7 +13,7 @@
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
     <VersionPrefix>1.8.2</VersionPrefix>
-    <TargetFrameworks>net462;net5.0;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
@@ -24,7 +24,8 @@
     <PackageReference Include="librdkafka.redist" Version="1.8.2">
         <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Confluent.Kafka/Diagnostics.cs
+++ b/src/Confluent.Kafka/Diagnostics.cs
@@ -18,16 +18,22 @@ using System.Diagnostics;
 
 namespace Confluent.Kafka
 {
+    /// <summary>
+    /// Implements Activity objects with OpenTelemetry messaging tags for instrumentation
+    /// </summary>
     internal static class Diagnostics
     {
         private const string ActivitySourceName = "Confluent.Kafka";
         public static ActivitySource ActivitySource { get; } = new ActivitySource(ActivitySourceName);
 
-        public static class Producer
+        /// <summary>
+        /// Provides an Activity object for the Producer with OpenTelemetry messaging tags for instrumentation
+        /// </summary>
+        internal static class Producer
         {
-            public const string ActivityName = ActivitySourceName + ".MessageProduced";
+            private const string ActivityName = ActivitySourceName + ".MessageProduced";
 
-            public static Activity Start<TKey, TValue>(TopicPartition topicPartition, Message<TKey, TValue> message)
+            internal static Activity Start<TKey, TValue>(TopicPartition topicPartition, Message<TKey, TValue> message)
             {
                 Activity activity = ActivitySource.StartActivity(ActivityName);
 

--- a/src/Confluent.Kafka/Diagnostics.cs
+++ b/src/Confluent.Kafka/Diagnostics.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System.Diagnostics;
+using System.Text;
 
 namespace Confluent.Kafka
 {
@@ -54,10 +55,13 @@ namespace Confluent.Kafka
             TopicPartition topicPartition,
             Message<TKey, TValue> message)
         {
+            int messagePayloadBytes = Encoding.UTF8.GetByteCount(message.Value.ToString());
+
             activity?.AddTag(OpenTelemetryMessaging.SYSTEM, "kafka");
             activity?.AddTag(OpenTelemetryMessaging.DESTINATION, topicPartition.Topic);
             activity?.AddTag(OpenTelemetryMessaging.DESTINATION_KIND, "topic");
             activity?.AddTag(OpenTelemetryMessaging.KAFKA_PARTITION, topicPartition.Partition.Value.ToString());
+            activity?.AddTag(OpenTelemetryMessaging.MESSAGE_PAYLOAD_SIZE_BYTES, messagePayloadBytes.ToString());
 
             if (message.Key != null)
                 activity?.AddTag(OpenTelemetryMessaging.KAFKA_MESSAGE_KEY, message.Key);

--- a/src/Confluent.Kafka/Diagnostics.cs
+++ b/src/Confluent.Kafka/Diagnostics.cs
@@ -15,7 +15,6 @@
 // Refer to LICENSE for more information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace Confluent.Kafka
 {
@@ -49,13 +48,13 @@ namespace Confluent.Kafka
             TopicPartition topicPartition,
             Message<TKey, TValue> message)
         {
-            activity?.AddTag("messaging.system", "kafka");
-            activity?.AddTag("messaging.destination", topicPartition.Topic);
-            activity?.AddTag("messaging.destination_kind", "topic");
-            activity?.AddTag("messaging.kafka.partition", topicPartition.Partition.Value.ToString());
+            activity?.AddTag(OpenTelemetryMessaging.SYSTEM, "kafka");
+            activity?.AddTag(OpenTelemetryMessaging.DESTINATION, topicPartition.Topic);
+            activity?.AddTag(OpenTelemetryMessaging.DESTINATION_KIND, "topic");
+            activity?.AddTag(OpenTelemetryMessaging.KAFKA_PARTITION, topicPartition.Partition.Value.ToString());
 
             if (message.Key != null)
-                activity?.AddTag("messaging.kafka.message_key", message.Key);
+                activity?.AddTag(OpenTelemetryMessaging.KAFKA_MESSAGE_KEY, message.Key);
 
             return activity;
         }

--- a/src/Confluent.Kafka/Diagnostics.cs
+++ b/src/Confluent.Kafka/Diagnostics.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2022 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Confluent.Kafka
+{
+    internal static class Diagnostics
+    {
+        public const string ActivitySourceName = "Confluent.Kafka.Activity";
+        public static ActivitySource ActivitySource { get; } = new ActivitySource(ActivitySourceName);
+
+        public static class Producer
+        {
+            public const string ActivityName = ActivitySourceName + ".MessageProduced";
+
+            public static Activity Start <TKey, TValue>(string topic, Message<TKey, TValue> message)
+            {
+                Activity activity = ActivitySource.StartActivity(ActivityName);
+
+                if (activity == null)
+                    return null;
+
+                using (activity)
+                {
+                    activity?.AddDefaultOpenTelemetryTags(topic, message);
+                }
+
+                return activity;
+            }
+
+            public static Activity Start<TKey, TValue>(TopicPartition topicPartition, Message<TKey, TValue> message)
+            {
+                Activity activity = ActivitySource.StartActivity(ActivityName);
+
+                if (activity == null)
+                    return null;
+
+                using (activity)
+                {
+                    activity?.AddDefaultOpenTelemetryTags(topicPartition.Topic, message);
+                    activity?.AddTag("messaging.kafka.partition", topicPartition.Partition.Value);
+                }
+
+                return activity;
+            }
+        }
+
+        private static Activity AddDefaultOpenTelemetryTags<TKey, TValue>(this Activity activity, string topic, Message<TKey, TValue> message)
+        {
+            activity?.AddTag("messaging.system", "kafka");
+            activity?.AddTag("messaging.destination", topic);
+            activity?.AddTag("messaging.destination_kind", "topic");
+
+            if (message.Key != null)
+                activity?.AddTag("messaging.kafka.message_key", message.Key);
+
+            if (message.Value != null)
+                activity?.AddTag("messaging.message_payload_size_bytes", Marshal.SizeOf(message.Value));
+
+            return activity;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Diagnostics.cs
+++ b/src/Confluent.Kafka/Diagnostics.cs
@@ -42,22 +42,6 @@ namespace Confluent.Kafka
 
                 return activity;
             }
-
-            public static Activity Start<TKey, TValue>(TopicPartition topicPartition, Message<TKey, TValue> message)
-            {
-                Activity activity = ActivitySource.StartActivity(ActivityName);
-
-                if (activity == null)
-                    return null;
-
-                using (activity)
-                {
-                    activity?.AddDefaultOpenTelemetryTags(topicPartition.Topic, message);
-                    activity?.AddTag("messaging.kafka.partition", topicPartition.Partition.Value);
-                }
-
-                return activity;
-            }
         }
 
         private static Activity AddDefaultOpenTelemetryTags<TKey, TValue>(this Activity activity, string topic, Message<TKey, TValue> message)

--- a/src/Confluent.Kafka/Diagnostics.cs
+++ b/src/Confluent.Kafka/Diagnostics.cs
@@ -21,7 +21,7 @@ namespace Confluent.Kafka
 {
     internal static class Diagnostics
     {
-        public const string ActivitySourceName = "Confluent.Kafka";
+        private const string ActivitySourceName = "Confluent.Kafka";
         public static ActivitySource ActivitySource { get; } = new ActivitySource(ActivitySourceName);
 
         public static class Producer
@@ -38,7 +38,6 @@ namespace Confluent.Kafka
                 using (activity)
                 {
                     activity?.AddDefaultOpenTelemetryTags(topicPartition, message);
-                    activity?.AddTag("messaging.kafka.partition", topicPartition.Partition.Value);
                 }
 
                 return activity;
@@ -53,13 +52,10 @@ namespace Confluent.Kafka
             activity?.AddTag("messaging.system", "kafka");
             activity?.AddTag("messaging.destination", topicPartition.Topic);
             activity?.AddTag("messaging.destination_kind", "topic");
-            activity?.AddTag("messaging.kafka.partition", topicPartition.Partition.Value);
+            activity?.AddTag("messaging.kafka.partition", topicPartition.Partition.Value.ToString());
 
             if (message.Key != null)
                 activity?.AddTag("messaging.kafka.message_key", message.Key);
-
-            if (message.Value != null)
-                activity?.AddTag("messaging.message_payload_size_bytes", Marshal.SizeOf(message.Value));
 
             return activity;
         }

--- a/src/Confluent.Kafka/OpenTelemetryMessaging.cs
+++ b/src/Confluent.Kafka/OpenTelemetryMessaging.cs
@@ -46,5 +46,10 @@ namespace Confluent.Kafka
         /// Kafka message key.
         /// </summary>
         public const string KAFKA_MESSAGE_KEY = "messaging.kafka.message_key";
+
+        /// <summary>
+        /// Kafka message payload size (bytes).
+        /// </summary>
+        public const string MESSAGE_PAYLOAD_SIZE_BYTES = "messaging.message_payload_size_bytes";
     }
 }

--- a/src/Confluent.Kafka/OpenTelemetryMessaging.cs
+++ b/src/Confluent.Kafka/OpenTelemetryMessaging.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2022 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    /// Provides the OpenTelemetry messaging attributes.
+    /// The complete list of messaging attributes specification is available here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#messaging-attributes
+    /// </summary>
+    public static class OpenTelemetryMessaging
+    {
+        /// <summary>
+        /// Message system. For Kafka, attribute value must be "kafka".
+        /// </summary>
+        public const string SYSTEM = "messaging.system";
+
+        /// <summary>
+        /// Message destination. For Kafka, attribute value must be a Kafka topic.
+        /// </summary>
+        public const string DESTINATION = "messaging.destination";
+
+        /// <summary>
+        /// Destination kind. For Kafka, attribute value must be "topic".
+        /// </summary>
+        public const string DESTINATION_KIND = "messaging.destination_kind";
+
+        /// <summary>
+        /// Kafka partition number.
+        /// </summary>
+        public const string KAFKA_PARTITION = "messaging.kafka.partition";
+
+        /// <summary>
+        /// Kafka message key.
+        /// </summary>
+        public const string KAFKA_MESSAGE_KEY = "messaging.kafka.message_key";
+    }
+}

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -16,7 +16,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -581,7 +584,9 @@ namespace Confluent.Kafka
 
             this.DeliveryReportCallback = DeliveryReportCallbackImpl;
 
-            Librdkafka.Initialize(null);
+            string pathToLibrd = Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(Directory.GetCurrentDirectory())), "Debug\\net6.0\\librdkafka\\x64\\librdkafka.dll");
+
+            Librdkafka.Initialize(pathToLibrd);
 
             var modifiedConfig = Library.NameAndVersionConfig
                 .Concat(config
@@ -784,6 +789,8 @@ namespace Confluent.Kafka
                     ex);
             }
 
+            Activity activity = Diagnostics.Producer.Start(topicPartition, message);
+
             try
             {
                 if (enableDeliveryReports)
@@ -835,6 +842,10 @@ namespace Confluent.Kafka
                         Message = message,
                         TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
                     });
+            }
+            finally
+            {
+                activity?.Stop();
             }
         }
 
@@ -907,6 +918,8 @@ namespace Confluent.Kafka
                     ex);
             }
 
+            Activity activity = Diagnostics.Producer.Start(topicPartition, message);
+
             try
             {
                 ProduceImpl(
@@ -932,6 +945,10 @@ namespace Confluent.Kafka
                             Message = message,
                             TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
                         });
+            }
+            finally
+            {
+                activity?.Stop();
             }
         }
 

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -584,9 +584,7 @@ namespace Confluent.Kafka
 
             this.DeliveryReportCallback = DeliveryReportCallbackImpl;
 
-            string pathToLibrd = Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(Directory.GetCurrentDirectory())), "Debug\\net6.0\\librdkafka\\x64\\librdkafka.dll");
-
-            Librdkafka.Initialize(pathToLibrd);
+            Librdkafka.Initialize(null);
 
             var modifiedConfig = Library.NameAndVersionConfig
                 .Concat(config

--- a/test/Confluent.Kafka.IntegrationTests/ActivityEventsRecorder.cs
+++ b/test/Confluent.Kafka.IntegrationTests/ActivityEventsRecorder.cs
@@ -1,0 +1,54 @@
+﻿// Copyright 2022 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    internal class ActivityEventsRecorder
+    {
+        internal ConcurrentQueue<KeyValuePair<string, IEnumerable<KeyValuePair<string, string>>>> Events = new();
+        private readonly string activityName;
+
+        internal ActivityEventsRecorder(string activityName)
+        {
+            this.activityName = activityName;
+        }
+
+        internal ActivityListener BuildActivityListener()
+        {
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    if (activity.DisplayName == activityName)
+                        Events.Enqueue(new KeyValuePair<string, IEnumerable<KeyValuePair<string, string>>>(activity.Id, activity.Tags));
+                },
+                ActivityStopped = activity =>
+                {
+                    if (activity.DisplayName == activityName)
+                        Events.Enqueue(new KeyValuePair<string, IEnumerable<KeyValuePair<string, string>>>(activity.Id, activity.Tags));
+                }
+            };
+
+            return listener;
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/ActivityEventsRecorder.cs
+++ b/test/Confluent.Kafka.IntegrationTests/ActivityEventsRecorder.cs
@@ -30,6 +30,10 @@ namespace Confluent.Kafka.IntegrationTests
             this.activityName = activityName;
         }
 
+        /// <summary>
+        /// Builds an ActivityListener with callbacks to store start and stop events to a concurrent queue.
+        /// </summary>
+        /// <returns></returns>
         internal ActivityListener BuildActivityListener()
         {
             using var listener = new ActivityListener

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
@@ -85,6 +85,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.DESTINATION && tag.Value == singlePartitionTopic);
                 Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.KAFKA_PARTITION && tag.Value == "0");
                 Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.KAFKA_MESSAGE_KEY && tag.Value.Contains("test key"));
+                Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.MESSAGE_PAYLOAD_SIZE_BYTES && tag.Value == "10");
             }
         }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
@@ -80,11 +80,11 @@ namespace Confluent.Kafka.IntegrationTests
             // Check if default OpenTelemetry attributes were created on start events
             foreach (IEnumerable<KeyValuePair<string, string>> startEventTags in startEventsTags)
             {
-                Assert.Contains(startEventTags, tag => tag.Key == "messaging.system" && tag.Value == "kafka");
-                Assert.Contains(startEventTags, tag => tag.Key == "messaging.destination_kind" && tag.Value == "topic");
-                Assert.Contains(startEventTags, tag => tag.Key == "messaging.destination" && tag.Value == singlePartitionTopic);
-                Assert.Contains(startEventTags, tag => tag.Key == "messaging.kafka.partition" && tag.Value == "0");
-                Assert.Contains(startEventTags, tag => tag.Key == "messaging.kafka.message_key" && tag.Value.Contains("test key"));
+                Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.SYSTEM && tag.Value == "kafka");
+                Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.DESTINATION_KIND && tag.Value == "topic");
+                Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.DESTINATION && tag.Value == singlePartitionTopic);
+                Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.KAFKA_PARTITION && tag.Value == "0");
+                Assert.Contains(startEventTags, tag => tag.Key == OpenTelemetryMessaging.KAFKA_MESSAGE_KEY && tag.Value.Contains("test key"));
             }
         }
 


### PR DESCRIPTION
This PR introduces a distributed tracing instrumentation for the Producer by leveraging the use of `Activity` objects with tags mapping the [OpenTelemetry messaging attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#messaging-attributes) specification. 

The implementation is inspired on the great discussion on issue #1269  and the @CodeBlanch's proposal on the PR #1278.