### PR TITLE
ci: Update mac build agents versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       jobs:
         - name: 'Build and test'
           commands:


### PR DESCRIPTION
- Update mac agent to 13.5 which is close to developer's local versions.
- new mac agent syntax is same as ubuntu agents