### PR TITLE
[DRAFT] feat: Add distributed tracing

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -24,7 +24,8 @@
     <PackageReference Include="librdkafka.redist" Version="1.9.2">
         <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Confluent.Kafka/Diagnostics/Conventions.cs
+++ b/src/Confluent.Kafka/Diagnostics/Conventions.cs
@@ -1,0 +1,100 @@
+namespace Confluent.Kafka.Diagnostics
+{
+    /// <summary>
+    /// The conventions in OTel are still work-in-progress (Status: Experimental).
+    /// </summary>
+    internal static class Conventions
+    {
+        internal static class OperationName
+        {
+            /// <summary>
+            /// A message is sent to a destination by a message producer/client.
+            /// </summary>
+            public const string Send = "send";
+
+            /// <summary>
+            /// A message is received from a destination by a message consumer/server.
+            /// </summary>
+            public const string Receive = "receive";
+
+            /// <summary>
+            /// A message that was previously received from a destination is processed by a message consumer/server.
+            /// </summary>
+            public const string Process = "process";
+        }
+
+        /// <summary>
+        /// Provides the OpenTelemetry messaging attributes.
+        /// The complete list of messaging attributes specification is available here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#messaging-attributes
+        /// </summary>
+        internal static class MessagingTag
+        {
+            /// <summary>
+            /// A string identifying the messaging system.
+            /// For Kafka, attribute value must be "kafka".
+            /// </summary>
+            public const string System = "messaging.system";
+
+            /// <summary>
+            /// The message destination name. This might be equal to the span name but is required nevertheless.
+            /// For Kafka, attribute value must be a Kafka topic.
+            /// </summary>
+            public const string Destination = "messaging.destination";
+
+            /// <summary>
+            /// The kind of message destination.
+            /// For Kafka, attribute value must be "topic".
+            /// </summary>
+            public const string DestinationKind = "messaging.destination_kind";
+
+            /// <summary>
+            /// The (uncompressed) size of the message payload in bytes.
+            /// Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
+            /// </summary>
+            public const string MessagePayloadSizeBytes = "messaging.message_payload_size_bytes";
+
+            /// <summary>
+            /// A string identifying the kind of message consumption. If the operation is "send", this attribute MUST NOT be set.
+            /// </summary>
+            public const string Operation = "messaging.operation";
+
+            /// <summary>
+            /// The identifier for the consumer receiving a message.
+            /// For Kafka, set it to {messaging.kafka.consumer_group} - {messaging.kafka.client_id}, if both are present, or only messaging.kafka.consumer_group.
+            /// </summary>
+            public const string ConsumerId = "messaging.consumer_id";
+        }
+
+        /// <summary>
+        /// Provides the OpenTelemetry additional attributes for Kafka.
+        /// The complete list of Kafka attributes specification is available here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#apache-kafka
+        /// </summary>
+        internal static class KafkaTag
+        {
+            /// <summary>
+            /// Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
+            /// </summary>
+            public const string MessageKey = "messaging.kafka.message_key";
+
+            /// <summary>
+            /// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
+            /// </summary>
+            public const string ConsumerGroup = "messaging.kafka.consumer_group";
+
+            /// <summary>
+            /// Client Id for the Consumer or Producer that is handling the message.
+            /// </summary>
+            public const string ClientId = "messaging.kafka.client_id";
+
+            /// <summary>
+            /// Partition the message is sent to.
+            /// </summary>
+            public const string Partition = "messaging.kafka.partition";
+
+            /// <summary>
+            /// A boolean that is true if the message is a tombstone.
+            /// </summary>
+            public const string Tombstone = "messaging.kafka.tombstone";
+        }
+    }
+}

