### PR TITLE
Support AOT for basic consumer app

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -22,6 +22,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Confluent.Kafka.snk</AssemblyOriginatorKeyFile>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -29,6 +29,9 @@ using System.Reflection;
 #if NET462
 using System.ComponentModel;
 #endif
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 
 namespace Confluent.Kafka.Impl
@@ -173,7 +176,11 @@ namespace Confluent.Kafka.Impl
             }
         }
 
-        static bool SetDelegates(Type nativeMethodsClass)
+        static bool SetDelegates(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+            Type nativeMethodsClass)
         {
             var methods = nativeMethodsClass.GetRuntimeMethods().ToArray();
 
@@ -675,14 +682,23 @@ namespace Confluent.Kafka.Impl
 
 #endif
 
-        private static bool TrySetDelegates(List<Type> nativeMethodCandidateTypes)
+        private static bool TrySetDelegates(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] 
+#endif
+            Type nativeMethodCandidateType1,
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] 
+#endif
+            Type nativeMethodCandidateType2 = null)
         {
-            foreach (var t in nativeMethodCandidateTypes)
+            if (SetDelegates(nativeMethodCandidateType1))
             {
-                if (SetDelegates(t))
-                {
-                    return true;
-                }
+                return true;
+            }
+            if (nativeMethodCandidateType2 != null && SetDelegates(nativeMethodCandidateType2))
+            {
+                return true;
             }
 
             throw new DllNotFoundException("Failed to load the librdkafka native library.");
@@ -700,7 +716,7 @@ namespace Confluent.Kafka.Impl
                 }
             }
 
-            TrySetDelegates(new List<Type> { typeof(NativeMethods.NativeMethods) });
+            TrySetDelegates(typeof(NativeMethods.NativeMethods));
         }
 
         private static void LoadOSXDelegates(string userSpecifiedPath)
@@ -713,7 +729,7 @@ namespace Confluent.Kafka.Impl
                 }
             }
 
-            TrySetDelegates(new List<Type> { typeof(NativeMethods.NativeMethods) });
+            TrySetDelegates(typeof(NativeMethods.NativeMethods));
         }
 
         private static void LoadLinuxDelegates(string userSpecifiedPath)
@@ -725,7 +741,7 @@ namespace Confluent.Kafka.Impl
                     throw new InvalidOperationException($"Failed to load librdkafka at location '{userSpecifiedPath}'. dlerror: '{PosixNative.LastError}'.");
                 }
 
-                TrySetDelegates(new List<Type> { typeof(NativeMethods.NativeMethods) });
+                TrySetDelegates(typeof(NativeMethods.NativeMethods));
             }
             else
             {
@@ -734,17 +750,14 @@ namespace Confluent.Kafka.Impl
                 var osName = PlatformApis.GetOSName();
                 if (osName.Equals("alpine", StringComparison.OrdinalIgnoreCase))
                 {
-                    delegates.Add(typeof(NativeMethods.NativeMethods_Alpine));
+                    TrySetDelegates(typeof(NativeMethods.NativeMethods_Alpine));
                 }
                 else
                 {
-                    // Try to load first the shared library with GSSAPI linkage 
-                    // and then the one without.
-                    delegates.Add(typeof(NativeMethods.NativeMethods));
-                    delegates.Add(typeof(NativeMethods.NativeMethods_Centos8));
+                    TrySetDelegates(
+                        typeof(NativeMethods.NativeMethods),
+                        typeof(NativeMethods.NativeMethods_Centos8));
                 }
-
-                TrySetDelegates(delegates);
             }
         }
 

--- a/src/Confluent.Kafka/Internal/Util.cs
+++ b/src/Confluent.Kafka/Internal/Util.cs
@@ -20,6 +20,9 @@ using System.Text;
 using SystemMarshal = System.Runtime.InteropServices.Marshal;
 using SystemGCHandle = System.Runtime.InteropServices.GCHandle;
 using SystemGCHandleType = System.Runtime.InteropServices.GCHandleType;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 
 namespace Confluent.Kafka.Internal
@@ -84,7 +87,11 @@ namespace Confluent.Kafka.Internal
                 return Encoding.UTF8.GetString((byte*)strPtr, (int)strLength);
             }
 
-            public static T PtrToStructure<T>(IntPtr ptr)
+            public static T PtrToStructure<
+#if NET5_0_OR_GREATER
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+#endif
+                T>(IntPtr ptr)
             {
                 return SystemMarshal.PtrToStructure<T>(ptr);
             }


### PR DESCRIPTION
Hello, I managed to have my app working with AOT on windows and linux (ubuntu wsl). I tested only with net8.0 and net9.0 on windows (11) and wsl (ubuntu 24.04).

It's a basic consumer app with avalonia UI. But can be summarized as below: 

```csharp
var config = new ConsumerConfig
{
    BootstrapServers = kafkaServers,
    GroupId = "GroupIdPrefix" + Guid.NewGuid(),
    AutoOffsetReset = AutoOffsetReset.Latest,
};

using var consumer = new ConsumerBuilder<string, byte[]>(config)
    .SetErrorHandler((_, e) => {/* ... */})
    .Build();

consumer.Subscribe("my-topic");

while (true)
{
    var result = consumer.Consume(TimeSpan.FromMilliseconds(1000));
    // ...
}
```

I don't know if it will work with the current list of TargetFrameworks or if we need to add net8.0 explicitly.

Waiting for your feedback.

Should fix https://github.com/confluentinc/confluent-kafka-dotnet/issues/2146