### PR TITLE
Reproduce access violation exception

### DIFF
--- a/examples/Consumer/Consumer.csproj
+++ b/examples/Consumer/Consumer.csproj
@@ -9,7 +9,9 @@
 
   <ItemGroup>
     <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.1.1" /> -->
-    <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
+	<PackageReference Include="Confluent.Kafka" Version="2.1.1" />
+    <!--<ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />-->
+	<PackageReference Include="Testcontainers.Kafka" Version="3.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I use confluent-kafka-dotnet for integration tests where many consumers are created, closed and disposed.
I am often getting AccessViolationException which is killing the host .net process.

I made some changes on the Consumer sample project so that you should be easily reproduce this error.

Reproduction steps:
1. Have docker installed with linux containers
2. Clone the repository and checkout the tpapp/reproduce-access-violation branch
3. Build the Consumer sample project
4. Run this command for a few times:
```bash
cls; dotnet run --project C:\git\confluent-kafka-dotnet\examples\Consumer\Consumer.csproj -- subscribe 20 NetworkTopology
```
5. Within a few runs you should see System.AccessViolationException

For example:
[failed run.log](https://github.com/confluentinc/confluent-kafka-dotnet/files/11435118/failed.run.log)
