### PR TITLE
Speedup string marshaling for net6+

### DIFF
--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -285,10 +285,25 @@ namespace Confluent.Kafka.Impl
             }
 
             SafeTopicHandle topicHandle = null;
+
+            #if NET6_0_OR_GREATER
+
+            IntPtr topicStringPtr = Marshal.StringToCoTaskMemUTF8(topic);
+            try
+            {
+                topicHandle = Librdkafka.topic_new(handle, topicStringPtr, config);
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(topicStringPtr);
+            }
+
+            #else
             using (var pinnedString = new Util.Marshal.StringAsPinnedUTF8(topic))
             {
                 topicHandle = Librdkafka.topic_new(handle, pinnedString.Ptr, config);
             }
+            #endif
 
             if (topicHandle.IsInvalid)
             {

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -56,6 +56,12 @@ namespace Confluent.Kafka.Internal
             /// </summary>
             public unsafe static string PtrToStringUTF8(IntPtr strPtr)
             {
+                #if NET6_0_OR_GREATER
+
+                return SystemMarshal.PtrToStringUTF8(strPtr);
+
+                #else
+
                 if (strPtr == IntPtr.Zero)
                 {
                     return null;
@@ -67,6 +73,7 @@ namespace Confluent.Kafka.Internal
                 var length = (int)(pTraverse - (byte*)strPtr);
 
                 return Encoding.UTF8.GetString((byte*)strPtr.ToPointer(), length);
+                #endif
             }
 
             public unsafe static string PtrToStringUTF8(IntPtr strPtr, UIntPtr strLength)


### PR DESCRIPTION
dotnet 6 has faster and less allocating alternatives for string marshaling
Some benchmarks in the end of Interop section  https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#interop