### PR TITLE
Thread Starvation: Support async serializers with produce callbacks

### DIFF
--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -339,6 +339,110 @@ namespace Confluent.Kafka
             }
         }
 
+        private async Task ProduceImplAsync(
+            TopicPartition topicPartition,
+            Message<TKey, TValue> message,
+            IDeliveryHandler deliveryHandler)
+        {
+            if (message.Timestamp.Type != TimestampType.CreateTime)
+            {
+                if (message.Timestamp != Timestamp.Default)
+                {
+                    throw new ArgumentException("Timestamp must be either Timestamp.Default, or Timestamp.CreateTime.");
+                }
+            }
+
+            Headers headers = message.Headers ?? new Headers();
+
+            byte[] keyBytes;
+            try
+            {
+                keyBytes = (keySerializer != null)
+                    ? keySerializer.Serialize(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic, message.Headers))
+                    : await asyncKeySerializer.SerializeAsync(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic, message.Headers)).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new ProduceException<TKey, TValue>(
+                    new Error(ErrorCode.Local_KeySerialization),
+                    new DeliveryResult<TKey, TValue>
+                    {
+                        Message = message,
+                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
+                    },
+                    ex);
+            }
+
+            byte[] valBytes;
+            try
+            {
+                valBytes = (valueSerializer != null)
+                    ? valueSerializer.Serialize(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic, message.Headers))
+                    : await asyncValueSerializer.SerializeAsync(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic, message.Headers)).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new ProduceException<TKey, TValue>(
+                    new Error(ErrorCode.Local_ValueSerialization),
+                    new DeliveryResult<TKey, TValue>
+                    {
+                        Message = message,
+                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
+                    },
+                    ex);
+            }
+
+            ErrorCode err;
+            if (this.enableDeliveryReports && deliveryHandler != null)
+            {
+                // Passes the TaskCompletionSource to the delivery report callback via the msg_opaque pointer
+
+                // Note: There is a level of indirection between the GCHandle and
+                // physical memory address. GCHandle.ToIntPtr doesn't get the
+                // physical address, it gets an id that refers to the object via
+                // a handle-table.
+                var gch = GCHandle.Alloc(deliveryHandler);
+                var ptr = GCHandle.ToIntPtr(gch);
+
+                err = KafkaHandle.Produce(
+                    topicPartition.Topic,
+                    valBytes, 0, valBytes == null ? 0 : valBytes.Length,
+                    keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length,
+                    topicPartition.Partition.Value,
+                    message.Timestamp.UnixTimestampMs,
+                    headers,
+                    ptr);
+
+                if (err != ErrorCode.NoError)
+                {
+                    // note: freed in the delivery handler callback otherwise.
+                    gch.Free();
+                }
+            }
+            else
+            {
+                err = KafkaHandle.Produce(
+                    topicPartition.Topic,
+                    valBytes, 0, valBytes == null ? 0 : valBytes.Length,
+                    keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length,
+                    topicPartition.Partition.Value,
+                    message.Timestamp.UnixTimestampMs,
+                    headers,
+                    IntPtr.Zero);
+            }
+
+            if (err != ErrorCode.NoError)
+            {
+                throw new ProduceException<TKey, TValue>(
+                    KafkaHandle.CreatePossiblyFatalError(err, null),
+                    new DeliveryResult<TKey, TValue>
+                    {
+                        Message = message,
+                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
+                    });
+            }
+        }
+
 
         /// <inheritdoc/>
         public int Poll(TimeSpan timeout)
