### PR TITLE
Fix calls with empty lists

### DIFF
--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -891,13 +891,13 @@ namespace Confluent.Kafka.Examples
                 {
                     var listOffsetsResult = await adminClient.ListOffsetsAsync(topicPartitionOffsets, options);
                     Console.WriteLine("ListOffsetsResult:");
-                    PrintListOffsetsResultInfos(listOffsetsResult.ListOffsetsResultInfos);
+                    PrintListOffsetsResultInfos(listOffsetsResult.ResultInfos);
                 }
                 catch (ListOffsetsException e)
                 {
                     Console.WriteLine("ListOffsetsReport:");
                     Console.WriteLine($"  Error: {e.Error}");
-                    PrintListOffsetsResultInfos(e.Result.ListOffsetsResultInfos);
+                    PrintListOffsetsResultInfos(e.Result.ResultInfos);
                 }
                 catch (KafkaException e)
                 {

--- a/src/Confluent.Kafka/Admin/ListOffsetsReport.cs
+++ b/src/Confluent.Kafka/Admin/ListOffsetsReport.cs
@@ -31,7 +31,7 @@ namespace Confluent.Kafka.Admin
         ///     with ListOffsets. At least one of these
         ///     results will be in error.
         /// </summary>
-        public List<ListOffsetsResultInfo> ListOffsetsResultInfos { get; set; }
+        public List<ListOffsetsResultInfo> ResultInfos { get; set; }
 
         /// <summary>
         ///     Operation error status.
@@ -47,8 +47,8 @@ namespace Confluent.Kafka.Admin
         public override string ToString()
         {
             var result = new StringBuilder();
-            result.Append($"{{\"ListOffsetsResultInfos\": [");
-            result.Append(string.Join(",", ListOffsetsResultInfos.Select(b => $" {b.ToString()}")));
+            result.Append($"{{\"ResultInfos\": [");
+            result.Append(string.Join(",", ResultInfos.Select(b => $" {b.ToString()}")));
             result.Append($"], \"Error\": \"{Error.Code}\"}}");
             return result.ToString();
         }

--- a/src/Confluent.Kafka/Admin/ListOffsetsResult.cs
+++ b/src/Confluent.Kafka/Admin/ListOffsetsResult.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.Admin
         ///     Result information for all the partitions queried
         ///     with ListOffsets.
         /// </summary>
-        public List<ListOffsetsResultInfo> ListOffsetsResultInfos { get; set; }
+        public List<ListOffsetsResultInfo> ResultInfos { get; set; }
 
 
         /// <summary>
@@ -42,8 +42,8 @@ namespace Confluent.Kafka.Admin
         public override string ToString()
         {
             var result = new StringBuilder();
-            result.Append($"{{\"ListOffsetsResultInfos\": [");
-            result.Append(string.Join(",", ListOffsetsResultInfos.Select(b => $" {b.ToString()}")));
+            result.Append($"{{\"ResultInfos\": [");
+            result.Append(string.Join(",", ResultInfos.Select(b => $" {b.ToString()}")));
             result.Append("]}");
             return result.ToString();
         }

--- a/src/Confluent.Kafka/Admin/OffsetSpec.cs
+++ b/src/Confluent.Kafka/Admin/OffsetSpec.cs
@@ -32,6 +32,10 @@ namespace Confluent.Kafka.Admin
         /// </summary>
         public class EarliestSpec : OffsetSpec
         {
+            internal EarliestSpec()
+            {
+            }
+
             internal override long Value()
             {
                 return -2;
@@ -43,6 +47,10 @@ namespace Confluent.Kafka.Admin
         /// </summary>
         public class LatestSpec : OffsetSpec
         {
+            internal LatestSpec()
+            {
+            }
+
             internal override long Value()
             {
                 return -1;
@@ -55,6 +63,10 @@ namespace Confluent.Kafka.Admin
         ///     can be specified client-side.
         /// </summary>
         public class MaxTimestampSpec : OffsetSpec {
+            internal MaxTimestampSpec()
+            {
+            }
+
             internal override long Value()
             {
                 return -3;

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -597,8 +597,12 @@ namespace Confluent.Kafka
         private ListOffsetsReport extractListOffsetsReport(IntPtr resultPtr)
         {
             var resultInfosPtr = Librdkafka.ListOffsets_result_infos(resultPtr, out UIntPtr resulInfosCntPtr);
+            
             IntPtr[] resultResponsesPtrArr = new IntPtr[(int)resulInfosCntPtr];
-            Marshal.Copy(resultInfosPtr, resultResponsesPtrArr, 0, (int)resulInfosCntPtr);
+            if ((int)resulInfosCntPtr > 0)
+            {
+                Marshal.Copy(resultInfosPtr, resultResponsesPtrArr, 0, (int)resulInfosCntPtr);
+            }            
             
             ErrorCode reportErrorCode = ErrorCode.NoError;
             var listOffsetsResultInfos = resultResponsesPtrArr.Select(resultResponsePtr => 
@@ -625,7 +629,7 @@ namespace Confluent.Kafka
 
             return new ListOffsetsReport
             {
-                ListOffsetsResultInfos = listOffsetsResultInfos,
+                ResultInfos = listOffsetsResultInfos,
                 Error = new Error(reportErrorCode)
             };
         }
@@ -1241,7 +1245,7 @@ namespace Confluent.Kafka
                                         }
                                         else
                                         {
-                                            var result = new ListOffsetsResult() { ListOffsetsResultInfos = report.ListOffsetsResultInfos };
+                                            var result = new ListOffsetsResult() { ResultInfos = report.ResultInfos };
                                             Task.Run(() =>
                                                 ((TaskCompletionSource<ListOffsetsResult>)adminClientResult).TrySetResult(
                                                     result));

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -2512,7 +2512,7 @@ namespace Confluent.Kafka.Impl
                         topic_partition,
                         (int) Util.Marshal.OffsetOf<rd_kafka_topic_partition>("offset"),
                         topicPartitionOffset.OffsetSpec.Value());
-                }  
+                }
                 Librdkafka.ListOffsets(handle, topic_partition_list, optionsPtr, resultQueuePtr);
             }
             finally

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -2532,11 +2532,6 @@ namespace Confluent.Kafka.Impl
         {
             ThrowIfHandleClosed();
 
-            if (topicCollection.Topics.Count() == 0)
-            {
-                throw new ArgumentException("at least one topic should be provided to DescribeTopics");
-            }
-
             var optionsPtr = IntPtr.Zero;
             var topicCollectionPtr = IntPtr.Zero;
             try

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListOffsets.cs
@@ -65,9 +65,9 @@ namespace Confluent.Kafka.IntegrationTests
                 
                 var listOffsetsResult = await adminClient.ListOffsetsAsync(topicPartitionOffsetSpecs, options);
 
-                foreach (var ListOffsetsResultInfo in listOffsetsResult.ListOffsetsResultInfos)
+                foreach (var resultInfo in listOffsetsResult.ResultInfos)
                 {
-                    TopicPartitionOffsetError topicPartition = ListOffsetsResultInfo.TopicPartitionOffsetError;
+                    TopicPartitionOffsetError topicPartition = resultInfo.TopicPartitionOffsetError;
                     Assert.Equal(offset, topicPartition.Offset);
                 }
             }

--- a/test/Confluent.Kafka.UnitTests/Admin/DescribeTopicsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/DescribeTopicsError.cs
@@ -1,0 +1,124 @@
+// Copyright 2023 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Xunit;
+using System;
+using Confluent.Kafka.Admin;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class DescribeTopicsErrorTests
+    {
+        private readonly List<DescribeTopicsOptions> options = new List<DescribeTopicsOptions>
+        {
+            new DescribeTopicsOptions {},
+            new DescribeTopicsOptions { RequestTimeout = TimeSpan.FromMilliseconds(200) },
+            new DescribeTopicsOptions { IncludeAuthorizedOperations = true },
+            new DescribeTopicsOptions { RequestTimeout = TimeSpan.FromMilliseconds(200), IncludeAuthorizedOperations = false },
+        };
+
+        [Fact]
+        public async void NullTopicCollection()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
+            {
+                foreach (var option in options)
+                {
+                    await Assert.ThrowsAsync<NullReferenceException>(() =>
+                        adminClient.DescribeTopicsAsync(null, option)
+                    );
+                }
+            }
+        }
+        
+        [Fact]
+        public async void EmptyTopicCollection()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var result = await adminClient.DescribeTopicsAsync(
+                        TopicCollection.OfTopicNames(new List<string> {}),
+                        option);
+                    Assert.Empty(result.TopicDescriptions);
+                }
+            }
+        }
+
+        
+        [Fact]
+        public async void WrongTopicNames()
+        {
+            var wrongTopicCollections = new List<TopicCollection>
+            {
+                TopicCollection.OfTopicNames(new List<string> {""}),
+                TopicCollection.OfTopicNames(new List<string> {"correct", ""}),
+            };
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
+            {
+                foreach (var option in options)
+                {
+                    foreach (var collection in wrongTopicCollections)
+                    {
+                        await Assert.ThrowsAsync<KafkaException>(() =>
+                            adminClient.DescribeTopicsAsync(collection, option)
+                        );
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async void WrongRequestTimeoutValue()
+        {
+            var topicCollections =  TopicCollection.OfTopicNames(new List<string> {});
+            var wrongRequestTimeoutValue = new DescribeTopicsOptions
+            {
+                RequestTimeout = TimeSpan.FromSeconds(-1)
+            };
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
+            {
+                await Assert.ThrowsAsync<KafkaException>(() =>
+                    adminClient.DescribeTopicsAsync(topicCollections, wrongRequestTimeoutValue)
+                );
+            }
+        }
+
+        [Fact]
+        public async void LocalTimeout()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.DescribeTopicsAsync(
+                            TopicCollection.OfTopicNames(new List<string> {"test"}),
+                            option)
+                    );
+                    Assert.Equal("Failed while waiting for controller: Local: Timed out", ex.Message);
+                }
+            }
+        }
+    }
+}

