### PR TITLE
Fix IConsumer breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - Fix backwards compatability of TopicPartitionOffset constructor. ([drinehimer](https://github.com/drinehimer), #2066)
+- Fix IConsumer breaking change. ([ttd2089](https://github.com/ttd2089), #2071)
 
 
 # 2.1.1

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -263,7 +263,7 @@ namespace Confluent.Kafka
                     {
                         try
                         {
-                            assignmentWithPositions.Add(PositionTopicPartitionOffset(tp));
+                            assignmentWithPositions.Add(this.PositionTopicPartitionOffset(tp));
                         }
                         catch
                         {
@@ -510,22 +510,15 @@ namespace Confluent.Kafka
         /// <inheritdoc/>
         public Offset Position(TopicPartition partition)
         {
-            return PositionTopicPartitionOffset(partition).Offset;
-        }
-        
-        /// <inheritdoc/>
-        public TopicPartitionOffset PositionTopicPartitionOffset(TopicPartition partition)
-        {
             try
             {
-                return kafkaHandle.Position(new List<TopicPartition> { partition }).First();
+                return kafkaHandle.Position(new List<TopicPartition> { partition }).First().Offset;
             }
             catch (TopicPartitionOffsetException e)
             {
                 throw new KafkaException(e.Results[0].Error);
             }
         }
-
 
         /// <inheritdoc/>
         public List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestampsToSearch, TimeSpan timeout)

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 
@@ -556,24 +557,6 @@ namespace Confluent.Kafka
         ///     Thrown if the request failed.
         /// </exception>
         Offset Position(TopicPartition partition);
-        
-
-        /// <summary>
-        ///     Gets the current position (offset) for the
-        ///     specified topic / partition.
-        ///
-        ///     The offset field of each requested partition
-        ///     will be set to the offset of the last consumed
-        ///     message + 1, or Offset.Unset in case there was
-        ///     no previous message consumed by this consumer.
-        ///     
-        ///     The returned TopicPartitionOffset contains the leader epoch
-        ///     too.
-        /// </summary>
-        /// <exception cref="Confluent.Kafka.KafkaException">
-        ///     Thrown if the request failed.
-        /// </exception>
-        TopicPartitionOffset PositionTopicPartitionOffset(TopicPartition partition);
 
 
         /// <summary>

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 

--- a/src/Confluent.Kafka/IConsumerExtensions.cs
+++ b/src/Confluent.Kafka/IConsumerExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    /// Common extension methods for <see cref="IConsumer{TKey, TValue}"/> implementations.
+    /// </summary>
+    public static class IConsumerExtensions
+    {
+        /// <summary>
+        ///     Gets the current position (offset) for the
+        ///     specified topic / partition.
+        ///
+        ///     The offset field of each requested partition
+        ///     will be set to the offset of the last consumed
+        ///     message + 1, or Offset.Unset in case there was
+        ///     no previous message consumed by this consumer.
+        ///     
+        ///     The returned TopicPartitionOffset contains the leader epoch
+        ///     too.
+        /// </summary>
+        /// <exception cref="Confluent.Kafka.KafkaException">
+        ///     Thrown if the request failed.
+        /// </exception>
+        public static TopicPartitionOffset PositionTopicPartitionOffset<TKey, TValue>(
+            this IConsumer<TKey, TValue> consumer,
+            TopicPartition partition)
+        {
+            try
+            {
+                return consumer.Handle.LibrdkafkaHandle.Position(new List<TopicPartition> { partition }).First();
+            }
+            catch (TopicPartitionOffsetException e)
+            {
+                throw new KafkaException(e.Results[0].Error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Fixes a breaking change in the IConsumer interface introduced by #2027 by replacing the interface method and the implementation on Consumer with an extension method on IConsumer. This ensures that existing implementations of IConsumer remain unbroken and have the same functionality as the default Consumer implementation.

Referenced from #2067.

### Testing

Integration tests