### PR TITLE
Introduce simplified producer syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ class Program
             try
             {
                 var dr = await p.ProduceAsync("test-topic", new Message<Null, string> { Value="test" });
+                // or simplified syntax
+                var dr = await p.ProduceAsync("test-topic", "test");
                 Console.WriteLine($"Delivered '{dr.Value}' to '{dr.TopicPartitionOffset}'");
             }
             catch (ProduceException<Null, string> e)
@@ -136,6 +138,8 @@ class Program
             for (int i=0; i<100; ++i)
             {
                 p.Produce("my-topic", new Message<Null, string> { Value = i.ToString() }, handler);
+                // or simplified syntax
+                p.Produce("my-topic", i.ToString(), handler);
             }
 
             // wait for up to 10 seconds for any inflight messages to be delivered.

--- a/examples/AvroBlogExamples/Program.cs
+++ b/examples/AvroBlogExamples/Program.cs
@@ -56,7 +56,7 @@ namespace AvroBlogExample
                 record.Add("Message", "a test log message");
                 record.Add("Severity", new GenericEnum(logLevelSchema, "Error"));
                 await producer
-                    .ProduceAsync("log-messages", new Message<Null, GenericRecord> { Value = record })
+                    .ProduceAsync("log-messages", record)
                     .ContinueWith(task => Console.WriteLine(
                         task.IsFaulted
                             ? $"error producing message: {task.Exception.Message}"
@@ -75,15 +75,12 @@ namespace AvroBlogExample
                     .Build())
             {
                 await producer.ProduceAsync("log-messages",
-                    new Message<Null, MessageTypes.LogMessage>
+                    new MessageTypes.LogMessage
                     {
-                        Value = new MessageTypes.LogMessage
-                        {
-                            IP = "192.168.0.1",
-                            Message = "a test message 2",
-                            Severity = MessageTypes.LogLevel.Info,
-                            Tags = new Dictionary<string, string> { { "location", "CA" } }
-                        }
+                        IP = "192.168.0.1",
+                        Message = "a test message 2",
+                        Severity = MessageTypes.LogLevel.Info,
+                        Tags = new Dictionary<string, string> { { "location", "CA" } }
                     });
 
                 producer.Flush(TimeSpan.FromSeconds(30));

--- a/examples/AvroGeneric/Program.cs
+++ b/examples/AvroGeneric/Program.cs
@@ -109,7 +109,7 @@ namespace Confluent.Kafka.Examples.AvroGeneric
 
                     try
                     {
-                        var dr = await producer.ProduceAsync(topicName, new Message<string, GenericRecord> { Key = text, Value = record });
+                        var dr = await producer.ProduceAsync(topicName, (text, record));
                         Console.WriteLine($"produced to: {dr.TopicPartitionOffset}");
                     }
                     catch (ProduceException<string, GenericRecord> ex)

--- a/examples/AvroSpecific/Program.cs
+++ b/examples/AvroSpecific/Program.cs
@@ -113,7 +113,7 @@ namespace Confluent.Kafka.Examples.AvroSpecific
                 {
                     User user = new User { name = text, favorite_color = "green", favorite_number = ++i, hourly_rate = new Avro.AvroDecimal(67.99) };
                     producer
-                        .ProduceAsync(topicName, new Message<string, User> { Key = text, Value = user })
+                        .ProduceAsync(topicName, (text, user))
                         .ContinueWith(task =>
                             {
                                 if (!task.IsFaulted)

--- a/examples/ConfluentCloud/Program.cs
+++ b/examples/ConfluentCloud/Program.cs
@@ -23,9 +23,9 @@ namespace ConfluentCloudExample
     /// <summary>
     ///     This is a simple example demonstrating how to produce a message to
     ///     Confluent Cloud then read it back again.
-    ///     
+    ///
     ///     https://www.confluent.io/confluent-cloud/
-    /// 
+    ///
     ///     Confluent Cloud does not auto-create topics. You will need to use the ccloud
     ///     cli to create the dotnet-test-topic topic before running this example. The
     ///     <ccloud bootstrap servers>, <ccloud key> and <ccloud secret> parameters are
@@ -51,11 +51,11 @@ namespace ConfluentCloudExample
 
             using (var producer = new ProducerBuilder<Null, string>(pConfig).Build())
             {
-                producer.ProduceAsync("dotnet-test-topic", new Message<Null, string> { Value = "test value" })
+                producer.ProduceAsync("dotnet-test-topic", "test value")
                     .ContinueWith(task => task.IsFaulted
                         ? $"error producing message: {task.Exception.Message}"
                         : $"produced to: {task.Result.TopicPartitionOffset}");
-                
+
                 // block until all in-flight produce requests have completed (successfully
                 // or otherwise) or 10s has elapsed.
                 producer.Flush(TimeSpan.FromSeconds(10));

--- a/examples/ExactlyOnce/Program.cs
+++ b/examples/ExactlyOnce/Program.cs
@@ -263,7 +263,7 @@ namespace Confluent.Kafka.Examples.ExactlyOnce
                 foreach (var l in lines)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(1), ct);  // slow down the calls to produce to make the output more interesting to watch.
-                    await producer.ProduceAsync(Topic_InputLines, new Message<Null, string> { Value = l }, ct);  // Note: producing synchronously is slow and should generally be avoided.
+                    await producer.ProduceAsync(Topic_InputLines, l, ct);  // Note: producing synchronously is slow and should generally be avoided.
                     lCount += 1;
                     if (lCount % 10 == 0)
                     {
@@ -406,7 +406,7 @@ namespace Confluent.Kafka.Examples.ExactlyOnce
                                 {
                                     try
                                     {
-                                        producer.Produce(Topic_Words, new Message<string, Null> { Key = w });
+                                        producer.Produce(Topic_Words, (w, null));
                                         // Note: when using transactions, there is no need to check for errors of individual
                                         // produce call delivery reports because if the transaction commits successfully, you
                                         // can be sure that all the constituent messages were delivered successfully and in order.
@@ -661,7 +661,7 @@ namespace Confluent.Kafka.Examples.ExactlyOnce
                             count += 1;
                             WordCountState[cr.Partition].Session.Upsert(key, count);
 
-                            producer.Produce(Topic_Counts, new Message<string, int> { Key = cr.Message.Key, Value = count });
+                            producer.Produce(Topic_Counts, (cr.Message.Key, count));
 
                             wCount += 1;
                         }

--- a/examples/ExactlyOnceOldBroker/Program.cs
+++ b/examples/ExactlyOnceOldBroker/Program.cs
@@ -195,7 +195,7 @@ namespace Confluent.Kafka.Examples.Transactions
                 foreach (var l in lines)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(1), ct);  // slow down the calls to produce to make the output more interesting to watch.
-                    await producer.ProduceAsync(Topic_InputLines, new Message<Null, string> { Value = l }, ct);
+                    await producer.ProduceAsync(Topic_InputLines, l, ct);
                     lCount += 1;
                     if (lCount % 10 == 0)
                     {
@@ -330,7 +330,7 @@ namespace Confluent.Kafka.Examples.Transactions
                             {
                                 try
                                 {
-                                    producerState[cr.TopicPartition].Producer.Produce(Topic_Words, new Message<string, Null> { Key = w });
+                                    producerState[cr.TopicPartition].Producer.Produce(Topic_Words, (w, null));
                                     // Note: when using transactions, there is no need to check for errors of individual
                                     // produce call delivery reports because if the transaction commits successfully, you
                                     // can be sure that all the constituent messages were delivered successfully and in order.
@@ -562,7 +562,7 @@ namespace Confluent.Kafka.Examples.Transactions
                             try
                             {
                                 producerState[cr.TopicPartition].Producer.Produce(
-                                    Topic_Counts, new Message<string, int> { Key = cr.Message.Key, Value = updatedV });
+                                    Topic_Counts, (cr.Message.Key, updatedV));
                             }
                             catch (KafkaException e)
                             {

--- a/examples/JsonSerialization/Program.cs
+++ b/examples/JsonSerialization/Program.cs
@@ -26,7 +26,7 @@ using Newtonsoft.Json;
 
 
 /// <summary>
-///     An example of working with JSON data, Apache Kafka and 
+///     An example of working with JSON data, Apache Kafka and
 ///     Confluent Schema Registry (v5.5 or later required for
 ///     JSON schema support).
 /// </summary>
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.Examples.JsonSerialization
 {
     /// <summary>
     ///     A POCO class corresponding to the JSON data written
-    ///     to Kafka, where the schema is implicitly defined through 
+    ///     to Kafka, where the schema is implicitly defined through
     ///     the class properties and their attributes.
     /// </summary>
     /// <remarks>
@@ -83,7 +83,7 @@ namespace Confluent.Kafka.Examples.JsonSerialization
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
                 // Note: you can specify more than one schema registry url using the
-                // schema.registry.url property for redundancy (comma separated list). 
+                // schema.registry.url property for redundancy (comma separated list).
                 // The property name is not plural to follow the convention set by
                 // the Java implementation.
                 Url = schemaRegistryUrl
@@ -149,11 +149,11 @@ namespace Confluent.Kafka.Examples.JsonSerialization
                 while ((text = Console.ReadLine()) != "q")
                 {
                     User user = new User { Name = text, FavoriteColor = "blue", FavoriteNumber = i++ };
-                    try 
+                    try
                     {
-                        await producer.ProduceAsync(topicName, new Message<string, User> { Value = user });
+                        await producer.ProduceAsync(topicName, user);
                     }
-                    catch (Exception e) 
+                    catch (Exception e)
                     {
                         Console.WriteLine($"error producing message: {e.Message}");
                     }

--- a/examples/JsonWithReferences/Program.cs
+++ b/examples/JsonWithReferences/Program.cs
@@ -234,11 +234,7 @@ namespace Confluent.Kafka.Examples.JsonWithReferences
                     };
                     try
                     {
-                        await producer.ProduceAsync(topicName, new Message<long, Product>
-                        {
-                            Key = product.ProductId,
-                            Value = product
-                        });
+                        await producer.ProduceAsync(topicName, (product.ProductId, product));
                     }
                     catch (Exception e)
                     {

--- a/examples/OAuthOIDC/Program.cs
+++ b/examples/OAuthOIDC/Program.cs
@@ -107,7 +107,7 @@ namespace Confluent.Kafka.Examples.OAuthOIDC
                         var msg = Guid.NewGuid().ToString();
                         try
                         {
-                            var deliveryReport = await producer.ProduceAsync(topicName, new Message<string, string> { Value = msg });
+                            var deliveryReport = await producer.ProduceAsync(topicName, msg);
                             Console.WriteLine($"Produced message to {deliveryReport.TopicPartitionOffset}, {msg}");
                         }
                         catch (ProduceException<string, string> e)

--- a/examples/OAuthProducer/Program.cs
+++ b/examples/OAuthProducer/Program.cs
@@ -113,7 +113,7 @@ namespace Confluent.Kafka.Examples.OAuthProducer
 
                     try
                     {
-                        var deliveryReport = await producer.ProduceAsync(topicName, new Message<string, string> { Value = msg });
+                        var deliveryReport = await producer.ProduceAsync(topicName, msg);
                         Console.WriteLine($"Produced message to {deliveryReport.TopicPartitionOffset}, {msg}");
                     }
                     catch (ProduceException<string, string> e)

--- a/examples/Producer/Program.cs
+++ b/examples/Producer/Program.cs
@@ -96,7 +96,7 @@ namespace Confluent.Kafka.Examples.ProducerExample
                         // from proceeding until the acknowledgement from the broker is received (at the 
                         // expense of low throughput).
                         var deliveryReport = await producer.ProduceAsync(
-                            topicName, new Message<string, string> { Key = key, Value = val });
+                            topicName, (key, val));
 
                         Console.WriteLine($"delivered to: {deliveryReport.TopicPartitionOffset}");
                     }

--- a/examples/Protobuf/Program.cs
+++ b/examples/Protobuf/Program.cs
@@ -111,7 +111,7 @@ namespace Confluent.Kafka.Examples.Protobuf
                 {
                     User user = new User { Name = text, FavoriteColor = "green", FavoriteNumber = i++ };
                     await producer
-                        .ProduceAsync(topicName, new Message<string, User> { Key = text, Value = user })
+                        .ProduceAsync(topicName, (text,  user))
                         .ContinueWith(task => task.IsFaulted
                             ? $"error producing message: {task.Exception.Message}"
                             : $"produced to: {task.Result.TopicPartitionOffset}");

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -97,7 +97,7 @@ namespace Confluent.Kafka
             }
             catch (Exception)
             {
-                // Eat any exception thrown by user error handler code. Although these could be 
+                // Eat any exception thrown by user error handler code. Although these could be
                 // exposed to the application via the initiating function call easily enough,
                 // they aren't for consistency with the producer (where the poll method is called)
                 // on a background thread.
@@ -118,7 +118,7 @@ namespace Confluent.Kafka
             {
                 handlerException = e;
             }
-            
+
             return 0; // instruct librdkafka to immediately free the json ptr.
         }
 
@@ -172,9 +172,9 @@ namespace Confluent.Kafka
             {
                 // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
                 if (kafkaHandle.IsClosed)
-                { 
+                {
                     // The RebalanceCallback should never be invoked as a side effect of Dispose.
-                    // If for some reason flow of execution gets here, something is badly wrong. 
+                    // If for some reason flow of execution gets here, something is badly wrong.
                     // (and we have a closed librdkafka handle that is expecting an assign call...)
                     throw new Exception("Unexpected rebalance callback on disposed kafkaHandle");
                 }
@@ -578,13 +578,13 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Releases all resources used by this Consumer without
         ///     committing offsets and without alerting the group coordinator
-        ///     that the consumer is exiting the group. If you do not call 
+        ///     that the consumer is exiting the group. If you do not call
         ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close" /> or
         ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Unsubscribe" />
-        ///     prior to Dispose, the group will rebalance after a timeout 
+        ///     prior to Dispose, the group will rebalance after a timeout
         ///     specified by group's `session.timeout.ms`.
-        ///     You should commit offsets / unsubscribe from the group before 
-        ///     calling this method (typically by calling 
+        ///     You should commit offsets / unsubscribe from the group before
+        ///     calling this method (typically by calling
         ///     <see cref="Confluent.Kafka.Consumer{TKey,TValue}.Close()" />).
         /// </summary>
         public void Dispose()
@@ -607,7 +607,7 @@ namespace Confluent.Kafka
         {
             // Calling Dispose a second or subsequent time should be a no-op.
             lock (disposeHasBeenCalledLockObj)
-            { 
+            {
                 if (disposeHasBeenCalled) { return; }
                 disposeHasBeenCalled = true;
             }
@@ -858,13 +858,7 @@ namespace Confluent.Kafka
                             TopicPartitionOffset = new TopicPartitionOffset(topic,
                                 msg.partition, msg.offset,
                                 msgLeaderEpoch),
-                            Message = new Message<byte[], byte[]>
-                            {
-                                Timestamp = timestamp,
-                                Headers = headers,
-                                Key = KeyAsByteArray(msg),
-                                Value = ValueAsByteArray(msg)
-                            },
+                            Message = (KeyAsByteArray(msg), ValueAsByteArray(msg), timestamp, headers),
                             IsPartitionEOF = false
                         },
                         kafkaHandle.CreatePossiblyFatalMessageError(msgPtr));
@@ -891,13 +885,7 @@ namespace Confluent.Kafka
                             TopicPartitionOffset = new TopicPartitionOffset(topic,
                                 msg.partition, msg.offset,
                                 msgLeaderEpoch),
-                            Message = new Message<byte[], byte[]>
-                            {
-                                Timestamp = timestamp,
-                                Headers = headers,
-                                Key = KeyAsByteArray(msg),
-                                Value = ValueAsByteArray(msg)
-                            },
+                            Message = (KeyAsByteArray(msg), ValueAsByteArray(msg), timestamp, headers),
                             IsPartitionEOF = false
                         },
                         new Error(ErrorCode.Local_KeyDeserialization),
@@ -925,31 +913,19 @@ namespace Confluent.Kafka
                             TopicPartitionOffset = new TopicPartitionOffset(topic,
                                 msg.partition, msg.offset,
                                 msgLeaderEpoch),
-                            Message = new Message<byte[], byte[]>
-                            {
-                                Timestamp = timestamp,
-                                Headers = headers,
-                                Key = KeyAsByteArray(msg),
-                                Value = ValueAsByteArray(msg)
-                            },
+                            Message = (KeyAsByteArray(msg), ValueAsByteArray(msg), timestamp, headers),
                             IsPartitionEOF = false
                         },
                         new Error(ErrorCode.Local_ValueDeserialization),
                         ex);
                 }
 
-                return new ConsumeResult<TKey, TValue> 
+                return new ConsumeResult<TKey, TValue>
                 {
                     TopicPartitionOffset = new TopicPartitionOffset(topic,
                         msg.partition, msg.offset,
                         msgLeaderEpoch),
-                    Message = new Message<TKey, TValue>
-                    {
-                        Timestamp = timestamp,
-                        Headers = headers,
-                        Key = key,
-                        Value = val
-                    },
+                    Message = (key, val, timestamp, headers),
                     IsPartitionEOF = false
                 };
             }

--- a/src/Confluent.Kafka/Message.cs
+++ b/src/Confluent.Kafka/Message.cs
@@ -33,5 +33,57 @@ namespace Confluent.Kafka
         ///     Gets the message value (possibly null).
         /// </summary>
         public TValue Value { get; set; }
+
+        /// <summary>
+        /// Implicit conversion from value to <see cref="Message{TKey, TValue}"/>.
+        /// This conversion may be useful in case when key is <see cref="Null"/>.
+        /// </summary>
+        /// <param name="message">Value.</param>
+        public static implicit operator Message<TKey, TValue>(TValue message)
+        {
+            return new Message<TKey, TValue> { Value = message };
+        }
+
+        /// <summary>
+        /// Implicit conversion from tuple to <see cref="Message{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="message">Tuple of value and headers.</param>
+        public static implicit operator Message<TKey, TValue>((TValue, Headers) message)
+        {
+            return new Message<TKey, TValue> { Value = message.Item1, Headers = message.Item2 };
+        }
+
+        /// <summary>
+        /// Implicit conversion from tuple to <see cref="Message{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="message">Tuple of value and timestamp.</param>
+        public static implicit operator Message<TKey, TValue>((TValue, Timestamp) message)
+        {
+            return new Message<TKey, TValue> { Value = message.Item1, Timestamp = message.Item2 };
+        }
+
+        /// <summary>
+        /// Implicit conversion from tuple to <see cref="Message{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="message">Tuple of key and value.</param>
+        public static implicit operator Message<TKey, TValue>((TKey, TValue) message)
+        {
+            return new Message<TKey, TValue> { Key = message.Item1, Value = message.Item2 };
+        }
+
+        /// <summary>
+        /// Implicit conversion from tuple to <see cref="Message{TKey, TValue}"/>..
+        /// </summary>
+        /// <param name="message">Tuple of key, value, timestamp and headers.</param>
+        public static implicit operator Message<TKey, TValue>((TKey, TValue, Timestamp, Headers) message)
+        {
+            return new Message<TKey, TValue>
+            {
+                Key = message.Item1,
+                Value = message.Item2,
+                Timestamp = message.Item3,
+                Headers = message.Item4
+            };
+        }
     }
 }

--- a/src/Confluent.Kafka/Null.cs
+++ b/src/Confluent.Kafka/Null.cs
@@ -19,7 +19,7 @@ namespace Confluent.Kafka
 {
     /// <summary>
     ///     A type for use in conjunction with NullSerializer and NullDeserializer
-    ///     that enables null key or values to be enforced when producing or 
+    ///     that enables null key or values to be enforced when producing or
     ///     consuming messages.
     /// </summary>
     public sealed class Null

--- a/test/Confluent.Kafka.Benchmark/BenchmarkProducer.cs
+++ b/test/Confluent.Kafka.Benchmark/BenchmarkProducer.cs
@@ -72,7 +72,7 @@ namespace Confluent.Kafka.Benchmark
                     var val = new byte[msgSize].Select(a => ++cnt).ToArray();
 
                     // this avoids including connection setup, topic creation time, etc.. in result.
-                    firstDeliveryReport = producer.ProduceAsync(topic, new Message<Null, byte[]> { Value = val, Headers = headers }).Result;
+                    firstDeliveryReport = producer.ProduceAsync(topic, (val, headers)).Result;
 
                     var startTime = DateTime.Now.Ticks;
 
@@ -99,7 +99,7 @@ namespace Confluent.Kafka.Benchmark
                         {
                             try
                             {
-                                producer.Produce(topic, new Message<Null, byte[]> { Value = val, Headers = headers }, deliveryHandler);
+                                producer.Produce(topic, (val, headers), deliveryHandler);
                             }
                             catch (ProduceException<Null, byte[]> ex)
                             {
@@ -131,7 +131,7 @@ namespace Confluent.Kafka.Benchmark
                             var tasks = new Task[nMessages];
                             for (int i = 0; i < nMessages; i += 1)
                             {
-                                tasks[i] = producer.ProduceAsync(topic, new Message<Null, byte[]> { Value = val, Headers = headers });
+                                tasks[i] = producer.ProduceAsync(topic, (val, headers));
                                 if (tasks[i].IsFaulted)
                                 {
                                     if (((ProduceException<Null, byte[]>)tasks[i].Exception.InnerException).Error.Code == ErrorCode.Local_QueueFull)

--- a/test/Confluent.Kafka.Benchmark/Latency.cs
+++ b/test/Confluent.Kafka.Benchmark/Latency.cs
@@ -167,7 +167,7 @@ namespace Confluent.Kafka.Benchmark
                         {
                             bw.Write(elapsedMilliseconds);
                         }
-                        producer.Produce(topicName, new Message<Null, byte[]> { Value = payload, Headers = headers },
+                        producer.Produce(topicName, (payload, headers),
                             dr => { if (dr.Error.Code != ErrorCode.NoError) Console.WriteLine("Message delivery failed: " + dr.Error.Reason); });
 
                         var desiredProduceCount = (elapsedMilliseconds - startMilliseconds)/1000.0 * messagesPerSecond;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterListConsumerGroupOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterListConsumerGroupOffsets.cs
@@ -55,7 +55,7 @@ namespace Confluent.Kafka.IntegrationTests
                     {
                         producer.Produce(
                             new TopicPartition(topic.Name, 0),
-                            new Message<string, string> { Key = "test key " + i, Value = "test val " + i });
+                            ("test key " + i, "test val " + i));
 
                     }
                     producer.Flush(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteRecords.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteRecords.cs
@@ -42,8 +42,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 for (int i=0; i<10; ++i)
                 {
-                    producer.Produce(topic1.Name, new Message<Null, string> { Value = i.ToString() });
-                    producer.Produce(topic2.Name, new Message<Null, string> { Value = i.ToString() });
+                    producer.Produce(topic1.Name, i.ToString());
+                    producer.Produce(topic2.Name, i.ToString());
                 }
                 producer.Flush(TimeSpan.FromSeconds(10));
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListOffsets.cs
@@ -28,17 +28,17 @@ namespace Confluent.Kafka.IntegrationTests
         public async void AdminClient_ListOffsets(string bootstrapServers)
         {
             LogToFile("start AdminClient_ListOffsets");
-            
+
             using var topic = new TemporaryTopic(bootstrapServers, 1);
             using var producer = new ProducerBuilder<Null, string>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build();
             using var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
-            
+
             long basetimestamp = 10000000;
-            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 100, TimestampType.CreateTime)});
-            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 400, TimestampType.CreateTime)});
-            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 250, TimestampType.CreateTime)});
+            await producer.ProduceAsync(topic.Name, ("Producer Message", new Timestamp(basetimestamp + 100, TimestampType.CreateTime)));
+            await producer.ProduceAsync(topic.Name, ("Producer Message", new Timestamp(basetimestamp + 400, TimestampType.CreateTime)));
+            await producer.ProduceAsync(topic.Name, ("Producer Message", new Timestamp(basetimestamp + 250, TimestampType.CreateTime)));
             producer.Flush(new TimeSpan(0, 0, 10));
-            
+
             var timeout = TimeSpan.FromSeconds(30);
             ListOffsetsOptions options = new ListOffsetsOptions(){RequestTimeout = timeout, IsolationLevel = IsolationLevel.ReadUncommitted};
 
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Tuple.Create(OffsetSpec.MaxTimestamp(), new Offset(1)),
                 Tuple.Create(OffsetSpec.ForTimestamp(basetimestamp + 150), new Offset(1)),
             };
-            
+
             foreach (var fixture in testFixtures)
             {
                 var offsetSpec = fixture.Item1;
@@ -62,7 +62,7 @@ namespace Confluent.Kafka.IntegrationTests
                         OffsetSpec = offsetSpec
                     }
                 };
