### PR TITLE
Add Obsolete attribute for deprecated methods

### DIFF
--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -40,6 +40,7 @@ namespace Confluent.Kafka
         /// <param name="timeout">
         ///     The maximum period of time the call may block.
         /// </param>
+        [Obsolete("Superseded by ListConsumerGroups and DescribeConsumerGroups.")]
         List<GroupInfo> ListGroups(TimeSpan timeout);
 
 
@@ -64,6 +65,7 @@ namespace Confluent.Kafka
         ///     specified group or null if this group does
         ///     not exist.
         /// </returns>
+        [Obsolete("Superseded by ListConsumerGroups and DescribeConsumerGroups.")]
         GroupInfo ListGroup(string group, TimeSpan timeout);
 
 


### PR DESCRIPTION
Fixes #1998. Adding Obsolete will throw warnings in IDE.