### PR TITLE
Fix Backward Compatibility Issue in TopicPartitionOffset Constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.2.0
+
+## Fixes
+
+- Fix backwards compatability of TopicPartitionOffset constructor. ([drinehimer](https://github.com/drinehimer), #2066)
+
+
 # 2.1.1
 
 ## Enhancements

--- a/src/Confluent.Kafka/TopicPartitionOffset.cs
+++ b/src/Confluent.Kafka/TopicPartitionOffset.cs
@@ -34,6 +34,7 @@ namespace Confluent.Kafka
         /// </param>
         public TopicPartitionOffset(TopicPartition tp, Offset offset)
             : this(tp.Topic, tp.Partition, offset, null) { }
+        
         /// <summary>
         ///     Initializes a new TopicPartitionOffset instance.
         /// </summary>
@@ -62,12 +63,9 @@ namespace Confluent.Kafka
         /// <param name="offset">
         ///     A Kafka offset value.
         /// </param>
-        /// <param name="leaderEpoch">
-        ///     The optional offset leader epoch.
-        /// </param>
         public TopicPartitionOffset(string topic, Partition partition,
                                     Offset offset)
-            : this(topic, tp.Partition, offset, null) { }
+            : this(topic, partition, offset, null) { }
 
         /// <summary>
         ///     Initializes a new TopicPartitionOffset instance.

--- a/src/Confluent.Kafka/TopicPartitionOffset.cs
+++ b/src/Confluent.Kafka/TopicPartitionOffset.cs
@@ -32,12 +32,23 @@ namespace Confluent.Kafka
         /// <param name="offset">
         ///     A Kafka offset value.
         /// </param>
+        public TopicPartitionOffset(TopicPartition tp, Offset offset)
+            : this(tp.Topic, tp.Partition, offset, null) { }
+        /// <summary>
+        ///     Initializes a new TopicPartitionOffset instance.
+        /// </summary>
+        /// <param name="tp">
+        ///     Kafka topic name and partition.
+        /// </param>
+        /// <param name="offset">
+        ///     A Kafka offset value.
+        /// </param>
         /// <param name="leaderEpoch">
         ///     The offset leader epoch (optional).
         /// </param>
         public TopicPartitionOffset(TopicPartition tp, Offset offset,
-                                    int? leaderEpoch = null)
-            : this(tp.Topic, tp.Partition, offset, leaderEpoch) {}
+                                    int? leaderEpoch)
+            : this(tp.Topic, tp.Partition, offset, leaderEpoch) { }
 
         /// <summary>
         ///     Initializes a new TopicPartitionOffset instance.
@@ -55,7 +66,26 @@ namespace Confluent.Kafka
         ///     The optional offset leader epoch.
         /// </param>
         public TopicPartitionOffset(string topic, Partition partition,
-                                    Offset offset, int? leaderEpoch = null)
+                                    Offset offset)
+            : this(topic, tp.Partition, offset, null) { }
+
+        /// <summary>
+        ///     Initializes a new TopicPartitionOffset instance.
+        /// </summary>
+        /// <param name="topic">
+        ///     A Kafka topic name.
+        /// </param>
+        /// <param name="partition">
+        ///     A Kafka partition.
+        /// </param>
+        /// <param name="offset">
+        ///     A Kafka offset value.
+        /// </param>
+        /// <param name="leaderEpoch">
+        ///     The optional offset leader epoch.
+        /// </param>
+        public TopicPartitionOffset(string topic, Partition partition,
+                                    Offset offset, int? leaderEpoch)
         {
             Topic = topic;
             Partition = partition;


### PR DESCRIPTION
Fix a backward compatibility issue in the TopicPartitionOffset constructor by reintroducing the original constructor and overloading it to separately accommodate the optional parameters.

* Reintroduces the original constructor.
* Adds an overloaded constructor for additional parameters.


Referring - https://github.com/confluentinc/confluent-kafka-dotnet/pull/2061 and fixes #2060

___

### Testing

Integration tests