-                
+
                 var listOffsetsResult = await adminClient.ListOffsetsAsync(topicPartitionOffsetSpecs, options);
 
                 foreach (var resultInfo in listOffsetsResult.ResultInfos)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -50,10 +50,10 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<Null, string> dr, dr3;
             using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString }).Result;
-                producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString2 }).Wait();
-                dr3 = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString3 }).Result;
-                producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString4 }).Wait();
+                dr = producer.ProduceAsync(singlePartitionTopic, testString).Result;
+                producer.ProduceAsync(singlePartitionTopic, testString2).Wait();
+                dr3 = producer.ProduceAsync(singlePartitionTopic, testString3).Result;
+                producer.ProduceAsync(singlePartitionTopic, testString4).Wait();
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
@@ -64,7 +64,7 @@ namespace Confluent.Kafka.IntegrationTests
                 var cr = consumer.Consume(TimeSpan.FromSeconds(10));
                 consumer.Commit();
                 Assert.Equal(cr.Message.Value, testString);
-                
+
                 // Determine offset to consume from automatically.
                 consumer.Assign(new List<TopicPartition>() { dr.TopicPartition });
                 cr = consumer.Consume(TimeSpan.FromSeconds(10));

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -47,7 +47,7 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<Null, byte[]> dr;
             using (var producer = new ProducerBuilder<Null, byte[]>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize(testString, SerializationContext.Empty)).Result;
                 Assert.True(dr.Offset >= 0);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -110,7 +110,7 @@ namespace Confluent.Kafka.IntegrationTests
             var dr = new DeliveryResult<string, string>();
             using (var p = new MyProducerBuilder<string, string>(producerConfig).Build())
             {
-                dr = p.ProduceAsync(singlePartitionTopic, new Message<string, string> { Key = "abc", Value = "123" }).Result;
+                dr = p.ProduceAsync(singlePartitionTopic, ("abc", "123")).Result;
             }
             
             var consumerConfig = new ConsumerConfig

