### PR TITLE
#2183 switch to licence expression + repo info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.5.0
+
+## Fixes
+
+- Switch license expression and other repo information. (#2192, @thompson-tomo)
+
+
 # 2.4.0
 
 ## Enhancements

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -6,8 +6,8 @@
     <Copyright>Copyright 2016-2020 Confluent Inc., Andreas Heider</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
 	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
-	<RepositoryType>Git</RepositoryType>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
+	<RepositoryType>git</RepositoryType>
 	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;librdkafka</PackageTags>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -5,11 +5,12 @@
     <Description>Confluent's .NET Client for Apache Kafka</Description>
     <Copyright>Copyright 2016-2020 Confluent Inc., Andreas Heider</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
-	<RepositoryType>git</RepositoryType>
-	<PackageIcon>confluent-logo.png</PackageIcon>
-	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+    <PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+    <RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>confluent-logo.png</PackageIcon>
+    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;librdkafka</PackageTags>
     <PackageId>Confluent.Kafka</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -23,19 +24,19 @@
     <AssemblyOriginatorKeyFile>Confluent.Kafka.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="2.5.0-RC3">
-        <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="librdkafka.redist" Version="2.5.0-RC3">
+            <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="System.Memory" Version="4.5.0" />
+    </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-	<PackageReference Include="System.Console" Version="4.3.0" />
-	<PackageReference Include="System.Linq" Version="4.3.0" />
-	<PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-	<PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-	<PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Console" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -5,8 +5,10 @@
     <Description>Confluent's .NET Client for Apache Kafka</Description>
     <Copyright>Copyright 2016-2020 Confluent Inc., Andreas Heider</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryType>Git</RepositoryType>
+	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;librdkafka</PackageTags>
     <PackageId>Confluent.Kafka</PackageId>
@@ -29,11 +31,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Console" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Threading" Version="4.3.0" />
+	<PackageReference Include="System.Console" Version="4.3.0" />
+	<PackageReference Include="System.Linq" Version="4.3.0" />
+	<PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+	<PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+	<PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -24,12 +24,12 @@
     <AssemblyOriginatorKeyFile>Confluent.Kafka.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="librdkafka.redist" Version="2.5.0-RC3">
-            <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="System.Memory" Version="4.5.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="2.5.0-RC3">
+      <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.0" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Console" Version="4.3.0" />

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -8,8 +8,8 @@
 	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
 	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
-	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
-    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+	<PackageIcon>confluent-logo.png</PackageIcon>
+	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;librdkafka</PackageTags>
     <PackageId>Confluent.Kafka</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
@@ -6,8 +6,10 @@
     <Description>Provides an Avro Serializer and Deserializer for use with Confluent.Kafka with Confluent Schema Registry integration</Description>
     <Copyright>Copyright 2017-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryType>Git</RepositoryType>
+	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;Avro</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Avro</PackageId>
@@ -26,13 +28,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
-    <ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
+	<ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
+	<ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
@@ -6,11 +6,10 @@
     <Description>Provides an Avro Serializer and Deserializer for use with Confluent.Kafka with Confluent Schema Registry integration</Description>
     <Copyright>Copyright 2017-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
-	<RepositoryType>Git</RepositoryType>
-	<PackageIcon>confluent-logo.png</PackageIcon>
-	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+    <PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+    <RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>confluent-logo.png</PackageIcon>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;Avro</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Avro</PackageId>
@@ -29,17 +28,18 @@
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
-	<ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
+    <ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
+    <ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj
@@ -7,8 +7,9 @@
     <Copyright>Copyright 2017-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
 	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
 	<RepositoryType>Git</RepositoryType>
+	<PackageIcon>confluent-logo.png</PackageIcon>
 	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;Avro</PackageTags>
@@ -35,6 +36,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
 	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -6,11 +6,11 @@
     <Description>Provides a JSON Serializer and Deserializer for use with Confluent.Kafka with Confluent Schema Registry integration</Description>
     <Copyright>Copyright 2020-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
-	<RepositoryType>Git</RepositoryType>
-	<PackageIcon>confluent-logo.png</PackageIcon>
-	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+    <PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+    <RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>confluent-logo.png</PackageIcon>
+    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;JSON</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Json</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Json</Title>
@@ -33,12 +33,13 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -7,10 +7,10 @@
     <Copyright>Copyright 2020-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
 	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
 	<RepositoryType>Git</RepositoryType>
-	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
-    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+	<PackageIcon>confluent-logo.png</PackageIcon>
+	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;JSON</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Json</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Json</Title>
@@ -35,6 +35,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
 	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -6,8 +6,10 @@
     <Description>Provides a JSON Serializer and Deserializer for use with Confluent.Kafka with Confluent Schema Registry integration</Description>
     <Copyright>Copyright 2020-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryType>Git</RepositoryType>
+	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;JSON</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Json</PackageId>
@@ -31,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
@@ -7,10 +7,10 @@
     <Copyright>Copyright 2020-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
 	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
 	<RepositoryType>Git</RepositoryType>
-	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
-    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+	<PackageIcon>confluent-logo.png</PackageIcon>
+	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;Protobuf</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Protobuf</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Protobuf</Title>
@@ -38,6 +38,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
 	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -6,11 +6,12 @@
     <Description>Provides a Protobuf Serializer and Deserializer for use with Confluent.Kafka with Confluent Schema Registry integration</Description>
     <Copyright>Copyright 2020-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
-	<RepositoryType>Git</RepositoryType>
-	<PackageIcon>confluent-logo.png</PackageIcon>
-	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+    <PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+    <RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>confluent-logo.png</PackageIcon>
+    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;Protobuf</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Protobuf</PackageId>
     <Title>Confluent.SchemaRegistry.Serdes.Protobuf</Title>
@@ -31,17 +32,18 @@
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
-	<ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
+    <ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
+    <ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj
@@ -6,8 +6,10 @@
     <Description>Provides a Protobuf Serializer and Deserializer for use with Confluent.Kafka with Confluent Schema Registry integration</Description>
     <Copyright>Copyright 2020-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryType>Git</RepositoryType>
+	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry;Protobuf</PackageTags>
     <PackageId>Confluent.SchemaRegistry.Serdes.Protobuf</PackageId>
@@ -29,13 +31,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
-    <ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
+	<ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
+	<ProjectReference Include="..\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+	<PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+	<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
+++ b/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
@@ -7,10 +7,10 @@
     <Copyright>Copyright 2017-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
 	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
 	<RepositoryType>Git</RepositoryType>
-	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
-    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+	<PackageIcon>confluent-logo.png</PackageIcon>
+	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry</PackageTags>
     <PackageId>Confluent.SchemaRegistry</PackageId>
     <Title>Confluent.SchemaRegistry</Title>
@@ -31,6 +31,10 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
+++ b/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
@@ -6,11 +6,12 @@
     <Description>A .NET Client for Confluent Schema Registry</Description>
     <Copyright>Copyright 2017-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
-	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
-	<RepositoryType>Git</RepositoryType>
-	<PackageIcon>confluent-logo.png</PackageIcon>
-	<PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
+    <PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+    <RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>confluent-logo.png</PackageIcon>
+    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+    <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry</PackageTags>
     <PackageId>Confluent.SchemaRegistry</PackageId>
     <Title>Confluent.SchemaRegistry</Title>
@@ -24,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
+    <ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,7 +35,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\confluent-logo.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
+++ b/src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj
@@ -6,8 +6,10 @@
     <Description>A .NET Client for Confluent Schema Registry</Description>
     <Copyright>Copyright 2017-2022 Confluent Inc.</Copyright>
     <PackageProjectUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
+	<PackageLicenceExpression>Apache-2.0</PackageLicenceExpression>
+	<RepositoryUrl>https://github.com/confluentinc/confluent-kafka-dotnet/</RepositoryUrl>
+	<RepositoryType>Git</RepositoryType>
+	<PackageIconUrl>https://raw.githubusercontent.com/confluentinc/confluent-kafka-dotnet/master/confluent-logo.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/confluentinc/confluent-kafka-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Kafka;Confluent;Schema Registry</PackageTags>
     <PackageId>Confluent.SchemaRegistry</PackageId>
@@ -22,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
+	<ProjectReference Include="..\Confluent.Kafka\Confluent.Kafka.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This sets additional package info and switch to licence expression rather than url. Also lint csproj to be consistantly tabbed.

closes #2183 