--- a/src/Confluent.Kafka/Diagnostics/Diagnostic.cs
+++ b/src/Confluent.Kafka/Diagnostics/Diagnostic.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using static Confluent.Kafka.Diagnostics.Conventions;
+
+namespace Confluent.Kafka.Diagnostics
+{
+    internal static class Diagnostic
+    {
+        private const string ActivitySourceName = "Confluent.Kafka";
+        private const string System = "kafka";
+        private const string DestinationKind = "topic";
+
+        public static ActivitySource ActivitySource { get; } = new ActivitySource(ActivitySourceName);
+
+        /// <summary>
+        /// The span name SHOULD be set to the message destination name and the operation
+        /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#span-name
+        /// </summary>
+        /// <param name="topic">A Kafka topic name.</param>
+        /// <param name="operationName">Operation name.</param>
+        /// <returns></returns>
+        private static string GetSpanName(string topic, string operationName)
+        {
+            return $"{topic} {operationName}";
+        }
+
+        internal static class Producer
+        {
+            internal static Activity StartActivity<TKey, TValue>(TopicPartition topicPartition, Message<TKey, TValue> message)
+            {
+                var spanName = GetSpanName(topicPartition.Topic, OperationName.Send);
+                var initialTags = GetInitialTags(topicPartition, message);
+
+                ActivityContext parentContext = Activity.Current?.Context ?? default;
+
+                var activity = ActivitySource.StartActivity(
+                    spanName,
+                    ActivityKind.Producer,
+                    parentContext,
+                    initialTags);
+
+                if (activity?.IsAllDataRequested ?? false)
+                {
+                    // A message is an envelope with a potentially empty payload.
+                    // This envelope may offer the possibility to convey additional metadata, often in key / value form.
+                    // TODO: How to get the size of the message?
+                    // Is message.ToString() (or message.Value.ToString()) going to be very expensive?
+                    // Ideally getting the size would either be cheap or it would be an opt-in thing for users who need it enough to pay for it.
+                    //var messagePayloadBytes = Encoding.UTF8.GetByteCount(message.ToString() ?? string.Empty); // TODO: we can return null
+                    //activity.SetTag(MessagingTag.MessagePayloadSizeBytes, messagePayloadBytes);
+                }
+
+                return activity;
+            }
+
+            private static ActivityTagsCollection GetInitialTags<TKey, TValue>(
+                TopicPartition topicPartition,
+                Message<TKey, TValue> message)
+            {
+                var initialTags = new ActivityTagsCollection
+                {
+                    [MessagingTag.System] = System,
+                    [MessagingTag.Destination] = topicPartition.Topic,
+                    [MessagingTag.DestinationKind] = DestinationKind,
+
+                    // Apache Kafka
+                    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#apache-kafka
+                    //[KAFKA_MESSAGE_KEY] = ??, TODO: Type = string... convert or serialize?
+                    //[KAFKA_CLIENT_ID] = ??, // TODO: where can I get the data?
+                    [KafkaTag.Partition] = topicPartition.Partition.Value,
+                    //[KAFKA_TOMBSTONE] = ??, // A boolean that is true if the message is a tombstone. TODO: What is it and where can I get the data?
+                };
+                return initialTags;
+            }
+        }
+
+        internal static class Consumer
+        {
+            internal static Activity StartActivity<TKey, TValue>(string topic, int partition)
+            {
+                var spanName = GetSpanName(topic, OperationName.Process);
+                var initialTags = GetInitialTags<TKey, TValue>(topic, partition, OperationName.Process);
+
+                ActivityContext parentContext = default;
+                var activity = ActivitySource.StartActivity(
+                    spanName,
+                    ActivityKind.Consumer,
+                    parentContext,
+                    initialTags);
+
+                if (activity?.IsAllDataRequested ?? false)
+                {
+                    //activity?.SetTag(KAFKA_CONSUMER_GROUP, )
+
+                    // A message is an envelope with a potentially empty payload.
+                    // This envelope may offer the possibility to convey additional metadata, often in key / value form.
+                    // TODO: How to get the size of the message?
+                    // Is message.ToString() (or message.Value.ToString()) going to be very expensive?
+                    // Ideally getting the size would either be cheap or it would be an opt-in thing for users who need it enough to pay for it.
+                    //var messagePayloadBytes = Encoding.UTF8.GetByteCount(message.ToString() ?? string.Empty); // TODO: we can return null
+                    //activity.SetTag(MessagingTag.MessagePayloadSizeBytes, messagePayloadBytes);
+                }
+
+                return activity;
+            }
+        }
+
+        private static ActivityTagsCollection GetInitialTags<TKey, TValue>(
+            string topic,
+            int partition,
+            string operation)
+        {
+            var initialTags = new ActivityTagsCollection
+            {
+                [MessagingTag.System] = System,
+                [MessagingTag.Destination] = topic,
+                [MessagingTag.DestinationKind] = DestinationKind,
+
+                [MessagingTag.Operation] = operation,
+                [MessagingTag.ConsumerId] = "", // TODO: add consumer_id
+
+                // Apache Kafka
+                // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#apache-kafka
+                //[KAFKA_MESSAGE_KEY] = ??, TODO: Type = string... convert or serialize?
+                //[KAFKA_CONSUMER_GROUP] = ??, TODO: where can I get the data? Only applies to consumers, not producers.
+                //[KAFKA_CLIENT_ID] = ??, // TODO: where can I get the data?
+                [KafkaTag.Partition] = partition,
+                //[KAFKA_TOMBSTONE] = ??, // A boolean that is true if the message is a tombstone. TODO: What is it and where can I get the data?
+            };
+            return initialTags;
+        }
+    }
+}

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -22,7 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka.Impl;
 using Confluent.Kafka.Internal;