@@ -748,97 +852,34 @@ namespace Confluent.Kafka
             Message<TKey, TValue> message,
             CancellationToken cancellationToken)
         {
-            Headers headers = message.Headers ?? new Headers();
+            if (enableDeliveryReports)
+            {
+                var handler = new TypedTaskDeliveryHandlerShim(
+                    topicPartition.Topic,
+                    enableDeliveryReportKey ? message.Key : default(TKey),
+                    enableDeliveryReportValue ? message.Value : default(TValue));
 
-            byte[] keyBytes;
-            try
-            {
-                keyBytes = (keySerializer != null)
-                    ? keySerializer.Serialize(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic, headers))
-                    : await asyncKeySerializer.SerializeAsync(message.Key, new SerializationContext(MessageComponentType.Key, topicPartition.Topic, headers)).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                throw new ProduceException<TKey, TValue>(
-                    new Error(ErrorCode.Local_KeySerialization),
-                    new DeliveryResult<TKey, TValue>
-                    {
-                        Message = message,
-                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
-                    },
-                    ex);
-            }
-
-            byte[] valBytes;
-            try
-            {
-                valBytes = (valueSerializer != null)
-                    ? valueSerializer.Serialize(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic, headers))
-                    : await asyncValueSerializer.SerializeAsync(message.Value, new SerializationContext(MessageComponentType.Value, topicPartition.Topic, headers)).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                throw new ProduceException<TKey, TValue>(
-                    new Error(ErrorCode.Local_ValueSerialization),
-                    new DeliveryResult<TKey, TValue>
-                    {
-                        Message = message,
-                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
-                    },
-                    ex);
-            }
-
-            try
-            {
-                if (enableDeliveryReports)
+                if (cancellationToken.CanBeCanceled)
                 {
-                    var handler = new TypedTaskDeliveryHandlerShim(
-                        topicPartition.Topic,
-                        enableDeliveryReportKey ? message.Key : default(TKey),
-                        enableDeliveryReportValue ? message.Value : default(TValue));
-
-                    if (cancellationToken.CanBeCanceled)
-                    {
-                        handler.CancellationTokenRegistration
-                            = cancellationToken.Register(() => handler.TrySetCanceled());
-                    }
-
-                    ProduceImpl(
-                        topicPartition.Topic,
-                        valBytes, 0, valBytes == null ? 0 : valBytes.Length,
-                        keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length,
-                        message.Timestamp, topicPartition.Partition, headers,
-                        handler);
-
-                    return await handler.Task.ConfigureAwait(false);
+                    handler.CancellationTokenRegistration
+                        = cancellationToken.Register(() => handler.TrySetCanceled());
                 }
-                else
-                {
-                    ProduceImpl(
-                        topicPartition.Topic, 
-                        valBytes, 0, valBytes == null ? 0 : valBytes.Length, 
-                        keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, 
-                        message.Timestamp, topicPartition.Partition, headers, 
-                        null);
 
-                    var result = new DeliveryResult<TKey, TValue>
-                    {
-                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset),
-                        Message = message
-                    };
+                await ProduceImplAsync(topicPartition, message, handler).ConfigureAwait(false);
 
-                    return result;
-                }
+                return await handler.Task.ConfigureAwait(false);
             }
-            catch (KafkaException ex)
+            else
             {
-                throw new ProduceException<TKey, TValue>(
-                    ex.Error,
-                    new DeliveryResult<TKey, TValue>
-                    {
-                        Message = message,
-                        TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset)
-                    });
+                await ProduceImplAsync(topicPartition, message, null).ConfigureAwait(false);
+
+                var result = new DeliveryResult<TKey, TValue>
+                {
+                    TopicPartitionOffset = new TopicPartitionOffset(topicPartition, Offset.Unset),
+                    Message = message
+                };
+
+                return result;
             }
         }
 


### PR DESCRIPTION
As noted in issues/documentation, the preferred paradigm of invoking `Produce(...)` with a callback to handle delivery reports suffers from thread performance issues when used with asynchronous serializers wrapped by [`SyncOverAsyncSerializer<T>`](https://github.com/confluentinc/confluent-kafka-dotnet/blob/19bd96061b4d063a0bda9a33bb20d667a829bc68/src/Confluent.Kafka/SyncOverAsyncSerializer.cs).

It occurs to me that we don't need to block threads during serialization if we instead schedule an asynchronous continuation, utilizing the callback to communicate serialization failures the same way we do broker failures. This winds up being a relatively minor change (with some refactors to prevent duplication). It's also backwards compatible, since it only takes effect on code paths that previously threw an `InvalidOperationException` (passing a callback with an async serializer configured).

Please take a look as I believe this is a change worth making. It's painful to me that this library which advertises its throughput still doesn't support producing more than a handful of messages at a time.

Note, I previously attempted to address this on the serializer side with #1644. Removing the semaphores would dramatically improve the performance of the serializers, but that can be seen as a separate issue. This will allow many produce operations to execute concurrently regardless of serializer implementation.