### PR TITLE
Add SetSaslCredentials binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# vNext
+
+- Added SetSaslCredentials. This new method (on the Producer, Consumer, and AdminClient) allows modifying the stored
+  SASL PLAIN/SCRAM credentials that will be used for subsequent (new) connections to a broker (#1980).
+
+
 # 2.0.2
 
 ## Upgrade considerations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# vNext
+# 2.1.0
 
 - Added SetSaslCredentials. This new method (on the Producer, Consumer, and AdminClient) allows modifying the stored
   SASL PLAIN/SCRAM credentials that will be used for subsequent (new) connections to a broker (#1980).

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -1099,6 +1099,10 @@ namespace Confluent.Kafka
         public int AddBrokers(string brokers)
             => kafkaHandle.AddBrokers(brokers);
 
+        /// <inheritdoc/>
+        public void SetSaslCredentials(string username, string password)
+            => kafkaHandle.SetSaslCredentials(username, password);
+
         /// <summary>
         ///     Refer to <see cref="Confluent.Kafka.IClient.Name" />
         /// </summary>

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -544,6 +544,9 @@ namespace Confluent.Kafka
         public int AddBrokers(string brokers)
             => kafkaHandle.AddBrokers(brokers);
 
+        /// <inheritdoc/>
+        public void SetSaslCredentials(string username, string password)
+            => kafkaHandle.SetSaslCredentials(username, password);
 
         /// <inheritdoc/>
         public string Name

--- a/src/Confluent.Kafka/IClient.cs
+++ b/src/Confluent.Kafka/IClient.cs
@@ -76,5 +76,24 @@ namespace Confluent.Kafka
         ///     a second time.
         /// </returns>
         int AddBrokers(string brokers);
+
+        /// <summary>
+        ///     SetSaslCredentials sets the SASL credentials used for this
+        ///     client.
+        ///     The new credentials will overwrite the old ones (which were set
+        ///     when creating client or by a previous call to
+        ///     SetSaslCredentials). The new credentials will be used the next
+        ///     time the client needs to authenticate to a broker.
+        ///     This method will not disconnect existing broker connections that
+        ///     were established with the old credentials.
+        ///     This method applies only to the SASL PLAIN and SCRAM mechanisms.
+        /// </summary>
+        /// <param name="username">
+        ///     The username to set.
+        /// </param>
+        /// <param name="password">
+        ///     The password to set.
+        /// </param>
+        void SetSaslCredentials(string username, string password);
     }
 }

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -255,6 +255,7 @@ namespace Confluent.Kafka.Impl
             _list_groups = (ListGroups)methods.Single(m => m.Name == "rd_kafka_list_groups").CreateDelegate(typeof(ListGroups));
             _group_list_destroy = (Action<IntPtr>)methods.Single(m => m.Name == "rd_kafka_group_list_destroy").CreateDelegate(typeof(Action<IntPtr>));
             _brokers_add = (Func<IntPtr, string, IntPtr>)methods.Single(m => m.Name == "rd_kafka_brokers_add").CreateDelegate(typeof(Func<IntPtr, string, IntPtr>));
+            _sasl_set_credentials = (_sasl_set_credentials_delegate)methods.Single(m => m.Name == "rd_kafka_sasl_set_credentials").CreateDelegate(typeof(_sasl_set_credentials_delegate));
             _outq_len = (Func<IntPtr, int>)methods.Single(m => m.Name == "rd_kafka_outq_len").CreateDelegate(typeof(Func<IntPtr, int>));
             _queue_new = (Func<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_queue_new").CreateDelegate(typeof(Func<IntPtr, IntPtr>));
             _queue_destroy = (Action<IntPtr>)methods.Single(m => m.Name == "rd_kafka_queue_destroy").CreateDelegate(typeof(Action<IntPtr>));
@@ -1142,6 +1143,11 @@ namespace Confluent.Kafka.Impl
         private static Func<IntPtr, string, IntPtr> _brokers_add;
         internal static IntPtr brokers_add(IntPtr rk, string brokerlist)
             => _brokers_add(rk, brokerlist);
+
+        private delegate IntPtr _sasl_set_credentials_delegate(IntPtr rk, string username, string password);
+        private static _sasl_set_credentials_delegate _sasl_set_credentials;
+        internal static IntPtr sasl_set_credentials(IntPtr rk, string username, string password)
+            => _sasl_set_credentials(rk, username, password);
 
         private static Func<IntPtr, int> _outq_len;
         internal static int outq_len(IntPtr rk) => _outq_len(rk);

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
@@ -449,6 +449,11 @@ namespace Confluent.Kafka.Impl.NativeMethods
                 [MarshalAs(UnmanagedType.LPStr)] string brokerlist);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_sasl_set_credentials(IntPtr rk,
+                [MarshalAs(UnmanagedType.LPStr)] string username,
+                [MarshalAs(UnmanagedType.LPStr)] string password);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int rd_kafka_outq_len(IntPtr rk);
 
 

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
@@ -453,6 +453,11 @@ namespace Confluent.Kafka.Impl.NativeMethods
                 [MarshalAs(UnmanagedType.LPStr)] string brokerlist);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_sasl_set_credentials(IntPtr rk,
+                [MarshalAs(UnmanagedType.LPStr)] string username,
+                [MarshalAs(UnmanagedType.LPStr)] string password);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int rd_kafka_outq_len(IntPtr rk);
 
 

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos6.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos6.cs
@@ -453,6 +453,11 @@ namespace Confluent.Kafka.Impl.NativeMethods
                 [MarshalAs(UnmanagedType.LPStr)] string brokerlist);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_sasl_set_credentials(IntPtr rk,
+                [MarshalAs(UnmanagedType.LPStr)] string username,
+                [MarshalAs(UnmanagedType.LPStr)] string password);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int rd_kafka_outq_len(IntPtr rk);
 
 

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos7.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos7.cs
@@ -453,6 +453,11 @@ namespace Confluent.Kafka.Impl.NativeMethods
                 [MarshalAs(UnmanagedType.LPStr)] string brokerlist);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_sasl_set_credentials(IntPtr rk,
+                [MarshalAs(UnmanagedType.LPStr)] string username,
+                [MarshalAs(UnmanagedType.LPStr)] string password);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int rd_kafka_outq_len(IntPtr rk);
 
 

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -257,6 +257,16 @@ namespace Confluent.Kafka.Impl
             return (int)Librdkafka.brokers_add(handle, brokers);
         }
 