-
+using Confluent.Kafka.Diagnostics;
 
 namespace Confluent.Kafka
 {
@@ -784,6 +784,8 @@ namespace Confluent.Kafka
                     ex);
             }
 
+            var activity = Diagnostic.Producer.StartActivity(topicPartition, message);
+
             try
             {
                 if (enableDeliveryReports)
@@ -828,6 +830,9 @@ namespace Confluent.Kafka
             }
             catch (KafkaException ex)
             {
+#if NET6_0_OR_GREATER
+                activity?.SetStatus(System.Diagnostics.ActivityStatusCode.Error, ex.Message);
+#endif
                 throw new ProduceException<TKey, TValue>(
                     ex.Error,
                     new DeliveryResult<TKey, TValue>
@@ -835,6 +840,10 @@ namespace Confluent.Kafka
                         Message = message,
                         TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
                     });
+            }
+            finally
+            {
+                activity?.Stop();
             }
         }
 
@@ -907,6 +916,8 @@ namespace Confluent.Kafka
                     ex);
             }
 
+            var activity = Diagnostic.Producer.StartActivity(topicPartition, message);
+
             try
             {
                 ProduceImpl(
@@ -925,6 +936,9 @@ namespace Confluent.Kafka
             }
             catch (KafkaException ex)
             {
+#if NET6_0_OR_GREATER
+                activity?.SetStatus(System.Diagnostics.ActivityStatusCode.Error, ex.Message);
+#endif
                 throw new ProduceException<TKey, TValue>(
                     ex.Error,
                     new DeliveryReport<TKey, TValue>
@@ -932,6 +946,10 @@ namespace Confluent.Kafka
                             Message = message,
                             TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
                         });
+            }
+            finally
+            {
+                activity?.Stop();
             }
         }
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.11.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
This DRAFT PR introduces a distributed tracing instrumentation for the Producer and Consumer by leveraging the use of Activity objects with tags mapping the OpenTelemetry messaging attributes [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#messaging-attributes).

This is a continuation of the PR #1838.

- [ ] Determine the best place to start activities.
- [ ] Determine which attributes can be filled
- [ ] Add an extension method for connecting traces (see what options there may be)
- [ ] Discuss passing trace ID and span ID inside headers (I think it's better to take out a separate PR).