### PR TITLE
Add service.yml for adding project to the semaphore CI

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,11 @@
+name: confluent-kafka-dotnet
+lang: unknown
+lang_version: unknown
+git:
+  enable: true
+github:
+  enable: true
+  repo_name: confluentinc/confluent-kafka-dotnet
+semaphore:
+  enable: true
+  pipeline_enable: false


### PR DESCRIPTION
Taken reference from internal wikis and existing binding files
* https://github.com/confluentinc/confluent-kafka-go/blob/master/service.yml
* https://github.com/confluentinc/confluent-kafka-python/blob/master/service.yml

Will create the semaphore project once this is merged and test the CI from there.