--- a/test/Confluent.Kafka.IntegrationTests/Tests/CancellationDelayMax.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/CancellationDelayMax.cs
@@ -88,8 +88,8 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Close();
 
                 // for the producer, make do with just a simple check that this does not throw or hang.
-                var dr = producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 42 }, Value = new byte[] { 255 } }).Result;
-                
+                var dr = producer.ProduceAsync(topic.Name, (new byte[] { 42 }, new byte[] { 255 })).Result;
+
                 // for the admin client, make do with just simple check that this does not throw or hang.
                 var cr = new Confluent.Kafka.Admin.ConfigResource { Type = ResourceType.Topic, Name = topic.Name };
                 var configs = adminClient.DescribeConfigsAsync(new ConfigResource[] { cr }).Result;

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -46,11 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 dr = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]>
-                    {
-                        Value = Serializers.Utf8.Serialize("my-value", SerializationContext.Empty),
-                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
-                    }
+                    (Serializers.Utf8.Serialize("my-value", SerializationContext.Empty), new Headers() { new Header("my-header", new byte[] { 42 }) })
                 ).Result;
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -46,11 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 dr = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]>
-                    {
-                        Value = Serializers.Utf8.Serialize("my-value", SerializationContext.Empty),
-                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
-                    }
+                    (Serializers.Utf8.Serialize("my-value", SerializationContext.Empty), new Headers() { new Header("my-header", new byte[] { 42 }) })
                 ).Result;
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_MissingCommits.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_MissingCommits.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
                     {
                         for (int j=0; j<numMessagesPerPartition; ++j)
                         {
-                            producer.Produce(new TopicPartition(topic.Name, i), new Message<Null, string> { Value = "test" });
+                            producer.Produce(new TopicPartition(topic.Name, i), "test");
                         }
                     }
                     producer.Flush();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_OffsetsForTimes.cs
@@ -128,13 +128,12 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     var message = producer.ProduceAsync(
                         new TopicPartition(topic, partition),
-                        new Message<byte[], byte[]>
-                        { 
-                            Key = Serializers.Utf8.Serialize($"test key {index}", SerializationContext.Empty),
-                            Value = Serializers.Utf8.Serialize($"test val {index}", SerializationContext.Empty),
-                            Timestamp = new Timestamp(baseTime + index*1000, TimestampType.CreateTime),
-                            Headers = null
-                        }
+                        (
+                        Serializers.Utf8.Serialize($"test key {index}", SerializationContext.Empty),
+                        Serializers.Utf8.Serialize($"test val {index}", SerializationContext.Empty),
+                        new Timestamp(baseTime + index*1000, TimestampType.CreateTime),
+                        null
+                        )
                     ).Result;
                     messages[index] = message;
                     Task.Delay(200).Wait();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -61,13 +61,13 @@ namespace Confluent.Kafka.IntegrationTests
                 ConsumeResult<byte[], byte[]> record = consumer.Consume(TimeSpan.FromSeconds(2));
                 Assert.Null(record);
 
-                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(topic.Name, Serializers.Utf8.Serialize("test value", SerializationContext.Empty)).Wait();
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record?.Message);
                 Assert.Equal(0, record?.Offset);
 
                 consumer.Pause(assignment);
-                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value 2", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(topic.Name, Serializers.Utf8.Serialize("test value 2", SerializationContext.Empty)).Wait();
                 record = consumer.Consume(TimeSpan.FromSeconds(2));
                 Assert.Null(record);
                 consumer.Resume(assignment);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_DeserializationError.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_DeserializationError.cs
