### PR TITLE
Add a new type of Serializer for supporting zero allocation scenarios

### DIFF
--- a/src/Confluent.Kafka/DependentProducerBuilder.cs
+++ b/src/Confluent.Kafka/DependentProducerBuilder.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka
         ///     The configured client handle.
         /// </summary>
         public Handle Handle { get; set; }
-        
+
         /// <summary>
         ///     The configured key serializer.
         /// </summary>
@@ -54,9 +54,14 @@ namespace Confluent.Kafka
         /// </summary>
         public IAsyncSerializer<TValue> AsyncValueSerializer { get; set; }
 
+        /// <summary>
+        ///     The configured async value serializer.
+        /// </summary>
+        public ISegmentSerializer<TValue> SegmentValueSerializer { get; set; }
+
 
         /// <summary>
-        ///     An underlying librdkafka client handle that the Producer will use to 
+        ///     An underlying librdkafka client handle that the Producer will use to
         ///     make broker requests. The handle must be from another Producer
         ///     instance (not Consumer or AdminClient).
         /// </summary>
@@ -98,6 +103,15 @@ namespace Confluent.Kafka
         public DependentProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
             this.AsyncValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The segment serializer to use to serialize values.
+        /// </summary>
+        public DependentProducerBuilder<TKey, TValue> SetValueSerializer(ISegmentSerializer<TValue> serializer)
+        {
+            this.SegmentValueSerializer = serializer;
             return this;
         }
 

--- a/src/Confluent.Kafka/ISegmentSerializer.cs
+++ b/src/Confluent.Kafka/ISegmentSerializer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    ///     Defines a serializer for use with <see cref="Confluent.Kafka.Producer{TKey,TValue}" />.
+    /// </summary>
+    public interface ISegmentSerializer<T>
+    {
+        /// <summary>
+        ///     Serialize the key or value of a <see cref="Message{TKey,TValue}" />
+        ///     instance.
+        /// </summary>
+        /// <param name="data">
+        ///     The value to serialize.
+        /// </param>
+        /// <param name="context">
+        ///     Context relevant to the serialize operation.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="ArraySegment{T}"/> containing the serialized value.
+        /// </returns>
+        ArraySegment<byte> Serialize(T data, SerializationContext context);
+    }
+}

--- a/src/Confluent.Kafka/ProducerBuilder.cs
+++ b/src/Confluent.Kafka/ProducerBuilder.cs
@@ -84,7 +84,7 @@ namespace Confluent.Kafka
         /// </summary>
         internal protected Action<IProducer<TKey, TValue>, string> OAuthBearerTokenRefreshHandler { get; set; }
 
-        /// <summary>        
+        /// <summary>
         ///     The per-topic custom partitioners.
         /// </summary>
         internal protected Dictionary<string, PartitionerDelegate> Partitioners { get; set; } = new Dictionary<string, PartitionerDelegate>();
@@ -103,6 +103,11 @@ namespace Confluent.Kafka
         ///     The configured value serializer.
         /// </summary>
         internal protected ISerializer<TValue> ValueSerializer { get; set; }
+
+        /// <summary>
+        ///     The configured segment value serializer.
+        /// </summary>
+        internal protected ISegmentSerializer<TValue> SegmentValueSerializer { get; set; }
 
         /// <summary>
         ///     The configured async key serializer.
@@ -137,9 +142,9 @@ namespace Confluent.Kafka
         }
 
         /// <summary>
-        ///     A collection of librdkafka configuration parameters 
+        ///     A collection of librdkafka configuration parameters
         ///     (refer to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
-        ///     and parameters specific to this client (refer to: 
+        ///     and parameters specific to this client (refer to:
         ///     <see cref="Confluent.Kafka.ConfigPropertyNames" />).
         ///     At a minimum, 'bootstrap.servers' must be specified.
         /// </summary>
@@ -321,7 +326,7 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(ISerializer<TValue> serializer)
         {
-            if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null || this.SegmentValueSerializer != null)
             {
                 throw new InvalidOperationException("Value serializer may not be specified more than once.");
             }
@@ -359,11 +364,30 @@ namespace Confluent.Kafka
         /// </remarks>
         public ProducerBuilder<TKey, TValue> SetValueSerializer(IAsyncSerializer<TValue> serializer)
         {
-            if (this.ValueSerializer != null || this.AsyncValueSerializer != null)
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null || this.SegmentValueSerializer != null)
             {
                 throw new InvalidOperationException("Value serializer may not be specified more than once.");
             }
             this.AsyncValueSerializer = serializer;
+            return this;
+        }
+
+        /// <summary>
+        ///     The serializer to use to serialize values.
+        /// </summary>
+        /// <remarks>
+        ///     If your value serializer throws an exception, this will be
+        ///     wrapped in a ProduceException with ErrorCode
+        ///     Local_ValueSerialization and thrown by the initiating call to
+        ///     Produce or ProduceAsync.
+        /// </remarks>
+        public ProducerBuilder<TKey, TValue> SetValueSerializer(ISegmentSerializer<TValue> serializer)
+        {
+            if (this.ValueSerializer != null || this.AsyncValueSerializer != null || this.SegmentValueSerializer != null)
+            {
+                throw new InvalidOperationException("Value serializer may not be specified more than once.");
+            }
+            this.SegmentValueSerializer = serializer;
             return this;
         }
 


### PR DESCRIPTION
Right now `ISerializer` and `ISerializerAsync` are forced to allocate a new array for every message which is sent. For a high throughput application we'd like to avoid allocating large amounts of memory.

The API exposed by librdkafka supports buffer reuse as it accepts a length and offset alongside each byte array, however this is not exposed by the serialization framework in Kafka dotnet.

The simplest approach here is to allow `ArraySegment<byte>` to be returned by the serializer rather than `byte[]`, however changing all serializers to return `ArraySegment<byte>` would surely be a large breaking change. So instead I decided to implement this as a new type of serializer.

Please give me some feedback and thoughts on this PR.

Thanks