### PR TITLE
Add default rebalance callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Fixes
 
-- Added default rebalance callback handler to prevent consumers not having partition revoked handlers from entering into the erroneous state.
+- During a group rebalance, partitions are now always revoked as a side effect of a call to Consume, whether or not a partitions revoked handler has been specified. Previously, if no handler was specified, the timing of when the consumer lost ownership of partitions during a rebalance was arbitrarily, frequently resulting in an erroneous state exception when committing or storing offsets.
 
 
 # 1.9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Upgraded `NJsonSchema` to v10.6.3
 - Added `LatestCompatibilityStrict` configuration property to JsonSerializerConfig to check the compatibility with latest schema
   when `UseLatestVersion` is set to true.
+- Added DeleteConsumerGroupOffset to AdminClient.
+
+## Fixes
+
+- Added default rebalance callback handler to prevent consumers not having partition revoked handlers from entering into the erroneous state.
 
 
 # 1.9.4

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -691,10 +691,14 @@ namespace Confluent.Kafka
 
             IntPtr configPtr = configHandle.DangerousGetHandle();
 
-            if (partitionsAssignedHandler != null || partitionsRevokedHandler != null || partitionsLostHandler != null)
-            {
-                Librdkafka.conf_set_rebalance_cb(configPtr, rebalanceDelegate);
-            }
+            // if (partitionsAssignedHandler != null || partitionsRevokedHandler != null || partitionsLostHandler != null)
+            // {
+            //     Librdkafka.conf_set_rebalance_cb(configPtr, rebalanceDelegate);
+            // }
+
+            // Set the rebalance callback always to prevent the consumer from entering in erroneous state trap.
+            Librdkafka.conf_set_rebalance_cb(configPtr, rebalanceDelegate);
+
             if (offsetsCommittedHandler != null)
             {
                 Librdkafka.conf_set_offset_commit_cb(configPtr, commitDelegate);

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -691,7 +691,6 @@ namespace Confluent.Kafka
 
             IntPtr configPtr = configHandle.DangerousGetHandle();
 
-            // Set the rebalance callback always to prevent the consumer from entering in erroneous state trap.
             Librdkafka.conf_set_rebalance_cb(configPtr, rebalanceDelegate);
 
             if (offsetsCommittedHandler != null)

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -691,11 +691,6 @@ namespace Confluent.Kafka
 
             IntPtr configPtr = configHandle.DangerousGetHandle();
 
-            // if (partitionsAssignedHandler != null || partitionsRevokedHandler != null || partitionsLostHandler != null)
-            // {
-            //     Librdkafka.conf_set_rebalance_cb(configPtr, rebalanceDelegate);
-            // }
-
             // Set the rebalance callback always to prevent the consumer from entering in erroneous state trap.
             Librdkafka.conf_set_rebalance_cb(configPtr, rebalanceDelegate);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Drain.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Drain.cs
@@ -60,6 +60,7 @@ namespace Confluent.Kafka.IntegrationTests
                     while (consumer.Assignment.Count == 0)
                     {
                         Thread.Sleep(1000);
+                        consumer.Consume(TimeSpan.FromSeconds(1));
                         Assert.True(cnt++ < 10);
                     }
                     var committed = consumer.Committed(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset_ErrState.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset_ErrState.cs
@@ -60,7 +60,10 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer2.Subscribe(topic.Name);
 
                 // wait until each consumer is assigned to one partition.
-                cr = consumer2.Consume();
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                
+                cr = consumer2.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(1, consumer1.Assignment.Count);
 
                 // StoreOffset should throw when attempting to assign to a

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription_DisjointTopics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription_DisjointTopics.cs
@@ -59,6 +59,10 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(topic1.Name, consumer1.Assignment[0].Topic);
 
                 consumer2.Subscribe(topic2.Name);
+                // Allow rebalance to complete 
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
                 consumer1.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(4, consumer1.Assignment.Count);
                 Assert.Equal(topic1.Name, consumer1.Assignment[0].Topic);
@@ -67,6 +71,11 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(topic2.Name, consumer2.Assignment[0].Topic);
 
                 consumer3.Subscribe(topic3.Name);
+                // Allow rebalance to complete 
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
                 consumer1.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(4, consumer1.Assignment.Count);
                 Assert.Equal(topic1.Name, consumer1.Assignment[0].Topic);
@@ -78,6 +87,12 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(topic3.Name, consumer3.Assignment[0].Topic);
 
                 consumer4.Subscribe(topic4.Name);
+                // Allow rebalance to complete 
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
                 consumer1.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(4, consumer1.Assignment.Count);
                 Assert.Equal(topic1.Name, consumer1.Assignment[0].Topic);
@@ -92,6 +107,14 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(topic4.Name, consumer4.Assignment[0].Topic);
 
                 consumer5.Subscribe(topic2.Name);
+                // Allow rebalance to complete 
+                consumer5.Consume(TimeSpan.FromSeconds(10));
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
+                consumer2.Consume(TimeSpan.FromSeconds(10));
                 consumer5.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(2, consumer2.Assignment.Count);
                 Assert.Equal(2, consumer5.Assignment.Count);
@@ -99,6 +122,20 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(topic2.Name, consumer5.Assignment[0].Topic);
 
                 consumer6.Subscribe(new List<string> { topic3.Name, topic4.Name });
+                // Allow rebalance to complete 
+                consumer6.Consume(TimeSpan.FromSeconds(10));
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer5.Consume(TimeSpan.FromSeconds(10));
+                consumer6.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer5.Consume(TimeSpan.FromSeconds(10));
                 consumer6.Consume(TimeSpan.FromSeconds(10));
                 Assert.True(consumer3.Assignment.Count > 0);
                 Assert.True(consumer4.Assignment.Count > 0);
@@ -109,11 +146,38 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(consumer6.Assignment[0].Topic == topic3.Name || consumer6.Assignment[0].Topic == topic4.Name);
 
                 consumer1.Unsubscribe();
-                consumer2.Consume(TimeSpan.FromSeconds(10)); // wait for rebalance.
-                Assert.Equal(0, consumer1.Assignment.Count);
+                // Allow rebalance to complete 
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer5.Consume(TimeSpan.FromSeconds(10));
+                consumer6.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer5.Consume(TimeSpan.FromSeconds(10));
+                consumer6.Consume(TimeSpan.FromSeconds(10));
 
+                Assert.Equal(0, consumer1.Assignment.Count);
+                // Allow rebalance to complete 
                 consumer1.Subscribe(topic1.Name);
                 consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer5.Consume(TimeSpan.FromSeconds(10));
+                consumer6.Consume(TimeSpan.FromSeconds(10));
+                // Get the assignment
+                consumer1.Consume(TimeSpan.FromSeconds(10));
+                consumer2.Consume(TimeSpan.FromSeconds(10));
+                consumer3.Consume(TimeSpan.FromSeconds(10));
+                consumer4.Consume(TimeSpan.FromSeconds(10));
+                consumer5.Consume(TimeSpan.FromSeconds(10));
+                consumer6.Consume(TimeSpan.FromSeconds(10));
+
                 Assert.Equal(4, consumer1.Assignment.Count);
                 Assert.Equal(topic1.Name, consumer1.Assignment[0].Topic);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription_Regex.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Subscription_Regex.cs
@@ -64,15 +64,18 @@ namespace Confluent.Kafka.IntegrationTests
                 // discovered and corresponding rebalance.
                 using var topic3 = new TemporaryTopic(prefix, bootstrapServers, 1);
                 Thread.Sleep(topicMetadataRefreshPeriodMs + rebalanceWaitMs);
+                consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(3, consumer.Assignment.Count);
 
                 // Repeat a couple more times... 
                 using var topic4 = new TemporaryTopic(prefix, bootstrapServers, 1);
                 Thread.Sleep(topicMetadataRefreshPeriodMs + rebalanceWaitMs);
+                consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(4, consumer.Assignment.Count);
 
                 using var topic5 = new TemporaryTopic(prefix, bootstrapServers, 1);
                 Thread.Sleep(topicMetadataRefreshPeriodMs + rebalanceWaitMs);
+                consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.Equal(5, consumer.Assignment.Count);
 
                 consumer.Close();


### PR DESCRIPTION
Added default rebalance callback handler to prevent consumers not having partition revoked handlers from entering into the erroneous state.

Consumers might enter into erroneous state as they might have lost the partitions during rebalance but still they are committing the offsets for them as they aren't aware of the changes.

Some changes were needed to the tests to make sure the rebalance is running properly.

### Testing

Verified all the integration tests are working.