@@ -41,9 +41,9 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 var keyData = Encoding.UTF8.GetBytes("key");
-                firstProduced = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Key = keyData }).Result.TopicPartitionOffset;
+                firstProduced = producer.ProduceAsync(singlePartitionTopic, (keyData, (byte[])null)).Result.TopicPartitionOffset;
                 var valData = Encoding.UTF8.GetBytes("val");
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = valData });
+                producer.ProduceAsync(singlePartitionTopic, valData);
                 Assert.True(producer.Flush(TimeSpan.FromSeconds(10)) == 0);
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
@@ -49,9 +49,9 @@ namespace Confluent.Kafka.IntegrationTests
                     .Build())
             {
                 const string checkValue = "check value";
-                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(checkValue, SerializationContext.Empty) }).Result;
-                var dr2 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("second value", SerializationContext.Empty) }).Result;
-                var dr3 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("third value", SerializationContext.Empty) }).Result;
+                var dr = producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize(checkValue, SerializationContext.Empty)).Result;
+                var dr2 = producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize("second value", SerializationContext.Empty)).Result;
+                var dr3 = producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize("third value", SerializationContext.Empty)).Result;
 
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 
@@ -60,7 +60,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.NotNull(record.Message);
                 // check leader epoch of first record
                 Assert.Equal(0, record.LeaderEpoch);
-                
+
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
@@ -74,18 +74,18 @@ namespace Confluent.Kafka.IntegrationTests
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Equal(checkValue, record.Message.Value);
-                
+
                 consumer.Seek(firstRecord.TopicPartitionOffset);
-                
+
                 // position shouldn't be equal to the seek position.
                 var tpo = consumer.PositionTopicPartitionOffset(record.TopicPartition);
                 Assert.NotEqual(firstRecord.Offset, tpo.Offset);
-                
+
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record.Message);
                 Assert.Equal(checkValue, record.Message.Value);
                 Assert.Equal(0, record.LeaderEpoch);
-                
+
                 // position should be equal to last consumed message position + 1.
                 tpo = consumer.PositionTopicPartitionOffset(record.TopicPartition);
                 Assert.Equal(record.Offset + 1, tpo.Offset);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
@@ -64,7 +64,7 @@ namespace Confluent.Kafka.IntegrationTests
                 ConsumeResult<Null, string> record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.Null(record);
 
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test store offset value", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize("test store offset value", SerializationContext.Empty)).Wait();
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record?.Message);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -52,7 +52,7 @@ namespace Confluent.Kafka.IntegrationTests
                 DeliveryResult<byte[], byte[]> dr;
                 using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
                 {
-                    dr = producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }).Result;
+                    dr = producer.ProduceAsync(topic.Name, Serializers.Utf8.Serialize(testString, SerializationContext.Empty)).Result;
                     Assert.NotNull(dr);
                     producer.Flush(TimeSpan.FromSeconds(10));
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -40,7 +40,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }).Wait();
+                producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize("test string", SerializationContext.Empty)).Wait();
             }
 
             using (var consumer = new ConsumerBuilder<byte[], byte[]>(consumerConfig).Build())

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -56,7 +56,7 @@ namespace Confluent.Kafka.IntegrationTests
                 headers.Add("test-header", new byte[] { 142 } );
                 dr_single = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value", Headers = headers }).Result;
+                    ("the value", headers)).Result;
                 Assert.Single(dr_single.Message.Headers);
                 Assert.Equal("test-header", dr_single.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 142 }, dr_single.Message.Headers[0].GetValueBytes());
@@ -65,13 +65,13 @@ namespace Confluent.Kafka.IntegrationTests
                 var headers0 = new Headers();
                 dr_empty = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value", Headers = headers0 }).Result;
+                    ("the value", headers0)).Result;
                 Assert.Empty(dr_empty.Message.Headers);
 
                 // null header value
                 dr_null = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value" }).Result;
+                    "the value").Result;
                 Assert.Empty(dr_null.Message.Headers);
 
                 // multiple header values (also Headers no Dictionary, since order is tested).
@@ -80,7 +80,7 @@ namespace Confluent.Kafka.IntegrationTests
                 headers2.Add("test-header-b", new byte[] { 112 } );
                 dr_multiple = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value", Headers = headers2 }).Result;
+                    ("the value", headers2)).Result;
                 Assert.Equal(2, dr_multiple.Message.Headers.Count);
                 Assert.Equal("test-header-a", dr_multiple.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 111 }, dr_multiple.Message.Headers[0].GetValueBytes());
@@ -94,7 +94,7 @@ namespace Confluent.Kafka.IntegrationTests
                 headers3.Add(new Header("test-header-a", new byte[] { 113 } ));
                 headers3.Add(new Header("test-header-b", new byte[] { 114 } ));
                 headers3.Add(new Header("test-header-c", new byte[] { 115 } ));
-                dr_duplicate = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "the value", Headers = headers3 }).Result;
+                dr_duplicate = producer.ProduceAsync(singlePartitionTopic, ("the value", headers3)).Result;
                 Assert.Equal(5, dr_duplicate.Message.Headers.Count);
                 Assert.Equal("test-header-a", dr_duplicate.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 111 }, dr_duplicate.Message.Headers[0].GetValueBytes());
@@ -103,11 +103,11 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Test headers work as expected with all serializing ProduceAsync variants.
 
-                dr_ol1 = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "the value" }).Result;
+                dr_ol1 = producer.ProduceAsync(singlePartitionTopic, "the value").Result;
                 Assert.Empty(dr_ol1.Message.Headers);
                 dr_ol3 = producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> { Value = "the value", Headers = headers }
+                    ("the value", headers)
                 ).Result;
                 Assert.Single(dr_ol3.Message.Headers);
                 Assert.Equal("test-header", dr_ol3.Message.Headers[0].Key);
@@ -117,10 +117,10 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Test headers work as expected with all serializing Produce variants. 
 
-                producer.Produce(singlePartitionTopic, new Message<Null, string> { Value = "the value" }, dh);
+                producer.Produce(singlePartitionTopic, "the value", dh);
                 producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0), 
-                    new Message<Null, string> { Value = "the value", Headers = headers2},
+                    ("the value", headers2),
                     dh);
 
                 producer.Flush(TimeSpan.FromSeconds(10));
@@ -309,7 +309,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var headers = new Headers();
                 headers.Add("my-header", null);
-                nulldr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "test-value", Headers = headers }).Result;
+                nulldr = producer.ProduceAsync(singlePartitionTopic, ("test-value", headers)).Result;
                 Assert.Single(nulldr.Headers);
                 Assert.Null(nulldr.Headers[0].GetValueBytes());
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers_SerializationContext.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers_SerializationContext.cs
@@ -78,7 +78,7 @@ namespace Confluent.Kafka.IntegrationTests
                 .SetValueDeserializer(new TestDeserializer())
                 .Build())
             {
-                producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "aaa" });
+                producer.ProduceAsync(topic.Name, "aaa");
                 consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
                 var cr = consumer.Consume();
                 Assert.NotNull(cr.Message);
@@ -99,7 +99,7 @@ namespace Confluent.Kafka.IntegrationTests
                 .SetValueDeserializer(new TestDeserializer())
                 .Build())
             {
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Value = "aaa", Headers = new Headers { new Header("original", new byte[] { 32 }) } });
+                producer.ProduceAsync(topic.Name, ("aaa", new Headers { new Header("original", new byte[] { 32 }) }));
                 consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
                 var cr = consumer.Consume();
                 Assert.NotNull(cr.Message);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -40,10 +40,10 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 // Assume that all these produce calls succeed.
-                dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }).Result;
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = new byte[1] { 1 } }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[1] { 0 }, Value = null }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[1] { 42 }, Value = new byte[2] { 42, 240 } }).Wait();
+                dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), ((byte[])null, (byte[])null)).Result;
+                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), (null, new byte[1] { 1 })).Wait();
+                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), (new byte[1] { 0 }, (byte[])null)).Wait();
+                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), (new byte[1] { 42 }, new byte[2] { 42, 240 })).Wait();
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -60,7 +60,7 @@ namespace Confluent.Kafka.IntegrationTests
                     .SetLogHandler((_, m) => logCount += 1)
                     .Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }).Result;
+                dr = producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize("test value", SerializationContext.Empty)).Result;
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -46,10 +46,10 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 // Assume that all these produce calls succeed.
-                dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }).Result;
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = new byte[0] {} }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[0] {}, Value = null }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[0] {}, Value = new byte[0] {} }).Wait();
+                dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), ((byte[])null, (byte[])null)).Result;
+                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), (null, new byte[0] {})).Wait();
+                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), (new byte[0] {}, (byte[])null)).Wait();
+                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), (new byte[0] {}, new byte[0] {})).Wait();
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.IntegrationTests
             // Producing onto the topic to make sure it exists.
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }).Result;
+                var dr = producer.ProduceAsync(singlePartitionTopic, Serializers.Utf8.Serialize("test string", SerializationContext.Empty)).Result;
                 Assert.NotEqual(Offset.Unset, dr.Offset);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_CustomPartitioner.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_CustomPartitioner.cs
@@ -107,7 +107,7 @@ namespace Confluent.Kafka.IntegrationTests
                         {
                             producer.Produce(
                                 topic.Name,
-                                new Message<string, string> { Key = $"test key {i}", Value = $"test val {i}" }, dh);
+                                ($"test key {i}", $"test val {i}"), dh);
                         }
 
                         producer.Flush(TimeSpan.FromSeconds(10));
@@ -134,7 +134,7 @@ namespace Confluent.Kafka.IntegrationTests
                 })
                 .Build())
             {
-                producer.Produce(topic.Name, new Message<Null, string> { Value = "test value" });
+                producer.Produce(topic.Name, "test value");
                 producer.Flush(TimeSpan.FromSeconds(10));
                 Assert.Equal(1, partitionerCalledTimes);
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_DisableDeliveryReports.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_DisableDeliveryReports.cs
@@ -53,29 +53,29 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 Assert.Throws<InvalidOperationException>(() => producer.Produce(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue },
+                    (TestKey, TestValue),
                     (DeliveryReport<byte[], byte[]> dr) => Console.WriteLine("should not print")));
 
                 Assert.Throws<InvalidOperationException>(() => producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue },
+                    (TestKey, TestValue),
                     (DeliveryReport<byte[], byte[]> dr) => Console.WriteLine("should not print")));
 
                 producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    (TestKey, TestValue));
 
                 producer.Produce(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    (TestKey, TestValue));
 
                 producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    (TestKey, TestValue));
 
                 var drTask = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    (TestKey, TestValue));
                 Assert.True(drTask.IsCompleted); // should complete immediately.
                 Assert.Equal(Offset.Unset, drTask.Result.Offset);
                 Assert.Equal(Partition.Any, drTask.Result.Partition);
