### PR TITLE
Fix inadvertent and misleading use of new Guid()

### DIFF
--- a/examples/Consumer/Program.cs
+++ b/examples/Consumer/Program.cs
@@ -160,7 +160,7 @@ namespace Confluent.Kafka.Examples.ConsumerExample
             {
                 // the group.id property must be specified when creating a consumer, even 
                 // if you do not intend to use any consumer group functionality.
-                GroupId = new Guid().ToString(),
+                GroupId = Guid.NewGuid().ToString(),
                 BootstrapServers = brokerList,
                 // partition offsets can be committed to a group even by consumers not
                 // subscribed to the group. in this example, auto commit is disabled

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AutoRegisterSchemaDisabled.cs
@@ -60,7 +60,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     Assert.Throws<SchemaRegistryException>(() =>
                     {
-                        string guidTopic = new Guid().ToString();
+                        string guidTopic = Guid.NewGuid().ToString();
                         try
                         {
                             producer


### PR DESCRIPTION
new Guid() gives `00000000-0000-0000-0000-000000000000`, `Guid.NewGuid()` gives a new unique guid, which is the intent.