### PR TITLE
Increase number of network threads

### DIFF
--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterConfigs.cs
@@ -34,13 +34,6 @@ namespace Confluent.Kafka.IntegrationTests
         public void AdminClient_AlterConfigs(string bootstrapServers)
         {
             LogToFile("start AdminClient_AlterConfigs");
-            bool skipFlakyTests = semaphoreSkipFlakyTests();
-            if (skipFlakyTests)
-            {
-                LogToFile("Skipping AdminClient_AlterConfigs Test on Semaphore due to its flaky nature");
-                return;
-            }
-
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 // 1. create a new topic to play with.
@@ -102,7 +95,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     { 
                         new ConfigResource { Name = "0", Type = ResourceType.Broker },
-                        new List<ConfigEntry> { new ConfigEntry { Name="num.network.threads", Value="2" } }
+                        new List<ConfigEntry> { new ConfigEntry { Name="num.network.threads", Value="6" } }
                     }
                 };
                 adminClient.AlterConfigsAsync(toUpdate).Wait();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_IncrementalAlterConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_IncrementalAlterConfigs.cs
@@ -102,7 +102,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     { 
                         new ConfigResource { Name = "0", Type = ResourceType.Broker },
-                        new List<ConfigEntry> { new ConfigEntry { Name = "num.network.threads", Value = "2" , IncrementalOperation = AlterConfigOpType.Set } }
+                        new List<ConfigEntry> { new ConfigEntry { Name = "num.network.threads", Value = "6" , IncrementalOperation = AlterConfigOpType.Set } }
                     }
                 };
                 adminClient.IncrementalAlterConfigsAsync(toUpdate).Wait();


### PR DESCRIPTION
in integration test to avoid disconnections from broker 0.

It seems the broker is disconnecting when available threads are exhausted, this problem is more evident when number of broker thread was reduced to 2 instead of the default of 3.