@@ -85,7 +85,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 drTask = producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    (TestKey, TestValue));
                 Assert.True(drTask.IsCompleted); // should complete immediately.
                 Assert.Equal(Offset.Unset, drTask.Result.Offset);
                 Assert.Equal(0, (int)drTask.Result.Partition);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
@@ -46,32 +46,32 @@ namespace Confluent.Kafka.IntegrationTests
                 using (var producer7 = new ProducerBuilder<double, double>(producerConfig).Build())
                 using (var adminClient = new DependentAdminClientBuilder(producer7.Handle).Build())
                 {
-                    var r1 = producer1.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 42 }, Value = new byte[] { 33 } }).Result;
+                    var r1 = producer1.ProduceAsync(topic.Name, (new byte[] { 42 }, new byte[] { 33 })).Result;
                     Assert.Equal(new byte[] { 42 }, r1.Key);
                     Assert.Equal(new byte[] { 33 }, r1.Value);
                     Assert.Equal(0, r1.Offset);
 
-                    var r2 = producer2.ProduceAsync(topic.Name, new Message<string, string> { Key = "hello", Value = "world" }).Result;
+                    var r2 = producer2.ProduceAsync(topic.Name, ("hello", "world")).Result;
                     Assert.Equal("hello", r2.Key);
                     Assert.Equal("world", r2.Value);
 
-                    var r3 = producer3.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 40 }, Value = new byte[] { 31 } }).Result;
+                    var r3 = producer3.ProduceAsync(topic.Name, (new byte[] { 40 }, new byte[] { 31 })).Result;
                     Assert.Equal(new byte[] { 40 }, r3.Key);
                     Assert.Equal(new byte[] { 31 }, r3.Value);
 
-                    var r4 = producer4.ProduceAsync(topic.Name, new Message<int, string> { Key = 42, Value = "mellow world" }).Result;
+                    var r4 = producer4.ProduceAsync(topic.Name, (42, "mellow world")).Result;
                     Assert.Equal(42, r4.Key);
                     Assert.Equal("mellow world", r4.Value);
 
-                    var r5 = producer5.ProduceAsync(topic.Name, new Message<int, int> { Key = int.MaxValue, Value = int.MinValue }).Result;
+                    var r5 = producer5.ProduceAsync(topic.Name, (int.MaxValue, int.MinValue)).Result;
                     Assert.Equal(int.MaxValue, r5.Key);
                     Assert.Equal(int.MinValue, r5.Value);
 
-                    var r6 = producer6.ProduceAsync(topic.Name, new Message<string, byte[]> { Key = "yellow mould", Value = new byte[] { 69 } }).Result;
+                    var r6 = producer6.ProduceAsync(topic.Name, ("yellow mould", new byte[] { 69 })).Result;
                     Assert.Equal("yellow mould", r6.Key);
                     Assert.Equal(new byte[] { 69 }, r6.Value);
 
-                    var r7 = producer7.ProduceAsync(topic.Name, new Message<double, double> { Key = 44.0, Value = 234.4 }).Result;
+                    var r7 = producer7.ProduceAsync(topic.Name, (44.0, 234.4)).Result;
                     Assert.Equal(44.0, r7.Key);
                     Assert.Equal(234.4, r7.Value);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_MultiPartitioner.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_MultiPartitioner.cs
@@ -75,12 +75,12 @@ namespace Confluent.Kafka.IntegrationTests
                     }
                 };
 
-                producer.Produce(topic1.Name, new Message<string, Null> { Key = "hello" }, dh);
-                producer.Produce(topic2.Name, new Message<string, Null> { Key = "world" }, dh);
+                producer.Produce(topic1.Name, ("hello", null), dh);
+                producer.Produce(topic2.Name, ("world", null), dh);
                 // both default and topic-specific partitioners return a fixed value > number of partitions
                 // in topic 3. If either of these partitioners is errantly used in producing this message,
                 // this test will fail most of the time.
-                producer.Produce(topic3.Name, new Message<string, Null> { Key = "kafka" }, dh);
+                producer.Produce(topic3.Name, ("kafka", null), dh);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_OptimizeDeliveryReports.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_OptimizeDeliveryReports.cs
@@ -35,24 +35,19 @@ namespace Confluent.Kafka.IntegrationTests
             byte[] TestValue = new byte[] { 5, 6, 7, 8 };
 
             var producerConfig = new ProducerConfig
-            { 
+            {
                 BootstrapServers = bootstrapServers,
                 DeliveryReportFields = "none"
             };
 
 
-            // serializing case. 
+            // serializing case.
 
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 var dr = await producer.ProduceAsync(
-                    singlePartitionTopic, 
-                    new Message<byte[], byte[]> 
-                    { 
-                        Key = TestKey, 
-                        Value = TestValue, 
-                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) } 
-                    }
+                    singlePartitionTopic,
+                    (TestKey, TestValue, default, new Headers() { new Header("my-header", new byte[] { 42 }) })
                 );
                 Assert.Equal(TimestampType.NotAvailable, dr.Timestamp.Type);
                 Assert.Equal(0, dr.Timestamp.UnixTimestampMs);
@@ -62,18 +57,13 @@ namespace Confluent.Kafka.IntegrationTests
             }
 
 
-            // byte[] case. 
+            // byte[] case.
 
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 var dr = await producer.ProduceAsync(
-                    singlePartitionTopic, 
-                    new Message<byte[], byte[]>
-                    { 
-                        Key = TestKey, 
-                        Value = TestValue, 
-                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) } 
-                    }
+                    singlePartitionTopic,
+                    (TestKey, TestValue, default, new Headers() { new Header("my-header", new byte[] { 42 }) })
                 );
                 Assert.Equal(TimestampType.NotAvailable, dr.Timestamp.Type);
                 Assert.Equal(0, dr.Timestamp.UnixTimestampMs);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll.cs
@@ -37,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
             using (var tempTopic = new TemporaryTopic(bootstrapServers, 1))
             using (var producer = new ProducerBuilder<Null, string>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                var r = producer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "a message" }).Result;
+                var r = producer.ProduceAsync(tempTopic.Name, "a message").Result;
                 Assert.True(r.Status == PersistenceStatus.Persisted);
 
                 // should be no events to serve and this should block for 500ms.
@@ -54,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 sw.Reset();
                 sw.Start();
-                producer.Produce(tempTopic.Name, new Message<Null, string> { Value = "a message 2" }, dr => Assert.False(dr.Error.IsError));
+                producer.Produce(tempTopic.Name, "a message 2", dr => Assert.False(dr.Error.IsError));
                 // should block until the callback for the Produce call executes.
                 Assert.Equal(1, producer.Poll(TimeSpan.FromSeconds(4)));
                 Assert.True(sw.ElapsedMilliseconds > 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll_Backoff.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll_Backoff.cs
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     try
                     {
-                        producer.Produce(tempTopic.Name, new Message<Null, string> { Value = "a message" });
+                        producer.Produce(tempTopic.Name, "a message");
                     }
                     catch (ProduceException<Null, string> ex)
                     {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce.cs
@@ -34,7 +34,7 @@ namespace Confluent.Kafka.IntegrationTests
             LogToFile("start Producer_Produce");
 
             var producerConfig = new ProducerConfig
-            { 
+            {
                 BootstrapServers = bootstrapServers,
                 EnableIdempotence = true,
                 LingerMs = 1.5
@@ -61,12 +61,12 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new ProducerBuilder<string, string>(producerConfig).Build())
             {
                 producer.Produce(
-                    new TopicPartition(singlePartitionTopic, 0), 
-                    new Message<string, string> { Key = "test key 0", Value = "test val 0" }, dh);
+                    new TopicPartition(singlePartitionTopic, 0),
+                    ("test key 0", "test val 0"), dh);
 
                 producer.Produce(
                     singlePartitionTopic,
-                    new Message<string, string> { Key = "test key 1", Value = "test val 1" }, dh);
+                    ("test key 1", "test val 1"), dh);
 
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
@@ -94,12 +94,12 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 producer.Produce(
-                    new TopicPartition(singlePartitionTopic, 0), 
-                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 42"), Value = Encoding.UTF8.GetBytes("test val 42") }, dh2);
+                    new TopicPartition(singlePartitionTopic, 0),
+                    (Encoding.UTF8.GetBytes("test key 42"), Encoding.UTF8.GetBytes("test val 42")), dh2);
 
                 producer.Produce(
-                    singlePartitionTopic, 
-                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 43"), Value = Encoding.UTF8.GetBytes("test val 43") }, dh2);
+                    singlePartitionTopic,
+                    (Encoding.UTF8.GetBytes("test key 43"), Encoding.UTF8.GetBytes("test val 43")), dh2);
 
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -41,7 +41,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     var dr = await producer.ProduceAsync(
                         singlePartitionTopic,
-                        new Message<Null, string> { Value = "test string" });
+                        "test string");
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                     Assert.NotEqual(Offset.Unset, dr.Offset);
                 }
@@ -66,7 +66,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") });
+                    Encoding.UTF8.GetBytes("test string"));
                 Assert.NotEqual(Offset.Unset, dr.Offset);
             }
 
@@ -91,7 +91,7 @@ namespace Confluent.Kafka.IntegrationTests
                     {
                         await producer.ProduceAsync(
                             new TopicPartition(singlePartitionTopic, 42),
-                            new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") });
+                            Encoding.UTF8.GetBytes("test string"));
                         throw new Exception("unexpected exception");
                     });
             }
