### PR TITLE
Update NJsonSchema to v11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ UpgradeLog*.htm
 *~
 \#*
 core
+
+# JetBrains Rider
+.idea/

--- a/examples/JsonWithReferences/Program.cs
+++ b/examples/JsonWithReferences/Program.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using NJsonSchema.Generation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 /// <summary>
@@ -150,7 +151,7 @@ namespace Confluent.Kafka.Examples.JsonWithReferences
             // from default one to camelCase.
             // It's also possible to add JsonProperty attributes to customize
             // serialization mapping and all available NJson attributes.
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {

--- a/examples/JsonWithReferences/Program.cs
+++ b/examples/JsonWithReferences/Program.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema.NewtonsoftJson.Generation;

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.6.3" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using Confluent.Kafka;
 using NJsonSchema;
 using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
 using NJsonSchema.Validation;
 
 
@@ -52,7 +53,7 @@ namespace Confluent.SchemaRegistry.Serdes
     {
         private readonly int headerSize = sizeof(int) + sizeof(byte);
 
-        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+        private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
         private JsonSchema schema = null;
         private ISchemaRegistryClient schemaRegistryClient;
         
@@ -78,7 +79,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, IEnumerable<KeyValuePair<string, string>> config = null,
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
         {
             this.schemaRegistryClient = schemaRegistryClient;
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -106,7 +107,7 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="jsonSchemaGeneratorSettings">
         ///     JSON schema generator settings.
         /// </param>
-        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
 
@@ -169,7 +170,7 @@ namespace Confluent.SchemaRegistry.Serdes
                             throw new InvalidDataException("Schema validation failed for properties: [" + string.Join(", ", validationResult.Select(r => r.Path)) + "]");
                         }
                     }
-                    return Task.FromResult(Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings));
+                    return Task.FromResult(Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.SerializerSettings));
                 }
             }
             catch (AggregateException e)

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -22,7 +22,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using NJsonSchema;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 using NJsonSchema.Validation;
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using NJsonSchema;
 using NJsonSchema.Generation;
 using Newtonsoft.Json.Linq;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -71,7 +72,7 @@ namespace Confluent.SchemaRegistry.Serdes
             {
                 NJsonSchema.Generation.JsonSchemaResolver schemaResolver =
                     new NJsonSchema.Generation.JsonSchemaResolver(rootObject, this.jsonSchemaGeneratorSettings ??
-                        new JsonSchemaGeneratorSettings());
+                        new NewtonsoftJsonSchemaGeneratorSettings());
 
                 JsonReferenceResolver referenceResolver =
                     new JsonReferenceResolver(schemaResolver);

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -28,6 +28,7 @@ using NJsonSchema;
 using NJsonSchema.Generation;
 using NJsonSchema.Validation;
 using Confluent.Kafka;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -64,7 +65,7 @@ namespace Confluent.SchemaRegistry.Serdes
         private int initialBufferSize = DefaultInitialBufferSize;
         private SubjectNameStrategyDelegate subjectNameStrategy = null;
         private ISchemaRegistryClient schemaRegistryClient;
-        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+        private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
         private HashSet<string> subjectsRegistered = new HashSet<string>();
         private SemaphoreSlim serializeMutex = new SemaphoreSlim(1);
         private readonly List<SchemaReference> ReferenceList = new List<SchemaReference>();
@@ -115,7 +116,7 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="jsonSchemaGeneratorSettings">
         ///     JSON schema generator settings.
         /// </param>
-        public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, JsonSerializerConfig config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+        public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, JsonSerializerConfig config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
         {
             this.schemaRegistryClient = schemaRegistryClient;
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -148,7 +149,7 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="jsonSchemaGeneratorSettings">
         ///     JSON schema generator settings.
         /// </param>
-        public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, JsonSerializerConfig config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+        public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, JsonSerializerConfig config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
         {
             this.schemaRegistryClient = schemaRegistryClient;
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -170,7 +171,7 @@ namespace Confluent.SchemaRegistry.Serdes
 
         /// <summary>
         ///     Serialize an instance of type <typeparamref name="T"/> to a UTF8 encoded JSON 
-        ///     represenation. The serialized data is preceeded by:
+        ///     representation. The serialized data is preceded by:
         ///       1. A "magic byte" (1 byte) that identifies this as a message with
         ///          Confluent Platform framing.
         ///       2. The id of the schema as registered in Confluent's Schema Registry
@@ -192,7 +193,7 @@ namespace Confluent.SchemaRegistry.Serdes
         {
             if (value == null) { return null; }
 
-            var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+            var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.SerializerSettings);
             var validationResult = validator.Validate(serializedString, this.schema);
             if (validationResult.Count > 0)
             {

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -25,7 +25,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using NJsonSchema;
-using NJsonSchema.Generation;
 using NJsonSchema.Validation;
 using Confluent.Kafka;
 using NJsonSchema.NewtonsoftJson.Generation;

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
@@ -22,7 +22,6 @@ using Confluent.Kafka.SyncOverAsync;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Generation;
 using NJsonSchema.NewtonsoftJson.Generation;
 
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
@@ -23,6 +23,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Linq;
 using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
@@ -139,7 +140,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
             var sr = new CachedSchemaRegistryClient(schemaRegistryConfig);
 
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -209,7 +210,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 // Test producing and consuming directly a JObject
                 var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(order,
-                    jsonSchemaGeneratorSettings.ActualSerializerSettings);
+                    jsonSchemaGeneratorSettings.SerializerSettings);
                 var jsonObject = JObject.Parse(serializedString);
                 
                 using (var producer =

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
@@ -22,6 +22,7 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -205,7 +206,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         {
             const int value = 1234;
             var expectedJson = $"{{\"Value\":{value * 2}}}";
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -249,7 +250,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 SubjectNameStrategy = SubjectNameStrategy.TopicRecord
             };
             
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -284,7 +285,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         [InlineData(EnumHandling.Integer, EnumType.OtherValue, "{\"Value\":5678}")]
         public async Task WithJsonSchemaGeneratorSettingsSerDe(EnumHandling enumHandling, EnumType value, string expectedJson)
         {
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 DefaultEnumHandling = enumHandling
             };


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-dotnet/issues/2169

A few notes:
- This is a breaking change, and should be included in a major version release only, as we're dropping support for NJsonSchema v10. This change **will** impact users that manage their own references to NJsonSchema v10.
- Newtonsoft.Json-based generators have been moved to a separate NuGet package, so the reference to NJsonSchema has been replaced with a reference to NJsonSchema.NewtonsoftJson. See [NSwag 14 announcement](https://github.com/RicoSuter/NSwag/issues/4524) and [NJsonSchema v11 release notes](https://github.com/RicoSuter/NJsonSchema/releases/tag/v11.0.0).
- `EnumHandling` no longer exists, so the `WithJsonSchemaGeneratorSettingsSerDe` unit test has been updated to use `JsonSerializerSettings` instead.