### PR TITLE
Use schema from ISpecificRecord instead of reflecting a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added SetSaslCredentials. This new method (on the Producer, Consumer, and AdminClient) allows modifying the stored
   SASL PLAIN/SCRAM credentials that will be used for subsequent (new) connections to a broker (#1980).
 - Fixed `OverflowException` thrown intermittently when using the `ListGroup` method (#2003).
+- Changed the way the `_SCHEMA` filed is accessed internally from reflecting the static field to accessing it from the instance. 
 
 
 # 2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added SetSaslCredentials. This new method (on the Producer, Consumer, and AdminClient) allows modifying the stored
   SASL PLAIN/SCRAM credentials that will be used for subsequent (new) connections to a broker (#1980).
 - Fixed `OverflowException` thrown intermittently when using the `ListGroup` method (#2003).
-- Changed the way the `_SCHEMA` filed is accessed internally from reflecting the static field to accessing it from the instance. 
+- Changed the way the `_SCHEMA` filed is accessed internally from reflecting the static field to accessing it from the instance ([AlexeyRaga](https://github.com/AlexeyRaga)).
 
 
 # 2.0.2

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificDeserializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificDeserializerImpl.cs
@@ -53,7 +53,7 @@ namespace Confluent.SchemaRegistry.Serdes
 
             if (typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
             {
-                ReaderSchema = (global::Avro.Schema)typeof(T).GetField("_SCHEMA", BindingFlags.Public | BindingFlags.Static).GetValue(null);
+                ReaderSchema = ((ISpecificRecord)Activator.CreateInstance<T>()).Schema;
             }
             else if (typeof(T).Equals(typeof(int)))
             {

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
@@ -123,7 +123,7 @@ namespace Confluent.SchemaRegistry.Serdes
             SerializerSchemaData serializerSchemaData = new SerializerSchemaData();
             if (typeof(ISpecificRecord).IsAssignableFrom(writerType))
             {
-                serializerSchemaData.WriterSchema = ((ISpecificRecord)Activator.CreateInstance<T>()).Schema;
+                serializerSchemaData.WriterSchema = ((ISpecificRecord)Activator.CreateInstance(writerType)).Schema;
             }
             else if (writerType.Equals(typeof(int)))
             {

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
@@ -123,7 +123,7 @@ namespace Confluent.SchemaRegistry.Serdes
             SerializerSchemaData serializerSchemaData = new SerializerSchemaData();
             if (typeof(ISpecificRecord).IsAssignableFrom(writerType))
             {
-                serializerSchemaData.WriterSchema = (global::Avro.Schema) writerType.GetField("_SCHEMA", BindingFlags.Public | BindingFlags.Static).GetValue(null);
+                serializerSchemaData.WriterSchema = ((ISpecificRecord)Activator.CreateInstance<T>()).Schema;
             }
             else if (writerType.Equals(typeof(int)))
             {


### PR DESCRIPTION
Use `ISpecificRecord` interface to get the schema instead of reflecting the static `_SCHEMA` field which is not a part of an interface. 

Address #1958. 