### PR TITLE
Disable sticky partitioning for null key producer in CustomPartitionerTest

### DIFF
--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_CustomPartitioner.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_CustomPartitioner.cs
@@ -117,6 +117,11 @@ namespace Confluent.Kafka.IntegrationTests
 
 
             // Null key
+            producerConfig = new ProducerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                StickyPartitioningLingerMs = 0 // disable sticky partitioning and run the default partitioner for null keys.
+            };
 
             using (var topic = new TemporaryTopic(bootstrapServers, PARTITION_COUNT))
             using (var producer = new ProducerBuilder<Null, string>(producerConfig)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_CustomPartitioner.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_CustomPartitioner.cs
@@ -117,6 +117,7 @@ namespace Confluent.Kafka.IntegrationTests
 
 
             // Null key
+            var partitionerCalledTimes = 0;
             producerConfig = new ProducerConfig
             {
                 BootstrapServers = bootstrapServers,
@@ -128,12 +129,14 @@ namespace Confluent.Kafka.IntegrationTests
                 .SetDefaultPartitioner((string topicName, int partitionCount, ReadOnlySpan<byte> keyData, bool keyIsNull) =>
                 {
                     Assert.True(keyIsNull);
+                    partitionerCalledTimes++;
                     return 0;
                 })
                 .Build())
             {
                 producer.Produce(topic.Name, new Message<Null, string> { Value = "test value" });
                 producer.Flush(TimeSpan.FromSeconds(10));
+                Assert.Equal(1, partitionerCalledTimes);
             }
 
             Assert.Equal(0, Library.HandleCount);


### PR DESCRIPTION
### Description

From #1955. 

Updated test for null key producer so that assertions inside the partitioner are actually called.


### Testing

Verified through logs that the partitioner is getting called.