### PR TITLE
Update Apache Avro from 1.11.0 to 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.1
+
+## Enhancements
+
+- References Apache.Avro 1.11.1 which resolves primitive schemas losing metadata. Refer to the [release notes](https://github.com/apache/avro/releases/tag/release-1.11.1) for further information ([csplugins](https://github.com/csplugins)).
+
 # 2.3.0
 
 ## Enhancements

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Avro" Version="1.11.0" />
+    <PackageReference Include="Apache.Avro" Version="1.11.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Avro" Version="1.11.0" />
+    <PackageReference Include="Apache.Avro" Version="1.11.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Apache.Avro" Version="1.11.0" />
+    <PackageReference Include="Apache.Avro" Version="1.11.1" />
     <PackageReference Include="System.Runtime" Version="4.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Created a PR in apache/avro to address a small but important change to primitive schema types losing metadata properties if any were specified. https://github.com/apache/avro/pull/1438

It's been two years since this was merged and release with apache/avro 1.11.1. Hoping this can get updated to finally remove a custom fork of this repo which simply increases the patch version by one.