### PR TITLE
Limit splitting auth info to a max of 2 parts

### DIFF
--- a/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
@@ -164,7 +164,7 @@ namespace Confluent.SchemaRegistry
             {
                 if (basicAuthInfo != "")
                 {
-                    var userPass = (basicAuthInfo).Split(':');
+                    var userPass = basicAuthInfo.Split(new char[] { ':' }, 2);
                     if (userPass.Length != 2)
                     {
                         throw new ArgumentException($"Configuration property {SchemaRegistryConfig.PropertyNames.SchemaRegistryBasicAuthUserInfo} must be of the form 'username:password'.");


### PR DESCRIPTION
Fixes #1767 (CachedSchemaRegistryClient.cs does not support passwords that include ':' character)