### PR TITLE
Expose serialiser schema ID

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Avro/IAvroSerializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/IAvroSerializerImpl.cs
@@ -22,5 +22,6 @@ namespace Confluent.SchemaRegistry.Serdes
     internal interface IAvroSerializerImpl<T>
     {
         Task<byte[]> Serialize(string topic, T data, bool isKey);
+        Task<int?> GetSchemaId(string topic, T data, bool isKey);
     }
 }


### PR DESCRIPTION
I have a use case where we would like to attach the schema ID as a header to our Kafka messages instead of the serialised wire format.

Ideally we would still prefer to stay compatible with the Confluent library and use that in our code but stop short of actually serialising the inputs.

This PR is a proposal to refactor the Schema Registry schema registration into a separate private method for each serialiser class and expose a public getter to retrieve the Schema ID - no new functionality of other behaviour change is intended.