@@ -104,7 +104,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     var dr = await producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 1001),
-                        new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") });
+                        Encoding.UTF8.GetBytes("test string"));
                     throw new Exception("unexpected exception.");
                 }
             };

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
@@ -43,7 +43,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drt = producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 42),
-                    new Message<string, string> { Key = "test key 0", Value = "test val 0" });
+                    ("test key 0", "test val 0"));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
@@ -78,7 +78,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drt2 = producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 42),
-                    new Message<byte[], byte[]> { Key = new byte[] { 100 }, Value = new byte[] { 101 } });
+                    (new byte[] { 100 }, new byte[] { 101 }));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_HighConcurrency.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_HighConcurrency.cs
@@ -58,14 +58,14 @@ namespace Confluent.Kafka.IntegrationTests
                 int N = workerThreads+2;
                 for (int i=0; i<N; ++i)
                 {
-                    tasks.Add(producer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "test" }));
+                    tasks.Add(producer.ProduceAsync(tempTopic.Name, "test"));
                 }
 
                 Task.WaitAll(tasks.ToArray());
 
                 for (int i=0; i<N; ++i)
                 {
-                    tasks.Add(dProducer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "test" }));
+                    tasks.Add(dProducer.ProduceAsync(tempTopic.Name, "test"));
                 }
 
                 Task.WaitAll(tasks.ToArray());

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -46,10 +46,10 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drs.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 1),
-                    new Message<string, string> { Key = "test key 0", Value = "test val 0" }));
+                    ("test key 0", "test val 0")));
                 drs.Add(producer.ProduceAsync(
                     partitionedTopic,
-                    new Message<string, string> { Key = "test key 1", Value = "test val 1" }));
+                    ("test key 1", "test val 1")));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
@@ -76,10 +76,10 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drs2.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 1),
-                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 2"), Value = Encoding.UTF8.GetBytes("test val 2") }));
+                    (Encoding.UTF8.GetBytes("test key 2"), Encoding.UTF8.GetBytes("test val 2"))));
                 drs2.Add(producer.ProduceAsync(
                     partitionedTopic,
-                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 3"), Value = Encoding.UTF8.GetBytes("test val 3") }));
+                    (Encoding.UTF8.GetBytes("test key 3"), Encoding.UTF8.GetBytes("test val 3"))));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_Async.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_Async.cs
@@ -44,16 +44,16 @@ namespace Confluent.Kafka.IntegrationTests
                 .Build())
             {
                 Assert.Throws<ProduceException<Null, string>>(
-                    () => producer.Produce(testTopic.Name, new Message<Null, string> { Value = "test" }));
+                    () => producer.Produce(testTopic.Name, "test"));
 
                 Assert.Throws<ProduceException<Null, string>>(
-                    () => producer.Produce(testTopic.Name, new Message<Null, string> { Value = "test" }, dr => { Assert.True(false); }));
+                    () => producer.Produce(testTopic.Name, "test", dr => { Assert.True(false); }));
 
                 Assert.Throws<ProduceException<string, Null>>(
-                    () => dProducer.Produce(testTopic.Name, new Message<string, Null> { Key = "test" }));
+                    () => dProducer.Produce(testTopic.Name, ("test", null)));
 
                 Assert.Throws<ProduceException<string, Null>>(
-                    () => dProducer.Produce(testTopic.Name, new Message<string, Null> { Key = "test" }, dr => { Assert.True(false); }));
+                    () => dProducer.Produce(testTopic.Name, ("test", null), dr => { Assert.True(false); }));
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_Error.cs
@@ -58,7 +58,7 @@ namespace Confluent.Kafka.IntegrationTests
                     .SetValueSerializer(Serializers.Utf8)
                     .Build())
             {
-                producer.Produce(new TopicPartition(singlePartitionTopic, 1), new Message<Null, String> { Value = "test" }, dh);
+                producer.Produce(new TopicPartition(singlePartitionTopic, 1), "test", dh);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 
@@ -82,7 +82,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var producer = new ProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                producer.Produce(new TopicPartition(singlePartitionTopic, 42), new Message<byte[], byte[]> { Key = new byte[] { 11 }}, dh2);
+                producer.Produce(new TopicPartition(singlePartitionTopic, 42), (new byte[] { 11 }, (byte[])null), dh2);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_SyncOverAsync.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_SyncOverAsync.cs
@@ -76,7 +76,7 @@ namespace Confluent.Kafka.IntegrationTests
                                 }
                             };
 
-                            producer.Produce(tempTopic.Name, new Message<Null, string> { Value = $"value: {taskNumber}" }, handler);
+                            producer.Produce(tempTopic.Name, $"value: {taskNumber}", handler);
 
                             lock (waitObj)
                             {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/SimpleProduceConsume.cs
@@ -81,7 +81,7 @@ namespace Confluent.Kafka.IntegrationTests
 
         private static DeliveryResult<Null, string> ProduceMessage(string topic, IProducer<Null, string> producer, string testString)
         {
-            var result = producer.ProduceAsync(topic, new Message<Null, string> { Value = testString }).Result;
+            var result = producer.ProduceAsync(topic, testString).Result;
             Assert.NotNull(result?.Message);
             Assert.Equal(topic, result.Topic);
             Assert.NotEqual<long>(result.Offset, Offset.Unset);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
@@ -52,44 +52,35 @@ namespace Confluent.Kafka.IntegrationTests
                 // --- ProduceAsync, serializer case.
 
                 drs_task.Add(producer.ProduceAsync(
-                    singlePartitionTopic, 
-                    new Message<Null, string> { Value = "testvalue" }).Result);
-                
+                    singlePartitionTopic,
+                    "testvalue").Result);
+
                 // TimestampType: CreateTime
                 drs_task.Add(producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> 
-                    { 
-                        Value = "test-value", 
-                        Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc))
-                    }).Result);
+                    ("test-value", new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)))
+                    ).Result);
 
                 // TimestampType: CreateTime (default)
                 drs_task.Add(producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> { Value = "test-value" }).Result);
+                    "test-value").Result);
 
                 // TimestampType: LogAppendTime
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 0),
-                        new Message<Null, string>
-                        {
-                            Value = "test-value", 
-                            Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) 
-                        }).Result);
+                        ("test-value", new Timestamp(DateTime.Now, TimestampType.LogAppendTime))
+                        ).Result);
 
                 // TimestampType: NotAvailable
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 0),
-                        new Message<Null, string> 
-                        { 
-                            Value = "test-value",
-                            Timestamp = new Timestamp(10, TimestampType.NotAvailable)
-                        }).Result);
+                        ("test-value", new Timestamp(10, TimestampType.NotAvailable))
+                        ).Result);
 
-                Action<DeliveryReport<Null, string>> dh 
+                Action<DeliveryReport<Null, string>> dh
                     = (DeliveryReport<Null, string> dr) => drs_produce.Add(dr);
 
 
@@ -97,42 +88,30 @@ namespace Confluent.Kafka.IntegrationTests
 
                 producer.Produce(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "testvalue" }, dh);
+                    "testvalue", dh);
 
                 // TimestampType: CreateTime
                 producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> 
-                    { 
-                        Value = "test-value", 
-                        Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc))
-                    },
+                    ("test-value", new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc))),
                     dh);
 
                 // TimestampType: CreateTime (default)
                 producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> { Value = "test-value" },
+                    "test-value",
                     dh);
 
                 // TimestampType: LogAppendTime
                 Assert.Throws<ArgumentException>(() => producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> 
-                    { 
-                        Value = "test-value", 
-                        Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime)
-                    }, 
+                    ("test-value", new Timestamp(DateTime.Now, TimestampType.LogAppendTime)),
                     dh));
 
                 // TimestampType: NotAvailable
                 Assert.Throws<ArgumentException>(() => producer.Produce(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> 
-                    { 
-                        Value = "test-value", 
-                        Timestamp = new Timestamp(10, TimestampType.NotAvailable)
-                    },
+                    ("test-value", new Timestamp(10, TimestampType.NotAvailable)),
                     dh));
 
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
@@ -258,7 +237,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 assertCloseToNow_byte(consumer, drs2_produce[2].TopicPartitionOffset);
             }
-            
+
             Assert.Equal(0, Library.HandleCount);
             LogToFile("end   Timestamps");
         }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Abort.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Abort.cs
@@ -40,13 +40,13 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 producer.InitTransactions(defaultTimeout);
                 producer.BeginTransaction();
-                producer.Produce(topic.Name, new Message<string, string> { Key = "test key 0", Value = "test val 0" }, (dr) => {
+                producer.Produce(topic.Name, ("test key 0", "test val 0"), (dr) => {
                     Assert.Equal(0, dr.Offset);
                 });
                 Thread.Sleep(4000); // ensure the abort ctrl message makes it into the log.
                 producer.AbortTransaction(defaultTimeout);
                 producer.BeginTransaction();
-                producer.Produce(topic.Name, new Message<string, string> { Key = "test key 1", Value = "test val 1" }, (dr) => {
+                producer.Produce(topic.Name, ("test key 1", "test val 1"), (dr) => {
                     // abort marker will be at offset 1.
                     Assert.Equal(2, dr.Offset);
                 });

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Commit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Commit.cs
@@ -47,10 +47,10 @@ namespace Confluent.Kafka.IntegrationTests
 
                     producer.InitTransactions(defaultTimeout);
                     producer.BeginTransaction();
-                    producer.Produce(topic.Name, new Message<string, string> { Key = "test key 0", Value = "test val 0" });
+                    producer.Produce(topic.Name, ("test key 0", "test val 0"));
                     producer.CommitTransaction(defaultTimeout);
                     producer.BeginTransaction();
-                    producer.Produce(topic.Name, new Message<string, string> { Key = "test key 1", Value = "test val 1" });
+                    producer.Produce(topic.Name, ("test key 1", "test val 1"));
                     producer.CommitTransaction(defaultTimeout);
 
                     var cr1 = consumer.Consume();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_SendOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_SendOffsets.cs
@@ -44,7 +44,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     producer.InitTransactions(defaultTimeout);
                     producer.BeginTransaction();
-                    producer.Produce(topic.Name, new Message<string, string> { Key = "test key 100", Value = "test val 100" });
+                    producer.Produce(topic.Name, ("test key 100", "test val 100"));
                     producer.SendOffsetsToTransaction(new List<TopicPartitionOffset> { new TopicPartitionOffset(topic.Name, 0, 73) }, consumer.ConsumerGroupMetadata, TimeSpan.FromSeconds(30));
                     producer.CommitTransaction(defaultTimeout);
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Statistics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Statistics.cs
@@ -64,17 +64,17 @@ namespace Confluent.Kafka.IntegrationTests
 
                 producer.InitTransactions(TimeSpan.FromSeconds(30));
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message_a" }).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message_a")).Wait();
                 producer.CommitTransaction(TimeSpan.FromSeconds(30));
 
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message_b" }).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message_b")).Wait();
                 producer.CommitTransaction(TimeSpan.FromSeconds(30));
 
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message1" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message2" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message3" }).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message1")).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message2")).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message3")).Wait();
 
                 for (int i=0; i<10; ++i)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_WatermarkOffsets.cs
