### PR TITLE
Add AdminClient_ListGroups test and remove unused field in Metadata struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added SetSaslCredentials. This new method (on the Producer, Consumer, and AdminClient) allows modifying the stored
   SASL PLAIN/SCRAM credentials that will be used for subsequent (new) connections to a broker (#1980).
+- Fixed `OverflowException` thrown intermittently when using the `ListGroup` method (#2003).
 
 
 # 2.0.2

--- a/src/Confluent.Kafka/Impl/Metadata.cs
+++ b/src/Confluent.Kafka/Impl/Metadata.cs
@@ -69,7 +69,6 @@ namespace Confluent.Kafka.Impl
         internal IntPtr member_metadata_size;
         internal IntPtr member_assignment;
         internal IntPtr member_assignment_size;
-        internal IntPtr member_assignment_toppars;
     };
 
     [StructLayout(LayoutKind.Sequential)]

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListGroups.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListGroups.cs
@@ -1,0 +1,57 @@
+// Copyright 2023 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public partial class Tests
+    {
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public void AdminClient_ListGroups(string bootstrapServers)
+        {
+            LogToFile("start AdminClient_ListGroups");
+
+            var groupId = Guid.NewGuid().ToString();
+            var consumerConfig = new ConsumerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                GroupId = groupId,
+                EnableAutoCommit = false,
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            };
+
+            using var topic = new TemporaryTopic(bootstrapServers, 1);
+            using var admin = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers })
+                .Build();
+            for (var i = 0; i < 10; i++)
+            {
+                using var consumer = new ConsumerBuilder<Ignore, Ignore>(consumerConfig).Build();
+                
+                consumer.Subscribe(topic.Name);
+                Task.Delay(TimeSpan.FromSeconds(1)).Wait();
+
+                var info = admin.ListGroup(groupId, TimeSpan.FromSeconds(5));
+                Assert.NotNull(info);
+                Assert.Equal(i + 1, info.Members.Count);
+            }
+            
+            LogToFile("end   AdminClient_ListGroups");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1995.

There was an extra field in `rd_kafka_group_member_info` which wasn't matching with the librdkafka struct and was causing mismatch in the .NET binding leading to the `overflow` exception.

Also added a new integration test. The AdminClient_ListGroups test verifies that the ListGroups API returns the expected group information. This test ensures that the bug has been fixed.