--- a/test/Confluent.Kafka.UnitTests/Admin/ListOffsetsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/ListOffsetsError.cs
@@ -1,0 +1,217 @@
+// Copyright 2023 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Xunit;
+using System;
+using Confluent.Kafka.Admin;
+using System.Collections.Generic;
+
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class ListOffsetsErrorTests
+    {
+        private readonly List<ListOffsetsOptions> options = new List<ListOffsetsOptions>
+        {
+            new ListOffsetsOptions {},
+            new ListOffsetsOptions { RequestTimeout = TimeSpan.FromMilliseconds(200) },
+            new ListOffsetsOptions { IsolationLevel = IsolationLevel.ReadUncommitted },
+            new ListOffsetsOptions { RequestTimeout = TimeSpan.FromMilliseconds(200), IsolationLevel = IsolationLevel.ReadCommitted },
+        };
+
+        [Fact]
+        public async void InvalidRequestTimeout()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                    adminClient.ListOffsetsAsync(
+                        new List<TopicPartitionOffsetSpec> {},
+                        new ListOffsetsOptions
+                        {
+                            RequestTimeout = TimeSpan.FromSeconds(-1)
+                        })
+                );
+                Assert.Contains("expecting integer in range", ex.Message);
+            }
+        }
+
+        [Fact]
+        public async void InvalidPartitions()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var invalidPartition = new List<TopicPartitionOffsetSpec>
+                    {
+                        new TopicPartitionOffsetSpec
+                        {
+                            TopicPartition = new TopicPartition(
+                                "", 0),
+                            OffsetSpec = OffsetSpec.Earliest()
+                        }
+                    };
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                    adminClient.ListOffsetsAsync(
+                        invalidPartition,
+                        option)
+                    );
+                    Assert.Contains("must be non-empty", ex.Message);
+
+                    invalidPartition = new List<TopicPartitionOffsetSpec>
+                    {
+                        new TopicPartitionOffsetSpec
+                        {
+                            TopicPartition = new TopicPartition(
+                                "correct", -1),
+                            OffsetSpec = OffsetSpec.Earliest()
+                        }
+                    };
+                    ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                    adminClient.ListOffsetsAsync(
+                        invalidPartition,
+                        option)
+                    );
+                    Assert.Contains("cannot be negative", ex.Message);
+                }
+            }
+        }
+        
+        [Fact]
+        public async void EmptyPartitions()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var result = await adminClient.ListOffsetsAsync(
+                        new List<TopicPartitionOffsetSpec>
+                        {},
+                        option);
+                    Assert.Empty(result.ResultInfos);
+                }
+            }
+        }
+
+        [Fact]
+        public async void SamePartitionDifferentOffsets()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ListOffsetsAsync(
+                            new List<TopicPartitionOffsetSpec>
+                            {
+                                new TopicPartitionOffsetSpec
+                                {
+                                    TopicPartition = new TopicPartition(
+                                        "test", 0),
+                                    OffsetSpec = OffsetSpec.Earliest()
+                                },
+                                new TopicPartitionOffsetSpec
+                                {
+                                    TopicPartition = new TopicPartition(
+                                        "test", 0),
+                                    OffsetSpec = OffsetSpec.Latest()
+                                }
+                            },
+                            option)
+                    );
+                    Assert.Contains("Partitions must not contain duplicates", ex.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async void TwoDifferentPartitions()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ListOffsetsAsync(
+                            new List<TopicPartitionOffsetSpec>
+                            {
+                                new TopicPartitionOffsetSpec
+                                {
+                                    TopicPartition = new TopicPartition(
+                                        "test", 0),
+                                    OffsetSpec = OffsetSpec.Earliest()
+                                },
+                                new TopicPartitionOffsetSpec
+                                {
+                                    TopicPartition = new TopicPartition(
+                                        "test", 1),
+                                    OffsetSpec = OffsetSpec.Latest()
+                                }
+                            },
+                            option)
+                    );
+                    Assert.Contains("Local: Timed out", ex.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async void SinglePartition()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ListOffsetsAsync(
+                            new List<TopicPartitionOffsetSpec>
+                            {
+                                new TopicPartitionOffsetSpec
+                                {
+                                    TopicPartition = new TopicPartition(
+                                        "test", 0),
+                                    OffsetSpec = OffsetSpec.Earliest()
+                                }
+                            },
+                            option)
+                    );
+                    Assert.Contains("Local: Timed out", ex.Message);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
DescribeTopics and ListOffsets should return an empty output if and empty input is passed as parameter.
Consistent with Java and user friendly for users using filter and map.