@@ -44,9 +44,9 @@ namespace Confluent.Kafka.IntegrationTests
 
                 producer.InitTransactions(TimeSpan.FromSeconds(30));
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message1" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message2" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message3" }).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message1")).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message2")).Wait();
+                producer.ProduceAsync(topic.Name, ("test", "message3")).Wait();
 
                 WatermarkOffsets wo2 = new WatermarkOffsets(Offset.Unset, Offset.Unset);
                 for (int i=0; i<10; ++i)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -50,7 +50,7 @@ namespace Confluent.Kafka.IntegrationTests
                 DeliveryResult<Null, string> dr;
                 using (var producer = new ProducerBuilder<Null, string>(producerConfig).Build())
                 {
-                    dr = producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = testString }).Result;
+                    dr = producer.ProduceAsync(topic.Name, testString).Result;
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10))); // this isn't necessary.
                 }
 

--- a/test/Confluent.Kafka.IntegrationTests/Util.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Util.cs
@@ -49,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 for (int i=0; i<number; ++i)
                 {
-                    var dr = producer.ProduceAsync(topic, new Message<Null, string> { Value = msg }).Result;
+                    var dr = producer.ProduceAsync(topic, msg).Result;
                     Assert.NotNull(dr);
                     Assert.NotNull(dr.Message);
                     if (i == 0)

--- a/test/Confluent.Kafka.SyncOverAsync/Program.cs
+++ b/test/Confluent.Kafka.SyncOverAsync/Program.cs
@@ -102,7 +102,7 @@ namespace Confluent.Kafka.SyncOverAsync
 
                             try
                             {
-                                producer.Produce(topic, new Message<Null, string> { Value = $"value: {taskNumber}" }, handler);
+                                producer.Produce(topic, $"value: {taskNumber}", handler);
                                 // will never get to after Produce, because deadlock occurs when running serializers.
                             }
                             catch (Exception ex)

--- a/test/Confluent.Kafka.Transactions/TestProducer.cs
+++ b/test/Confluent.Kafka.Transactions/TestProducer.cs
@@ -69,7 +69,7 @@ namespace Confluent.Kafka.Transactions
                 {
                     int val = currentState == ProducerState.MakingMessagesToCommit ? lastMessageValue++ : -1;
                     Thread.Sleep((int)(1000 * conf.MaxPauseSeconds));
-                    producer.Produce(conf.Topic, new Message<int, int> { Key = id, Value = val });
+                    producer.Produce(conf.Topic, (id, val));
                 }
             }
 

--- a/test/Confluent.Kafka.UnitTests/MoqExample.cs
+++ b/test/Confluent.Kafka.UnitTests/MoqExample.cs
@@ -40,14 +40,14 @@ namespace Confluent.Kafka.UnitTests
             // var produceCount = 0;
             // var flushCount = 0;
             // mock.Setup(m => m.Produce(It.IsAny<string>(), It.IsAny<Message<Null, string>>(), It.IsAny<Action<DeliveryReport<Null, string>>>()))
-            //     .Callback<string, Message<Null, string>, Action<DeliveryReport<Null, string>>>((topic, message, action) => 
+            //     .Callback<string, Message<Null, string>, Action<DeliveryReport<Null, string>>>((topic, message, action) =>
             //         {
             //             var result = new DeliveryReport<Null, string>
             //             {
-            //                 Topic = topic, Partition = 0, Offset = 0, Error = new Error(ErrorCode.NoError), 
+            //                 Topic = topic, Partition = 0, Offset = 0, Error = new Error(ErrorCode.NoError),
             //                 Message = message
             //             };
-                        
+
             //             // Note: this is a simplification of the actual Producer implementation -
             //             // A good mock would delay invocation of the callback and invoke it on a
             //             // different thread.
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.UnitTests
             // mock.Setup(m => m.Flush(It.IsAny<TimeSpan>())).Returns(0).Callback(() => flushCount += 1);
 
             // DeliveryReport<Null, string> produced = null;
-            // producer.Produce("my-topic", new Message<Null, string> { Value = "my-value" }, (m) => produced = m);
+            // producer.Produce("my-topic", "my-value", (m) => produced = m);
             // var remaining = producer.Flush(TimeSpan.FromSeconds(10));
 
             // Assert.Equal("my-topic", produced.Topic);

--- a/test/Confluent.Kafka.VerifiableClient/Program.cs
+++ b/test/Confluent.Kafka.VerifiableClient/Program.cs
@@ -207,7 +207,7 @@ namespace Confluent.Kafka.VerifiableClient
 
         private void Produce(string topic, string value)
         {
-            Handle.Produce(topic, new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes(value) }, record => HandleDelivery(record));
+            Handle.Produce(topic, Encoding.UTF8.GetBytes(value), record => HandleDelivery(record));
         }
 
         private void TimedProduce(object ignore)

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AutoRegisterSchemaDisabled.cs
@@ -64,7 +64,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         try
                         {
                             producer
-                                .ProduceAsync(guidTopic, new Message<string, int> { Key = "test", Value = 112 })
+                                .ProduceAsync(guidTopic, ("test", 112))
                                 .GetAwaiter()
                                 .GetResult();
                         }
@@ -102,7 +102,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     {
                         try
                         {
-                            producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 })
+                            producer.ProduceAsync(topic.Name, ("test", 112))
                                 .GetAwaiter()
                                 .GetResult();
                         }
@@ -122,7 +122,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test", 112)).Wait();
                 }
 
                 // config with avro.serializer.auto.register.schemas == false should work now.
@@ -133,7 +133,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test", 112)).Wait();
                 }
 
                 // config with avro.serializer.use.latest.version == true should also work now.
@@ -144,7 +144,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test", 112)).Wait();
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AvroAndRegular.cs
@@ -59,7 +59,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     // implicit check that this does not fail.
-                    producer.ProduceAsync(topic1.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();
+                    producer.ProduceAsync(topic1.Name, ("hello", "world")).Wait();
 
                     // check that the value type was registered with SR, and the key was not.
                     Assert.Throws<SchemaRegistryException>(() =>
@@ -84,7 +84,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     // implicit check that this does not fail.
-                    producer.ProduceAsync(topic2.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();
+                    producer.ProduceAsync(topic2.Name, ("hello", "world")).Wait();
 
                     // check that the key type was registered with SR, and the value was not.
                     Assert.Throws<SchemaRegistryException>(() =>

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumeIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumeIncompatibleTypes.cs
@@ -69,7 +69,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 };
 
                 producer
-                    .ProduceAsync(topic, new Message<string, User> { Key = user.name, Value = user })
+                    .ProduceAsync(topic, (user.name, user))
                     .Wait();
             }
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumePartitionEOF.cs
@@ -51,7 +51,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .SetValueSerializer(new AvroSerializer<User>(schemaRegistry))
                     .Build())
             {
-                producer.ProduceAsync(topic.Name, new Message<Null, User> { Value = new User { name = "test" } }).Wait();
+                producer.ProduceAsync(topic.Name, new User { name = "test" }).Wait();
 
                 var consumerConfig = new ConsumerConfig
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/PrimitiveTypes.cs
@@ -62,7 +62,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(stringTopic, new Message<string, string> { Key = "hello", Value = "world" })
+                        .ProduceAsync(stringTopic, ("hello", "world"))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
@@ -74,7 +74,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(bytesTopic, new Message<byte[], byte[]> { Key = new byte[] { 1, 4, 11 }, Value = new byte[] {} })
+                        .ProduceAsync(bytesTopic, (new byte[] { 1, 4, 11 }, new byte[] {}))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
@@ -86,7 +86,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(intTopic, new Message<int, int> { Key = 42, Value = 43 })
+                        .ProduceAsync(intTopic, (42, 43))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
@@ -98,7 +98,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(longTopic, new Message<long, long> { Key = -32, Value = -33 })
+                        .ProduceAsync(longTopic, (-32, -33))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
@@ -110,7 +110,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(boolTopic, new Message<bool, bool> { Key = true, Value = false })
+                        .ProduceAsync(boolTopic, (true, false))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
@@ -122,7 +122,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(floatTopic, new Message<float, float> { Key = 44.0f, Value = 45.0f })
+                        .ProduceAsync(floatTopic, (44.0f, 45.0f))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
@@ -134,7 +134,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     producer
-                        .ProduceAsync(doubleTopic, new Message<double, double> { Key = 46.0, Value = 47.0 })
+                        .ProduceAsync(doubleTopic, (46.0, 47.0))
                         .Wait();
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsume.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsume.cs
@@ -83,9 +83,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         favorite_number = i,
                         favorite_color = "blue"
                     };
-                    
+
                     producer
-                        .ProduceAsync(topic, new Message<string, ProduceConsumeUser> { Key = user.name, Value = user })
+                        .ProduceAsync(topic, (user.name, user))
                         .Wait();
                 }
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeGeneric.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeGeneric.cs
@@ -72,7 +72,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 record.Add("name", "my name 2");
                 record.Add("favorite_number", 44);
                 record.Add("favorite_color", null);
-                dr = p.ProduceAsync(topic, new Message<GenericRecord, Null> { Key = record }).Result;
+                dr = p.ProduceAsync(topic, (record, null)).Result;
             }
 
             // produce a specific record (to later consume back as a generic record).
@@ -89,8 +89,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     favorite_number = 47,
                     favorite_color = "orange"
                 };
-                
-                p.ProduceAsync(topic, new Message<ProduceConsumeUser2, Null> { Key = user }).Wait();
+
+                p.ProduceAsync(topic, (user, null)).Wait();
             }
 
             Assert.Null(dr.Message.Value);
@@ -182,7 +182,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 }
             }
         }
-        
+
         /// <summary>
         ///     Test that messages produced with the Avro serializer can be consumed with the
         ///     Avro deserializer (topic name strategy).

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeNull.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeNull.cs
@@ -78,7 +78,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 for (int i = 0; i < 100; ++i)
                 {
                     producer
-                        .ProduceAsync(topic, new Message<string, ProduceConsumeUser> { Key = null, Value = null })
+                        .ProduceAsync(topic, ((string)null, null))
                         .Wait();
                 }
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceGenericMultipleTopics.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceGenericMultipleTopics.cs
@@ -48,8 +48,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 record.Add("name", "my name 2");
                 record.Add("favorite_number", 44);
                 record.Add("favorite_color", null);