+        internal void SetSaslCredentials(string username, string password)
+        {
+            ThrowIfHandleClosed();
+            IntPtr err = Librdkafka.sasl_set_credentials(handle, username, password);
+            if (err != IntPtr.Zero)
+            {
+                throw new KafkaException(new Error(err, true));
+            }
+        }
+
         internal int Poll(IntPtr millisecondsTimeout)
         {
             ThrowIfHandleClosed();

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -480,6 +480,10 @@ namespace Confluent.Kafka
         public int AddBrokers(string brokers)
             => KafkaHandle.AddBrokers(brokers);
 
+        /// <inheritdoc/>
+        public void SetSaslCredentials(string username, string password)
+            => KafkaHandle.SetSaslCredentials(username, password);
+
 
         /// <inheritdoc/>
         public Handle Handle 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SetSaslCredentials.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SetSaslCredentials.cs
@@ -1,0 +1,73 @@
+// Copyright 2023 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+#pragma warning disable xUnit1026
+
+using System;
+using Xunit;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public partial class Tests
+    {
+        /// <summary>
+        /// Test that the SetSaslCredentials method doesn't crash for each of
+        /// Producer, Consumer, and AdminClient.
+        /// Also tests failure when username/password is null.
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public void SetSaslCredentials(string bootstrapServers)
+        {
+            LogToFile("start SetSaslCredentials");
+
+            var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
+            using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
+            {
+                producer.SetSaslCredentials("username", "password");
+
+                var errsEncountered = false;
+                try
+                {
+                    producer.SetSaslCredentials(null, null);
+                }
+                catch (KafkaException ke)
+                {
+                    Assert.StartsWith("Username and password are required", ke.Message);
+                    errsEncountered = true;
+                }
+                Assert.True(errsEncountered);
+            }
+
+            var consumerConfig = new ConsumerConfig {
+                BootstrapServers = bootstrapServers,
+                GroupId = Guid.NewGuid().ToString() };
+            using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
+            {
+                consumer.SetSaslCredentials("username", "password");
+                consumer.Close();
+            }
+
+            var adminClientConfig = new AdminClientConfig { BootstrapServers = bootstrapServers };
+            using (var adminClient = new AdminClientBuilder(adminClientConfig).Build())
+            {
+                adminClient.SetSaslCredentials("username", "password");
+            }
+
+            LogToFile("end SetSaslCredentials");
+        }
+    }
+}

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SetSaslCredentials.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SetSaslCredentials.cs
@@ -36,38 +36,37 @@ namespace Confluent.Kafka.IntegrationTests
 
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
-            {
-                producer.SetSaslCredentials("username", "password");
-
-                var errsEncountered = false;
-                try
-                {
-                    producer.SetSaslCredentials(null, null);
-                }
-                catch (KafkaException ke)
-                {
-                    Assert.StartsWith("Username and password are required", ke.Message);
-                    errsEncountered = true;
-                }
-                Assert.True(errsEncountered);
-            }
+                CheckSetSaslCredentials(producer);
 
             var consumerConfig = new ConsumerConfig {
                 BootstrapServers = bootstrapServers,
                 GroupId = Guid.NewGuid().ToString() };
             using (var consumer = new ConsumerBuilder<Null, string>(consumerConfig).Build())
-            {
-                consumer.SetSaslCredentials("username", "password");
-                consumer.Close();
-            }
+                CheckSetSaslCredentials(consumer);
 
             var adminClientConfig = new AdminClientConfig { BootstrapServers = bootstrapServers };
             using (var adminClient = new AdminClientBuilder(adminClientConfig).Build())
-            {
-                adminClient.SetSaslCredentials("username", "password");
-            }
+                CheckSetSaslCredentials(adminClient);
 
+            Assert.Equal(0, Library.HandleCount);
             LogToFile("end SetSaslCredentials");
+        }
+
+        private static void CheckSetSaslCredentials(IClient client)
+        {
+            client.SetSaslCredentials("username", "password");
+            client.SetSaslCredentials("override", "override");
+            var errsEncountered = false;
+            try
+            {
+                client.SetSaslCredentials(null, null);
+            }
+            catch (KafkaException ke)
+            {
+                Assert.StartsWith("Username and password are required", ke.Message);
+                errsEncountered = true;
+            }
+            Assert.True(errsEncountered);
         }
     }
 }


### PR DESCRIPTION
The dotnet binding for rd_kafka_sasl_set_credentials.

This binding is present in the go client only at the moment.

Ref: https://github.com/confluentinc/librdkafka/pull/4033