### PR TITLE
Serializers: Fix target symbols, using BinaryPrimitives

### DIFF
--- a/src/Confluent.Kafka/Deserializers.cs
+++ b/src/Confluent.Kafka/Deserializers.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers.Binary;
 using System.Text;
 
 
@@ -39,7 +40,7 @@ namespace Confluent.Kafka
                     return null;
                 }
 
-                #if NETCOREAPP2_1
+                #if NETCOREAPP2_1_OR_GREATER
                     return Encoding.UTF8.GetString(data);
                 #else
                     return Encoding.UTF8.GetString(data.ToArray());
@@ -95,16 +96,7 @@ namespace Confluent.Kafka
                     throw new ArgumentException($"Deserializer<Long> encountered data of length {data.Length}. Expecting data length to be 8.");
                 }
 
-                // network byte order -> big endian -> most significant byte in the smallest address.
-                long result = ((long)data[0]) << 56 |
-                    ((long)(data[1])) << 48 |
-                    ((long)(data[2])) << 40 |
-                    ((long)(data[3])) << 32 |
-                    ((long)(data[4])) << 24 |
-                    ((long)(data[5])) << 16 |
-                    ((long)(data[6])) << 8 |
-                    (data[7]);
-                return result;
+                return BinaryPrimitives.ReadInt64BigEndian(data);
             }
         }
 
@@ -127,12 +119,7 @@ namespace Confluent.Kafka
                     throw new ArgumentException($"Deserializer<Int32> encountered data of length {data.Length}. Expecting data length to be 4.");
                 }
 
-                // network byte order -> big endian -> most significant byte in the smallest address.
-                return
-                    (((int)data[0]) << 24) |
-                    (((int)data[1]) << 16) |
-                    (((int)data[2]) << 8) |
-                    (int)data[3];
+                return BinaryPrimitives.ReadInt32BigEndian(data); ;
             }
         }
 
@@ -171,7 +158,7 @@ namespace Confluent.Kafka
                 }
                 else
                 {
-                    #if NETCOREAPP2_1
+                    #if NETCOREAPP2_1_OR_GREATER
                         return BitConverter.ToSingle(data);
                     #else
                         return BitConverter.ToSingle(data.ToArray(), 0);
@@ -219,10 +206,10 @@ namespace Confluent.Kafka
                 }
                 else
                 {
-                    #if NETCOREAPP2_1
-                                    return BitConverter.ToDouble(data);
+                    #if NETCOREAPP2_1_OR_GREATER
+                        return BitConverter.ToDouble(data);
                     #else
-                                    return BitConverter.ToDouble(data.ToArray(), 0);
+                        return BitConverter.ToDouble(data.ToArray(), 0);
                     #endif
                 }
             }

--- a/src/Confluent.Kafka/Serializers.cs
+++ b/src/Confluent.Kafka/Serializers.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers.Binary;
 using System.Text;
 
 
@@ -66,14 +67,8 @@ namespace Confluent.Kafka
             public byte[] Serialize(long data, SerializationContext context)
             {
                 var result = new byte[8];
-                result[0] = (byte)(data >> 56);
-                result[1] = (byte)(data >> 48);
-                result[2] = (byte)(data >> 40);
-                result[3] = (byte)(data >> 32);
-                result[4] = (byte)(data >> 24);
-                result[5] = (byte)(data >> 16);
-                result[6] = (byte)(data >> 8);
-                result[7] = (byte)data;
+                BinaryPrimitives.WriteInt64BigEndian(result, data);
+
                 return result;
             }
         }
@@ -88,15 +83,9 @@ namespace Confluent.Kafka
         {
             public byte[] Serialize(int data, SerializationContext context)
             {
-                var result = new byte[4]; // int is always 32 bits on .NET.
-                // network byte order -> big endian -> most significant byte in the smallest address.
-                // Note: At the IL level, the conv.u1 operator is used to cast int to byte which truncates
-                // the high order bits if overflow occurs.
-                // https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.conv_u1.aspx
-                result[0] = (byte)(data >> 24);
-                result[1] = (byte)(data >> 16); // & 0xff;
-                result[2] = (byte)(data >> 8); // & 0xff;
-                result[3] = (byte)data; // & 0xff;
+                var result = new byte[4];
+                BinaryPrimitives.WriteInt32BigEndian(result, data);
+
                 return result;
             }
         }


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/dotnet/standard/frameworks 

```
- Version-specific symbols are only defined for the version you're targeting.

- The <framework>_OR_GREATER symbols are defined for the version you're targeting and all earlier versions.
```
NETCOREAPP2_1 symbol is defined only for netcoreapp2.1 and then net6.0 library version is compiled with array rather than with span-version of methods. It can be easily checked with decompiler. 

Also thanks to System.Memory nuget reference we have BinaryPrimitives type for converting int to bytes as big endian.