-                dr = p.ProduceAsync(topic, new Message<Null, GenericRecord> { Key = null, Value = record }).Result;
-                dr2 = p.ProduceAsync(topic2, new Message<Null, GenericRecord> { Key = null, Value = record }).Result;
+                dr = p.ProduceAsync(topic, record).Result;
+                dr2 = p.ProduceAsync(topic2, record).Result;
             }
 
             Assert.Null(dr.Key);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceIncompatibleTypes.cs
@@ -54,7 +54,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .Build())
             {
                 producer
-                    .ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" })
+                    .ProduceAsync(topic, ("hello", "world"))
                     .Wait();
 
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
@@ -72,7 +72,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     try
                     {
                         producer
-                            .ProduceAsync(topic, new Message<int, string> { Key = 42, Value = "world" })
+                            .ProduceAsync(topic, (42, "world"))
                             .GetAwaiter()
                             .GetResult();
                     }
@@ -96,7 +96,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     try
                     {
                         producer
-                            .ProduceAsync(topic, new Message<string, int> { Key = "world", Value = 42 })
+                            .ProduceAsync(topic, ("world", 42))
                             .GetAwaiter()
                             .GetResult();
                     }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceInvalid.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceInvalid.cs
@@ -51,7 +51,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    producer.ProduceAsync(topic, ("hello", "world")).GetAwaiter().GetResult();
                 }
                 catch (Exception e)
                 {
@@ -92,7 +92,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    producer.ProduceAsync(topic, ("hello", "world")).GetAwaiter().GetResult();
                 }
                 catch (Exception e)
                 {
@@ -133,7 +133,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    producer.ProduceAsync(topic, ("hello", "world")).GetAwaiter().GetResult();
                 }
                 catch (Exception e)
                 {
@@ -174,7 +174,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    producer.ProduceAsync(topic, ("hello", "world")).GetAwaiter().GetResult();
                 }
                 catch (Exception e)
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/SyncOverAsync.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/SyncOverAsync.cs
@@ -39,7 +39,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         {
             ThreadPool.GetMaxThreads(out int originalWorkerThreads, out int originalCompletionPortThreads);
 
-            ThreadPool.GetMinThreads(out int workerThreads, out int completionPortThreads);   
+            ThreadPool.GetMinThreads(out int workerThreads, out int completionPortThreads);
             ThreadPool.SetMaxThreads(workerThreads, completionPortThreads);
             ThreadPool.GetMaxThreads(out workerThreads, out completionPortThreads);
 
@@ -47,7 +47,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 BootstrapServers = bootstrapServers
             };
-            
+
             var schemaRegistryConfig = new SchemaRegistryConfig
             {
                 Url = schemaRegistryServers
@@ -61,7 +61,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var tasks = new List<Task>();
 
-                // will deadlock if N >= workerThreads. Set to max number that 
+                // will deadlock if N >= workerThreads. Set to max number that
                 // should not deadlock.
                 int N = workerThreads-1;
                 for (int i=0; i<N; ++i)
@@ -72,7 +72,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         {
                             object waitObj = new object();
 
-                            Action<DeliveryReport<Null, string>> handler = dr => 
+                            Action<DeliveryReport<Null, string>> handler = dr =>
                             {
                                 Assert.True(dr.Error.Code == ErrorCode.NoError);
 
@@ -82,7 +82,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                                 }
                             };
 
-                            producer.Produce(topic, new Message<Null, string> { Value = $"value: {taskNumber}" }, handler);
+                            producer.Produce(topic, $"value: {taskNumber}", handler);
 
                             lock (waitObj)
                             {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/ProduceConsumeMixedJson.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/ProduceConsumeMixedJson.cs
@@ -96,7 +96,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     Assert.Throws<ProduceException<string, PersonPoco>>(() => {
                         try
                         {
-                            producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }).Wait();
+                            producer.ProduceAsync(topic.Name, ("test1", p)).Wait();
                         }
                         catch (AggregateException ax)
                         {
@@ -115,7 +115,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         NumberWithRange = 3
                     };
                     Assert.Throws<AggregateException>(() => {
-                        producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }).Wait();
+                        producer.ProduceAsync(topic.Name, ("test1", p)).Wait();
                     });
                 }
 
@@ -145,7 +145,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             }
                         }
                     };
-                    producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", p)).Wait();
 
                     var schema = schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic.Name, null)).Result.SchemaString;
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/SubjectNameStrategies.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/SubjectNameStrategies.cs
@@ -49,7 +49,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new SubjectNameStrategyTestPoco();
                     u.Value = testString;
-                    producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                     var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
                     Assert.Contains(topic.Name + "-SubjectNameStrategyTestPoco", subjects);
@@ -64,7 +64,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new SubjectNameStrategyTestPoco();
                     u.Value = testString;
-                    producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                     var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
                     // Note: If this value is in SR by any means (even if not via this test),
@@ -80,7 +80,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new SubjectNameStrategyTestPoco();
                     u.Value = testString;
-                    producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                     var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
                     Assert.Contains(topic.Name + "-value", subjects);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseLatestVersionEnabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseLatestVersionEnabled.cs
@@ -40,16 +40,16 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
     public static partial class Tests
     {
         /// <summary>
-        ///     Test Use Latest Version on when AutoRegister enabled and disabled. 
+        ///     Test Use Latest Version on when AutoRegister enabled and disabled.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void UseLatestVersionCheck(string bootstrapServers, string schemaRegistryServers) 
+        public static void UseLatestVersionCheck(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
 
             using (var topic = new TemporaryTopic(bootstrapServers, 1))
-            using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig)) 
+            using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
             {
                 using (var producer =
                     new ProducerBuilder<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1.TestPoco>(producerConfig)
@@ -57,10 +57,10 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     var c = new Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1.TestPoco { IntField = 1 };
-                    producer.ProduceAsync(topic.Name, new Message<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1.TestPoco> { Key = "test1", Value = c }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", c)).Wait();
                 }
 
-                using (var producer = 
+                using (var producer =
                     new ProducerBuilder<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco>(producerConfig)
                         .SetValueSerializer(new JsonSerializer<Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco>(
                             schemaRegistry, new JsonSerializerConfig { UseLatestVersion = true, AutoRegisterSchemas = false, LatestCompatibilityStrict = true }))
@@ -68,7 +68,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var c = new Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco { StringField = "Test" };
                     Assert.Throws<AggregateException>(
-                        () => producer.ProduceAsync(topic.Name, new Message<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco> { Key = "test1", Value = c }).Wait());
+                        () => producer.ProduceAsync(topic.Name, ("test1", c)).Wait());
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
@@ -192,7 +192,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, Order> { Key = "test1", Value = order }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", order)).Wait();
                 }
                 
                 using (var consumer =
@@ -218,7 +218,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, JObject> { Key = "test1", Value = jsonObject }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", jsonObject)).Wait();
                 }
                 
                 using (var consumer =
@@ -249,7 +249,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     var c = new Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco { StringField = "Test" };
                     // Validation failure when passing TestClasses2.TestPoco
                     Assert.Throws<AggregateException>(
-                        () => producer.ProduceAsync(topic.Name, new Message<string, TestClasses2.TestPoco> { Key = "test1", Value = c }).Wait());
+                        () => producer.ProduceAsync(topic.Name, ("test1", c)).Wait());
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeBasic.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeBasic.cs
@@ -42,7 +42,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var u = new UInt32Value();
                 u.Value = 42;
-                producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                 var consumerConfig = new ConsumerConfig
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeExternalRef.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeExternalRef.cs
@@ -44,7 +44,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 var u = new WithExternalReference();
                 u.Value1 = new RefByAnother { Value = 111 };
                 u.Value2 = 123;
-                producer.ProduceAsync(topic.Name, new Message<string, WithExternalReference> { Key = "test1", Value = u }).Wait();
+                producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                 var consumerConfig = new ConsumerConfig
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeGoogleRef.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeGoogleRef.cs
@@ -46,7 +46,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 u.ReceivedTime = new Google.Protobuf.WellKnownTypes.Timestamp();
                 u.ReceivedTime.Seconds = 1591364591;
 
-                producer.ProduceAsync(topic.Name, new Message<string, WithGoogleRefs.TheRecord> { Key = "test1", Value = u }).Wait();
+                producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                 var consumerConfig = new ConsumerConfig
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeNested.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeNested.cs
@@ -44,7 +44,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var u = new NestedOuter.Types.NestedMid2.Types.NestedLower();
                 u.Field2 = "field_2_value";
-                producer.ProduceAsync(topic.Name, new Message<string, NestedOuter.Types.NestedMid2.Types.NestedLower> { Key = "test1", Value = u }).Wait();
+                producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                 var consumerConfig = new ConsumerConfig
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeSchemaManyMessages.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeSchemaManyMessages.cs
@@ -44,7 +44,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var u = new Msg230();
                 u.Value = 41;
-                producer.ProduceAsync(topic.Name, new Message<string, Msg230> { Key = "test1", Value = u }).Wait();
+                producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                 var consumerConfig = new ConsumerConfig
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/SubjectNameStrategies.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/SubjectNameStrategies.cs
@@ -42,7 +42,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new UInt32Value();
                     u.Value = 42;
-                    producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                     var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
                     Assert.Contains(topic.Name + "-UInt32Value", subjects);
@@ -57,7 +57,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new UInt32Value();
                     u.Value = 42;
-                    producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                     var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
                     // Note: If this value is in SR by any means (even if not via this test),
@@ -73,7 +73,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new UInt32Value();
                     u.Value = 42;
-                    producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                    producer.ProduceAsync(topic.Name, ("test1", u)).Wait();
 
                     var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
                     Assert.Contains(topic.Name + "-value", subjects);


### PR DESCRIPTION
This PR adds implicit cast operators from value tuples to `Message<T,V>` to allow such syntax
```
p.Produce("my-topic", i.ToString(), handler);
```
compared to current syntax
```
p.Produce("my-topic", new Message<Null, string> { Value = i.ToString() }, handler);
```

The goal is to reduce boilerplate code from user code shifting all needed machinery to compiler.

This PR adds one additional dependency for `netstandard1.3` target:
```xml
<PackageReference Include="System.ValueTuple" Version="4.5.0" />
```