### PR TITLE
Fix backwards compatability of TopicPartitionOffset constructor #2060

### DIFF
--- a/src/Confluent.Kafka/TopicPartitionOffset.cs
+++ b/src/Confluent.Kafka/TopicPartitionOffset.cs
@@ -32,12 +32,23 @@ namespace Confluent.Kafka
         /// <param name="offset">
         ///     A Kafka offset value.
         /// </param>
+        public TopicPartitionOffset(TopicPartition tp, Offset offset)
+            : this(tp.Topic, tp.Partition, offset, null) { }
+        /// <summary>
+        ///     Initializes a new TopicPartitionOffset instance.
+        /// </summary>
+        /// <param name="tp">
+        ///     Kafka topic name and partition.
+        /// </param>
+        /// <param name="offset">
+        ///     A Kafka offset value.
+        /// </param>
         /// <param name="leaderEpoch">
         ///     The offset leader epoch (optional).
         /// </param>
         public TopicPartitionOffset(TopicPartition tp, Offset offset,
-                                    int? leaderEpoch = null)
-            : this(tp.Topic, tp.Partition, offset, leaderEpoch) {}
+                                    int? leaderEpoch)
+            : this(tp.Topic, tp.Partition, offset, leaderEpoch) { }
 
         /// <summary>
         ///     Initializes a new TopicPartitionOffset instance.
@@ -55,7 +66,26 @@ namespace Confluent.Kafka
         ///     The optional offset leader epoch.
         /// </param>
         public TopicPartitionOffset(string topic, Partition partition,
-                                    Offset offset, int? leaderEpoch = null)
+                                    Offset offset)
+            : this(topic, tp.Partition, offset, null) { }
+
+        /// <summary>
+        ///     Initializes a new TopicPartitionOffset instance.
+        /// </summary>
+        /// <param name="topic">
+        ///     A Kafka topic name.
+        /// </param>
+        /// <param name="partition">
+        ///     A Kafka partition.
+        /// </param>
+        /// <param name="offset">
+        ///     A Kafka offset value.
+        /// </param>
+        /// <param name="leaderEpoch">
+        ///     The optional offset leader epoch.
+        /// </param>
+        public TopicPartitionOffset(string topic, Partition partition,
+                                    Offset offset, int? leaderEpoch)
         {
             Topic = topic;
             Partition = partition;


### PR DESCRIPTION
Version 2.1 (specifically commit https://github.com/confluentinc/confluent-kafka-dotnet/commit/9826d7941176882ac0d739a08912daa2054b3c95) introduced a breaking change (looks unintentional as you would think optional parameters would be non-breaking but they aren't). This is causing my applications that reference a library that uses a library that uses Confluent.Kafka to break when the entry app tries to upgrade to the latest Confluent.Kafka.

See #2060 