### PR TITLE
Fix: #1743 ClientConfig.SecurityProtocol not compatible with official config values.

### DIFF
--- a/src/Confluent.Kafka/Config.cs
+++ b/src/Confluent.Kafka/Config.cs
@@ -160,7 +160,8 @@ namespace Confluent.Kafka
         {
             var result = Get(key);
             if (result == null) { return null; }
-            if (EnumNameToConfigValueSubstitutes.Values.Count(v => v == result) > 0)
+            var lcResult = result.ToString().ToLowerInvariant();
+            if (EnumNameToConfigValueSubstitutes.Values.Count(v => v == lcResult) > 0)
             {
                 return Enum.Parse(type, EnumNameToConfigValueSubstitutes.First(v => v.Value == result).Key, ignoreCase: true);
             }


### PR DESCRIPTION
This PR tries to fix issue #1743 `ClientConfig.SecurityProtocol not compatible with official config values.`

By following getting started document, https://developer.confluent.io/get-started/dotnet/#configuration, We want to set `security.protocol=SASL_SSL`

But when creating ProducerConfig (inherits from ClientConfig) with given `producer.properties` file, ClientConfig.SecurityProtocol throws exception as described in #1743.
This PR convert value in lowercase before searching in `EnumNameToConfigValueSubstitutes` (same transformation as implemented in `SetObject` method) , so official config values would be supported correctly.
