### PR TITLE
Added schema id check to the JsonSchemaResolver

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using NJsonSchema;
 using NJsonSchema.Generation;
 using Newtonsoft.Json.Linq;
-
+using Confluent.Kafka;
 
 namespace Confluent.SchemaRegistry.Serdes
 {
@@ -45,7 +45,7 @@ namespace Confluent.SchemaRegistry.Serdes
         {
             string root_str = root.SchemaString;
             JObject schema = JObject.Parse(root_str);
-            string schemaId = (string)schema["$id"];
+            string schemaId = (string)schema["$id"] ?? throw new Exception("Provided schema does not have $id property.");
             if (!dictSchemaNameToSchema.ContainsKey(schemaId))
                 this.dictSchemaNameToSchema.Add(schemaId, root);
 


### PR DESCRIPTION
**Issue:** $id property is not required for JSON schemas but in the **JsonSchemaResolver** class we need to use the schema id value and there is no null check in place for it. 

**Current behavior:** `JsonSchemaResolver` throws the following error when the provided schema does not have a schema id;

- `System.ArgumentNullException: 'Value cannot be null. Arg_ParamName_Name'` (error reason is not clear)

**Desired behavior:** `JsonSchemaResolver` throws the following exception when the schema id is null;

- `System.Exception: 'Provided schema does not have $id property.'`


If you have a different solution for this issue or any suggestion for the exception message please let me know.


