### PR TITLE
Elect leader api(KIP-460) implemented

### DIFF
--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -968,11 +968,11 @@ namespace Confluent.Kafka.Examples
                         var result = e.Results.PartitionResults[i];
                         if (!result.Error.IsError)
                         {
-                            Console.WriteLine($"Elected leaders operation {i} completed successfully");
+                            Console.WriteLine($"Elected leaders operation completed successfully for Topic {result.Topic} Partition {result.Partition}");
                         }
                         else
                         {
-                            Console.WriteLine($"An error occurred in elect leaders operation {i}: Code: {result.Error.Code}" +
+                            Console.WriteLine($"An error occurred in elect leaders operation in Topic {result.Topic} Partition {result.Partition}: Code: {result.Error.Code}" +
                             $", Reason: {result.Error.Reason}");
                         }
                     }

--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -313,6 +313,30 @@ namespace Confluent.Kafka.Examples
             return Tuple.Create(isolationLevel, topicPartitionOffsetSpecs);
         }
 
+        static ElectLeadersRequest ParseElectLeadersArgs(string[] args)
+        {
+            if (args.Length < 3 || (args.Length -1 )%2 != 0)
+            {
+                Console.WriteLine("usage: .. <bootstrapServers> elect-leaders electionType(0/1) <topic1> <partition1> ..");
+                Environment.ExitCode = 1;
+                return null;
+            }
+            
+            var electionType = Enum.Parse<ElectionType>(args[0]);
+            var partitions = new List<TopicPartition>();
+            for (int i = 1; i < args.Length; i += 2)
+            {
+                var topic = args[i];
+                var partition = Int32.Parse(args[i + 1]);
+                partitions.Add(new TopicPartition(topic, partition));
+            }
+            return new ElectLeadersRequest
+            {
+                ElectionType = electionType,
+                Partitions = partitions
+            };
+        }
+
        static void PrintListOffsetsResultInfos(List<ListOffsetsResultInfo> ListOffsetsResultInfos)
        {
             foreach(var listOffsetsResultInfo in ListOffsetsResultInfos)
@@ -320,6 +344,15 @@ namespace Confluent.Kafka.Examples
                 Console.WriteLine("  ListOffsetsResultInfo:");
                 Console.WriteLine($"    TopicPartitionOffsetError: {listOffsetsResultInfo.TopicPartitionOffsetError}");
                 Console.WriteLine($"    Timestamp: {listOffsetsResultInfo.Timestamp}");
+            }
+        }
+
+        static void PrintElectLeaderResults(ElectLeadersResult result)
+        {
+            Console.WriteLine("  ElectLeadersResult:");
+            foreach (var partitionResult in result.PartitionResults)
+            {
+                Console.WriteLine($"Election successful in {partitionResult.Topic} {partitionResult.Partition}");
             }
         }
 
@@ -903,6 +936,51 @@ namespace Confluent.Kafka.Examples
                 {
                     Console.WriteLine($"An error occurred listing offsets: {e}");
                     Environment.ExitCode = 1;
+                }
+            }
+        }
+
+        static async Task ElectLeadersAsync(string bootstrapServers, string[] commandArgs)
+        {
+            if (commandArgs.Length < 1)
+            {
+                Console.WriteLine("usage: .. <bootstrapServers> elect-leaders <topic1> [<topic2 ... <topicN>]");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var electLeadersRequest = ParseElectLeadersArgs(commandArgs);
+
+            var timeout = TimeSpan.FromSeconds(30);
+            ElectLeadersOptions options = new ElectLeadersOptions() { RequestTimeout = timeout };
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
+            {
+                try
+                {
+                    var result = await adminClient.ElectLeadersAsync(electLeadersRequest, new ElectLeadersOptions() { RequestTimeout = timeout });
+                    PrintElectLeaderResults(result);
+                    
+                }
+                catch (ElectLeadersException e)
+                {
+                    Console.WriteLine("One or more elect leaders operations failed.");
+                    for (int i = 0; i < e.Results.PartitionResults.Count; ++i)
+                    {
+                        var result = e.Results.PartitionResults[i];
+                        if (!result.Error.IsError)
+                        {
+                            Console.WriteLine($"Elected leaders operation {i} completed successfully");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"An error occurred in elect leaders operation {i}: Code: {result.Error.Code}" +
+                            $", Reason: {result.Error.Reason}");
+                        }
+                    }
+                }
+                catch (KafkaException e)
+                {
+                    Console.WriteLine($"An error occurred calling the ElectLeaders operation: {e.Message}");
                 }
             }
         }

--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -942,22 +942,21 @@ namespace Confluent.Kafka.Examples
 
         static async Task ElectLeadersAsync(string bootstrapServers, string[] commandArgs)
         {
-            if (commandArgs.Length < 1)
+            if (commandArgs.Length < 3 && (commandArgs.Length - 1) % 2 != 0)
             {
-                Console.WriteLine("usage: .. <bootstrapServers> elect-leaders <topic1> [<topic2 ... <topicN>]");
+                Console.WriteLine("usage: .. <bootstrapServers> elect-leaders electionType(0/1) <topic1> <partition1> ..");
                 Environment.ExitCode = 1;
                 return;
             }
 
-            var electLeadersRequest = ParseElectLeadersArgs(commandArgs);
-
+            var electLeadersRequest = ParseElectLeadersArgs(commandArgs);        
             var timeout = TimeSpan.FromSeconds(30);
             ElectLeadersOptions options = new ElectLeadersOptions() { RequestTimeout = timeout };
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 try
                 {
-                    var result = await adminClient.ElectLeadersAsync(electLeadersRequest, new ElectLeadersOptions() { RequestTimeout = timeout });
+                    var result = await adminClient.ElectLeadersAsync(electLeadersRequest, options);
                     PrintElectLeaderResults(result);
                     
                 }

--- a/examples/AdminClient/Program.cs
+++ b/examples/AdminClient/Program.cs
@@ -1074,7 +1074,7 @@ namespace Confluent.Kafka.Examples
                         "list-consumer-group-offsets", "alter-consumer-group-offsets",
                         "incremental-alter-configs", "describe-user-scram-credentials", 
                         "alter-user-scram-credentials", "describe-topics",
-                        "describe-cluster", "list-offsets"
+                        "describe-cluster", "list-offsets", "elect-leaders"
                     }) +
                     " ..");
                 Environment.ExitCode = 1;
@@ -1137,6 +1137,9 @@ namespace Confluent.Kafka.Examples
                     break;
                 case "list-offsets":
                     await ListOffsetsAsync(bootstrapServers, commandArgs);
+                    break;
+                case "elect-leaders":
+                    await ElectLeadersAsync(bootstrapServers, commandArgs);
                     break;
                 default:
                     Console.WriteLine($"unknown command: {command}");

--- a/src/Confluent.Kafka/Admin/ElectLeadersException.cs
+++ b/src/Confluent.Kafka/Admin/ElectLeadersException.cs
@@ -1,0 +1,42 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka.Admin
+{
+    /// <summary>
+    ///    Represents an error that occured during the ElectLeaders opperation.
+    ///  </summary>
+    public class ElectLeadersException : KafkaException
+    {
+        /// <summary>
+        ///     Initializes a new instance of ElectLeadersException.
+        /// </summary>
+        /// <param name="report">
+        ///     The result of the ElectLeaders operation.
+        /// </param>
+        public ElectLeadersException(ElectLeadersReport report)
+            : base(new Error(ErrorCode.Local_Partial,
+                   "error electing leaders"))
+        {
+            this.Results = report;
+        }
+
+        /// <summary>
+        ///     Gets the results of the ElectLeaders operation.
+        /// </summary>
+        public ElectLeadersReport Results { get; }
+    }
+}

--- a/src/Confluent.Kafka/Admin/ElectLeadersOptions.cs
+++ b/src/Confluent.Kafka/Admin/ElectLeadersOptions.cs
@@ -1,0 +1,46 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System;
+
+namespace Confluent.Kafka.Admin
+{
+    /// <summary>
+    ///     Options for ElectLeaders method.
+    /// </summary>
+    public class ElectLeadersOptions
+    {
+        /// <summary>
+        ///     The overall request timeout, including broker lookup, request 
+        ///     transmission, operation time on broker, and response. If set
+        ///     to null, the default request timeout for the AdminClient will
+        ///     be used.
+        /// 
+        ///     Default: null
+        /// </summary>
+        public TimeSpan? RequestTimeout { get; set; }
+
+        /// <summary>
+        ///     The broker's operation timeout - the maximum time to wait for
+        ///     CreatePartitions before returning a result to the application.
+        ///     If set to null, will return immediately upon triggering partition
+        ///     creation.
+        /// 
+        ///     Default: null
+        /// </summary>
+        public TimeSpan? OperationTimeout { get; set; }
+    }
+}

--- a/src/Confluent.Kafka/Admin/ElectLeadersReport.cs
+++ b/src/Confluent.Kafka/Admin/ElectLeadersReport.cs
@@ -1,0 +1,55 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Confluent.Kafka.Admin
+{
+    /// <summary>
+    ///    Result information for all Partitions queried
+    ///    in an ElectLeaderRequest (including error status). 
+    ///  </summary>
+    public class ElectLeadersReport
+    {
+        /// <summary>
+        ///    Operational Error if any
+        ///  </summary>
+        public ErrorCode ErrorCode { get; set; }
+
+        /// <summary>
+        ///   Individual partition results. Atleast one of these partitions
+       ///    will be in error.
+        ///  </summary>
+        public List<TopicPartitionError> PartitionResults { get; set; }
+
+        /// <summary>
+        ///     A Json representation of the object.
+        ///  </summary>
+        ///  <returns>
+        ///     A Json representation of the object.
+        ///  </returns>
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+            result.Append($"{{\"TopLevelErrorCode\": \"{ErrorCode}\", \"PartitionResults\": [");
+            result.Append(string.Join(",", PartitionResults.Select(b => $" {b.ToString()}")));
+            result.Append($"]}}");
+            return result.ToString();
+        }
+    }
+}

--- a/src/Confluent.Kafka/Admin/ElectLeadersReport.cs
+++ b/src/Confluent.Kafka/Admin/ElectLeadersReport.cs
@@ -46,7 +46,7 @@ namespace Confluent.Kafka.Admin
         public override string ToString()
         {
             var result = new StringBuilder();
-            result.Append($"{{\"TopLevelErrorCode\": \"{ErrorCode}\", \"PartitionResults\": [");
+            result.Append($"{{\"ErrorCode\": \"{ErrorCode}\", \"PartitionResults\": [");
             result.Append(string.Join(",", PartitionResults.Select(b => $" {b.ToString()}")));
             result.Append($"]}}");
             return result.ToString();

--- a/src/Confluent.Kafka/Admin/ElectLeadersRequest.cs
+++ b/src/Confluent.Kafka/Admin/ElectLeadersRequest.cs
@@ -1,0 +1,38 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System.Collections.Generic;
+
+namespace Confluent.Kafka.Admin
+{
+    /// <summary>
+    ///      Request to elect a leader for a partition.
+    ///      This is used to trigger a leader election for a partition.
+    ///   </summary>
+    public class ElectLeadersRequest
+    {
+        /// <summary>
+        ///    The type of election to trigger.
+        /// </summary>
+        public ElectionType ElectionType { get; set; }
+
+        /// <summary>
+        ///     List of partitions to elect leaders for.
+        ///  </summary>
+        public List<TopicPartition> Partitions { get; set; }
+
+    }
+}

--- a/src/Confluent.Kafka/Admin/ElectLeadersResult.cs
+++ b/src/Confluent.Kafka/Admin/ElectLeadersResult.cs
@@ -1,0 +1,49 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Confluent.Kafka.Admin
+{
+    /// <summary>
+    ///    Result information for all Partitions queried
+    ///    in an ElectLeaderRequest. 
+    ///  </summary>
+    public class ElectLeadersResult
+    {
+        /// <summary>
+        ///   Individual partition results.
+        ///  </summary>
+        public List<TopicPartitionError> PartitionResults { get; set; }
+
+        /// <summary>
+        ///     A Json representation of the object.
+        ///  </summary>
+        ///  <returns>
+        ///     A Json representation of the object.
+        ///  </returns>
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+            result.Append($"{{ \"PartitionResults\": [");
+            result.Append(string.Join(",", PartitionResults.Select(b => $" {b.ToString()}")));
+            result.Append($"]}}");
+            return result.ToString();
+        }
+    }
+}

--- a/src/Confluent.Kafka/Admin/ElectionType.cs
+++ b/src/Confluent.Kafka/Admin/ElectionType.cs
@@ -22,9 +22,9 @@ namespace Confluent.Kafka.Admin
     public enum ElectionType : int
     {
         /// <summary>
-        ///     Preffered Elections
+        ///     Preferred Elections
         ///  </summary>
-        Preffered = 0,
+        Preferred = 0,
 
         /// <summary>
         ///     Unclean Elections

--- a/src/Confluent.Kafka/Admin/ElectionType.cs
+++ b/src/Confluent.Kafka/Admin/ElectionType.cs
@@ -1,0 +1,34 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka.Admin
+{
+    /// <summary>
+    ///     Enumerates the different types of ACL permission types.
+    /// </summary>
+    public enum ElectionType : int
+    {
+        /// <summary>
+        ///     Preffered Elections
+        ///  </summary>
+        Preffered = 0,
+
+        /// <summary>
+        ///     Unclean Elections
+        /// </summary>
+        Unclean = 1,
+    }
+}

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -682,7 +682,7 @@ namespace Confluent.Kafka
                                 }
 
                                 var type = Librdkafka.event_type(eventPtr);
-                                
+
                                 var ptr = (IntPtr)Librdkafka.event_opaque(eventPtr);
                                 var gch = GCHandle.FromIntPtr(ptr);
                                 var adminClientResult = gch.Target;

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -634,6 +634,38 @@ namespace Confluent.Kafka
             };
         }
 
+        private Tuple<ErrorCode,List<TopicPartitionError>> extractTopicPartitionErrors(IntPtr topicPartitionErrorsPtr, int topicPartitionErrorsCount)
+        {
+            ErrorCode err = ErrorCode.NoError;
+            if(topicPartitionErrorsPtr == IntPtr.Zero){
+                return null;
+            }
+            List<TopicPartitionError> topicPartitionErrors = new List<TopicPartitionError>(topicPartitionErrorsCount);
+            for(int i=0;i<topicPartitionErrorsCount;i++){
+                IntPtr topicPartitionErrorPtr = Librdkafka.ElectionResult_partitions_by_idx(topicPartitionErrorsPtr, (UIntPtr)i);
+                var tpe = Marshal.PtrToStructure<rd_kafka_topic_partition_result>(topicPartitionErrorPtr);
+                if(tpe.errCode != ErrorCode.NoError){
+                    err = tpe.errCode;
+                }
+                topicPartitionErrors.Add(new TopicPartitionError(
+                                                tpe.topic, 
+                                                new Partition(tpe.partition), 
+                                                new Error(tpe.errCode, tpe.errorStr)));
+            }
+            var result = new Tuple<ErrorCode, List<TopicPartitionError>>(err, topicPartitionErrors);
+            return result;        
+        }
+
+        private ElectLeadersReport extractElectLeadersResults(IntPtr resultPtr)
+        {
+            var partitionsPtr = Librdkafka.ElectionResult_partitions(resultPtr, out UIntPtr partitionsCountPtr);
+            var result = extractTopicPartitionErrors(partitionsPtr, (int)partitionsCountPtr);
+            return new ElectLeadersReport{
+                ErrorCode = result.Item1,
+                PartitionResults = result.Item2
+            };
+        }
+
         private Task StartPollTask(CancellationToken ct)
             => Task.Factory.StartNew(() =>
                 {
@@ -1252,6 +1284,40 @@ namespace Confluent.Kafka
                                         }
                                         break;
                                     }
+                                    case Librdkafka.EventType.ElectLeaders_Result:
+                                    {
+                                        if(errorCode != ErrorCode.NoError)
+                                        {
+                                            Task.Run(() =>
+                                                    ((TaskCompletionSource<ElectLeadersResult>)adminClientResult).TrySetException(
+                                                        new KafkaException(kafkaHandle.CreatePossiblyFatalError(errorCode, errorStr))));
+                                                break;
+                                        }
+                                        ErrorCode topLevelErrorCode = Librdkafka.ElectionResult_error(eventPtr);
+                                        if(topLevelErrorCode != ErrorCode.NoError)
+                                        {
+                                            Task.Run(() =>
+                                                    ((TaskCompletionSource<ElectLeadersResult>)adminClientResult).TrySetException(
+                                                        new KafkaException(new Error(topLevelErrorCode))));
+                                                break;
+                                        }
+                                        ElectLeadersReport report = extractElectLeadersResults(eventPtr);
+                                        if(report.ErrorCode != ErrorCode.NoError)
+                                        {
+                                            Task.Run(() =>
+                                                    ((TaskCompletionSource<ElectLeadersResult>)adminClientResult).TrySetException(
+                                                        new ElectLeadersException(report)));
+                                        }
+                                        else
+                                        {
+                                            var result = new ElectLeadersResult(){
+                                                PartitionResults = report.PartitionResults
+                                            };
+                                            Task.Run(() =>
+                                                ((TaskCompletionSource<ElectLeadersResult>)adminClientResult).TrySetResult(result));
+                                        }
+                                        break;
+                                    }
                                     default:
                                         // Should never happen.
                                         throw new InvalidOperationException($"Unknown result type: {type}");
@@ -1776,5 +1842,16 @@ namespace Confluent.Kafka
                 GCHandle.ToIntPtr(gch));
             return completionSource.Task;
         }
+        
+        public Task<ElectLeadersResult> ElectLeadersAsync(ElectLeadersRequest electLeadersRequest, ElectLeadersOptions options = null)
+        {
+            var completionSource = new TaskCompletionSource<ElectLeadersResult>();
+            var gch = GCHandle.Alloc(completionSource);
+            Handle.LibrdkafkaHandle.ElectLeaders(
+                electLeadersRequest, options, resultQueue,
+                GCHandle.ToIntPtr(gch));
+            return completionSource.Task;
+        }
+
     }
 }

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -1843,7 +1843,10 @@ namespace Confluent.Kafka
             return completionSource.Task;
         }
         
-        public Task<ElectLeadersResult> ElectLeadersAsync(ElectLeadersRequest electLeadersRequest, ElectLeadersOptions options = null)
+        /// <summary>
+        ///  Refer to <see cref="Confluent.Kafka.IAdminClientExtensions.ElectLeadersAsync(IAdminClient, ElectLeadersRequest, ElectLeadersOptions)" />
+        /// </summary>
+         public Task<ElectLeadersResult> ElectLeadersAsync(ElectLeadersRequest electLeadersRequest, ElectLeadersOptions options = null)
         {
             var completionSource = new TaskCompletionSource<ElectLeadersResult>();
             var gch = GCHandle.Alloc(completionSource);

--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -680,7 +680,9 @@ namespace Confluent.Kafka
                                 {
                                     continue;
                                 }
+
                                 var type = Librdkafka.event_type(eventPtr);
+                                
                                 var ptr = (IntPtr)Librdkafka.event_opaque(eventPtr);
                                 var gch = GCHandle.FromIntPtr(ptr);
                                 var adminClientResult = gch.Target;

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -638,16 +638,12 @@ namespace Confluent.Kafka
         /// </param>
         /// <param name="electLeadersRequest">
         ///      Contains :
-        ///         ElectionType : The type of election to trigger(Preferred or Uncklean).
+        ///         ElectionType : The type of election to trigger(Preferred or Unclean).
         ///         partitions: The partitions for which election has to be performed.
         /// </param>
         /// <param name="options">
         ///      The options to use for this call.
         /// </param>
-        /// <returns>
-        ///    A <see cref="Confluent.Kafka.Admin.ElectLeadersResult"/>
-        /// </returns>
-        /// <exception cref="NotImplementedException"></exception>
         public static Task<ElectLeadersResult> ElectLeadersAsync(
             this IAdminClient adminClient,
             ElectLeadersRequest electLeadersRequest,

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -631,14 +631,14 @@ namespace Confluent.Kafka
         }
         
         /// <summary>
-        ///    Perform Preffered or Unclean leader election for partitions.
+        ///    Perform Preferred or Unclean leader election for partitions.
         /// </summary>
         /// <param name="adminClient">
         ///     AdminClient interface.
         /// </param>
         /// <param name="electLeadersRequest">
         ///      Contains :
-        ///         ElectionType : The type of election to trigger(Preffered or Uncklean).
+        ///         ElectionType : The type of election to trigger(Preferred or Uncklean).
         ///         partitions: The partitions for which election has to be performed.
         /// </param>
         /// <param name="options">

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
+using System.Net;
 
 
 namespace Confluent.Kafka
@@ -626,6 +627,38 @@ namespace Confluent.Kafka
                 return ((AdminClient) adminClient).ListOffsetsAsync(
                         topicPartitionOffsets,
                         options);
+            }
+            throw new NotImplementedException();
+        }
+        
+        /// <summary>
+        ///    Perform Preffered or Unclean leader election for partitions.
+        /// </summary>
+        /// <param name="adminClient">
+        ///     AdminClient interface.
+        /// </param>
+        /// <param name="electLeadersRequest">
+        ///      Contains :
+        ///         ElectionType : The type of election to trigger(Preffered or Uncklean).
+        ///         partitions: The partitions for which election has to be performed.
+        /// </param>
+        /// <param name="options">
+        ///      The options to use for this call.
+        /// </param>
+        /// <returns>
+        ///    A <see cref="Confluent.Kafka.Admin.ElectLeadersResult"/>
+        /// </returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public static Task<ElectLeadersResult> ElectLeadersAsync(
+            this IAdminClient adminClient,
+            ElectLeadersRequest electLeadersRequest,
+            ElectLeadersOptions options = null)
+        {
+            if (adminClient is AdminClient)
+            {
+                return ((AdminClient) adminClient).ElectLeadersAsync(
+                    electLeadersRequest,
+                    options);
             }
             throw new NotImplementedException();
         }

--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -19,7 +19,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
-using System.Net;
 
 
 namespace Confluent.Kafka

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -76,6 +76,7 @@ namespace Confluent.Kafka.Impl
             DescribeTopics = 19,
             DescribeCluster = 20,
             ListOffsets = 21,
+            ElectLeaders = 22,
         }
 
         public enum EventType : int
@@ -109,6 +110,7 @@ namespace Confluent.Kafka.Impl
             DescribeTopics_Result = 0x100000,
             DescribeCluster_Result = 0x200000,
             ListOffsets_Result = 0x400000,
+            ElectLeaders_Result = 0x800000,
         }
 
         // Minimum librdkafka version.
@@ -471,6 +473,13 @@ namespace Confluent.Kafka.Impl
             _TopicPartitionInfo_leader = (_TopicPartitionInfo_leader_delegate)methods.Single(m => m.Name == "rd_kafka_TopicPartitionInfo_leader").CreateDelegate(typeof (_TopicPartitionInfo_leader_delegate));
             _TopicPartitionInfo_partition = (_TopicPartitionInfo_partition_delegate)methods.Single(m => m.Name == "rd_kafka_TopicPartitionInfo_partition").CreateDelegate(typeof (_TopicPartitionInfo_partition_delegate));
             _TopicPartitionInfo_replicas = (_TopicPartitionInfo_replicas_delegate)methods.Single(m => m.Name == "rd_kafka_TopicPartitionInfo_replicas").CreateDelegate(typeof (_TopicPartitionInfo_replicas_delegate));
+
+            _ElectLeaderRequest_new = (_ElectLeaderRequest_new_delegate)methods.Single(m => m.Name == "rd_kafka_ElectLeader_new").CreateDelegate(typeof(_ElectLeaderRequest_new_delegate));
+            _ElectLeaderRequest_destroy = (_ElectLeaderRequest_destroy_delegate)methods.Single(m => m.Name == "rd_kafka_ElectLeader_destroy").CreateDelegate(typeof(_ElectLeaderRequest_destroy_delegate));
+            _ElectLeader = (_ElectLeader_delegate)methods.Single(m => m.Name == "rd_kafka_ElectLeader").CreateDelegate(typeof(_ElectLeader_delegate));
+            _ElectionResult_partitions = (_ElectionResult_partitions_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_partitions").CreateDelegate(typeof(_ElectionResult_partitions_delegate));
+            _ElectionResult_partitions_by_idx = (_ElectionResult_partitions_by_idx_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_partitions_by_idx").CreateDelegate(typeof(_ElectionResult_partitions_by_idx_delegate));
+            _ElectionResult_error = (_ElectionResult_error_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_error").CreateDelegate(typeof(_ElectionResult_error_delegate));
 
             _DescribeCluster = (_DescribeCluster_delegate)methods.Single(m => m.Name == "rd_kafka_DescribeCluster").CreateDelegate(typeof (_DescribeCluster_delegate));
             _DescribeCluster_result_nodes = (_DescribeCluster_result_nodes_delegate)methods.Single(m => m.Name == "rd_kafka_DescribeCluster_result_nodes").CreateDelegate(typeof (_DescribeCluster_result_nodes_delegate));
@@ -2251,6 +2260,41 @@ namespace Confluent.Kafka.Impl
          private static _DescribeCluster_result_cluster_id_delegate _DescribeCluster_result_cluster_id;
          internal static IntPtr DescribeCluster_result_cluster_id(IntPtr result)
             => _DescribeCluster_result_cluster_id(result);
+        
+
+        //
+        // ElectLeaders
+        //
+
+        private delegate IntPtr _ElectLeaderRequest_new_delegate(ElectionType electionType, IntPtr partitions);
+        private static _ElectLeaderRequest_new_delegate _ElectLeaderRequest_new;
+        internal static IntPtr ElectLeaderRequest_New(ElectionType electionType, IntPtr partitions)
+              => _ElectLeaderRequest_new(electionType, partitions);
+
+        private delegate void _ElectLeaderRequest_destroy_delegate(IntPtr electLeaderRequest);
+        private static _ElectLeaderRequest_destroy_delegate _ElectLeaderRequest_destroy;
+        internal static void ElectLeaderRequest_destroy(IntPtr electLeaderRequest)
+              => _ElectLeaderRequest_destroy(electLeaderRequest);
+
+        private delegate void _ElectLeader_delegate(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
+        private static _ElectLeader_delegate _ElectLeader;
+        internal static void ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr)
+              => _ElectLeader(handle, electLeaderRequest, options, resultQueuePtr);
+
+        private delegate IntPtr _ElectionResult_partitions_delegate(IntPtr result, out UIntPtr cntp);
+        private static _ElectionResult_partitions_delegate _ElectionResult_partitions;
+        internal static IntPtr ElectionResult_partitions(IntPtr result, out UIntPtr cntp)
+              => _ElectionResult_partitions(result, out cntp);
+        
+        private delegate IntPtr _ElectionResult_partitions_by_idx_delegate(IntPtr result, UIntPtr idx);
+        private static _ElectionResult_partitions_by_idx_delegate _ElectionResult_partitions_by_idx;
+        internal static IntPtr ElectionResult_partitions_by_idx(IntPtr result, UIntPtr idx)
+              => _ElectionResult_partitions_by_idx(result, idx);
+
+        private delegate ErrorCode _ElectionResult_error_delegate(IntPtr result);
+        private static _ElectionResult_error_delegate _ElectionResult_error;
+        internal static ErrorCode ElectionResult_error(IntPtr result)
+              => _ElectionResult_error(result);
 
         //
         // Queues

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -477,8 +477,7 @@ namespace Confluent.Kafka.Impl
             _ElectLeaderRequest_new = (_ElectLeaderRequest_new_delegate)methods.Single(m => m.Name == "rd_kafka_ElectLeader_new").CreateDelegate(typeof(_ElectLeaderRequest_new_delegate));
             _ElectLeaderRequest_destroy = (_ElectLeaderRequest_destroy_delegate)methods.Single(m => m.Name == "rd_kafka_ElectLeader_destroy").CreateDelegate(typeof(_ElectLeaderRequest_destroy_delegate));
             _ElectLeader = (_ElectLeader_delegate)methods.Single(m => m.Name == "rd_kafka_ElectLeader").CreateDelegate(typeof(_ElectLeader_delegate));
-            _ElectionResult_partitions = (_ElectionResult_partitions_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_partitions").CreateDelegate(typeof(_ElectionResult_partitions_delegate));
-            _ElectionResult_partitions_by_idx = (_ElectionResult_partitions_by_idx_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_partitions_by_idx").CreateDelegate(typeof(_ElectionResult_partitions_by_idx_delegate));
+            _ElectionResult_partition = (_ElectionResult_partition_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_partition").CreateDelegate(typeof(_ElectionResult_partition_delegate));
             _ElectionResult_error = (_ElectionResult_error_delegate)methods.Single(m => m.Name == "rd_kafka_ElectionResult_error").CreateDelegate(typeof(_ElectionResult_error_delegate));
 
             _DescribeCluster = (_DescribeCluster_delegate)methods.Single(m => m.Name == "rd_kafka_DescribeCluster").CreateDelegate(typeof (_DescribeCluster_delegate));
@@ -2281,15 +2280,10 @@ namespace Confluent.Kafka.Impl
         internal static void ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr)
               => _ElectLeader(handle, electLeaderRequest, options, resultQueuePtr);
 
-        private delegate IntPtr _ElectionResult_partitions_delegate(IntPtr result, out UIntPtr cntp);
-        private static _ElectionResult_partitions_delegate _ElectionResult_partitions;
-        internal static IntPtr ElectionResult_partitions(IntPtr result, out UIntPtr cntp)
-              => _ElectionResult_partitions(result, out cntp);
-        
-        private delegate IntPtr _ElectionResult_partitions_by_idx_delegate(IntPtr result, UIntPtr idx);
-        private static _ElectionResult_partitions_by_idx_delegate _ElectionResult_partitions_by_idx;
-        internal static IntPtr ElectionResult_partitions_by_idx(IntPtr result, UIntPtr idx)
-              => _ElectionResult_partitions_by_idx(result, idx);
+        private delegate IntPtr _ElectionResult_partition_delegate(IntPtr result, out UIntPtr cntp);
+        private static _ElectionResult_partition_delegate _ElectionResult_partition;
+        internal static IntPtr ElectionResult_partition(IntPtr result, out UIntPtr cntp)
+              => _ElectionResult_partition(result, out cntp);
 
         private delegate ErrorCode _ElectionResult_error_delegate(IntPtr result);
         private static _ElectionResult_error_delegate _ElectionResult_error;

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
@@ -1282,10 +1282,7 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
-
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+        internal static extern IntPtr rd_kafka_ElectionResult_partition(IntPtr result, out UIntPtr cntp);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
@@ -1272,6 +1272,24 @@ namespace Confluent.Kafka.Impl.NativeMethods
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr rd_kafka_DescribeCluster_result_cluster_id(IntPtr result);
 
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectLeader_new(ElectionType electionType, IntPtr partitions);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader_destroy(IntPtr electLeader);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);
+
         //
         // Queues
         //

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
@@ -1276,6 +1276,24 @@ namespace Confluent.Kafka.Impl.NativeMethods
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr rd_kafka_DescribeCluster_result_cluster_id(IntPtr result);
 
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectLeader_new(ElectionType electionType, IntPtr partitions);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader_destroy(IntPtr electLeader);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);
+
         //
         // Queues
         //

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
@@ -1286,10 +1286,7 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
-
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+        internal static extern IntPtr rd_kafka_ElectionResult_partition(IntPtr result, out UIntPtr cntp);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos6.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos6.cs
@@ -1276,6 +1276,24 @@ namespace Confluent.Kafka.Impl.NativeMethods
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr rd_kafka_DescribeCluster_result_cluster_id(IntPtr result);
 
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectLeader_new(ElectionType electionType, IntPtr partitions);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader_destroy(IntPtr electLeader);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);
+
         //
         // Queues
         //

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos6.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos6.cs
@@ -1286,10 +1286,7 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
-
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+        internal static extern IntPtr rd_kafka_ElectionResult_partition(IntPtr result, out UIntPtr cntp);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos7.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos7.cs
@@ -1276,6 +1276,24 @@ namespace Confluent.Kafka.Impl.NativeMethods
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr rd_kafka_DescribeCluster_result_cluster_id(IntPtr result);
 
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectLeader_new(ElectionType electionType, IntPtr partitions);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader_destroy(IntPtr electLeader);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);
+
         //
         // Queues
         //

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos7.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos7.cs
@@ -1286,10 +1286,7 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern void rd_kafka_ElectLeader(IntPtr handle, IntPtr electLeaderRequest, IntPtr options, IntPtr resultQueuePtr);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partitions(IntPtr result, out UIntPtr cntp);
-
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rd_kafka_ElectionResult_partition_by_idx(IntPtr result, int idx);
+        internal static extern IntPtr rd_kafka_ElectionResult_partition(IntPtr result, out UIntPtr cntp);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode rd_kafka_ElectionResult_error(IntPtr result);

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -2540,7 +2540,6 @@ namespace Confluent.Kafka.Impl
         internal void ElectLeaders(ElectLeadersRequest electLeadersRequest, ElectLeadersOptions options, IntPtr resultQueuePtr, IntPtr completionSourcePtr)
         {
             ThrowIfHandleClosed();
-
             var optionsPtr = IntPtr.Zero;
             IntPtr topic_partition_list = IntPtr.Zero;
             IntPtr request = IntPtr.Zero;
@@ -2552,7 +2551,6 @@ namespace Confluent.Kafka.Impl
                 setOption_RequestTimeout(optionsPtr, options.RequestTimeout);
                 setOption_OperationTimeout(optionsPtr, options.OperationTimeout);
                 setOption_completionSource(optionsPtr, completionSourcePtr);
-
                 topic_partition_list = Librdkafka.topic_partition_list_new((IntPtr)electLeadersRequest.Partitions.Count());
                 foreach (var topicPartitions in electLeadersRequest.Partitions)
                 {

--- a/test/Confluent.Kafka.UnitTests/Admin/ElectLeadersError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/ElectLeadersError.cs
@@ -1,0 +1,176 @@
+// Copyright 2024 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+using Xunit;
+using System;
+using Confluent.Kafka.Admin;
+using System.Collections.Generic;
+
+namespace Confluent.Kafka.UnitTests
+{
+    public class ElectLeadersErrorTests
+    {
+        private readonly List<ElectLeadersOptions> options = new List<ElectLeadersOptions>
+        {
+            new ElectLeadersOptions {},
+            new ElectLeadersOptions { RequestTimeout = TimeSpan.FromMilliseconds(200) },
+            new ElectLeadersOptions { OperationTimeout = TimeSpan.FromMilliseconds(200)},
+            new ElectLeadersOptions { RequestTimeout = TimeSpan.FromMilliseconds(200), OperationTimeout = TimeSpan.FromMilliseconds(200) },
+        };
+
+        [Fact]
+        public async void InvalidRequestTimeout()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                    adminClient.ElectLeadersAsync(
+                        new ElectLeadersRequest { ElectionType = ElectionType.Preferred, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0) } },
+                        new ElectLeadersOptions
+                        {
+                            RequestTimeout = TimeSpan.FromSeconds(-1)
+                        })
+                );
+                Assert.Contains("expecting integer in range", ex.Message);
+                ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                    adminClient.ElectLeadersAsync(
+                        new ElectLeadersRequest { ElectionType = ElectionType.Unclean, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0) } },
+                        new ElectLeadersOptions
+                        {
+                            RequestTimeout = TimeSpan.FromSeconds(-1)
+                        })
+                );
+                Assert.Contains("expecting integer in range", ex.Message);
+            }
+        }
+
+        [Fact]
+        public async void EmptyPartitions()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach(var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Preferred, Partitions = new List<TopicPartition> { } },
+                            option)
+                    );
+                    Assert.Contains("No partitions specified", ex.Message);
+
+                    ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Unclean, Partitions = new List<TopicPartition> { } },
+                            option)
+                    );
+                    Assert.Contains("No partitions specified", ex.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async void DuplicatePartitions()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach(var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Preferred, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0), new TopicPartition("topic", 0) } },
+                            option)
+                    );
+                    Assert.Contains("Duplicate partitions specified", ex.Message);
+
+                    ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Unclean, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0), new TopicPartition("topic", 0) } },
+                            option)
+                    );
+                    Assert.Contains("Duplicate partitions specified", ex.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async void SinglePartition()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Preferred, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0) } },
+                            option)
+                    );
+                    Assert.Contains("Local: Timed out", ex.Message);
+
+                    ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Unclean, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0) } },
+                            option)
+                    );
+                    Assert.Contains("Local: Timed out", ex.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async void MultiplePartitions()
+        {
+            using (var adminClient = new AdminClientBuilder(new AdminClientConfig
+            { 
+                BootstrapServers = "localhost:90922",
+                SocketTimeoutMs = 10
+            }).Build())
+            {
+                foreach (var option in options)
+                {
+                    var ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Preferred, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0), new TopicPartition("topic", 1) } },
+                            option)
+                    );
+                    Assert.Contains("Local: Timed out", ex.Message);
+
+                    ex = await Assert.ThrowsAsync<KafkaException>(() =>
+                        adminClient.ElectLeadersAsync(
+                            new ElectLeadersRequest { ElectionType = ElectionType.Unclean, Partitions = new List<TopicPartition> { new TopicPartition("topic", 0), new TopicPartition("topic", 1) } },
+                            option)
+                    );
+                    Assert.Contains("Local: Timed out", ex.Message);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented the Elect Leaders API(KIP - 460) and wrote unit tests for it.

The build is gonna fail until the ElectLeaders api is merged in ibrdkafka.

Done the local testing and unit testing locally and getting desired results

`dotnet run localhost:9092 elect-leaders 0 Test1 0                                                                                                                                                                                                                                                           

One or more elect leaders operations failed.
An error occurred in elect leaders operation in Topic Test1 Partition [0]: Code: ElectionNotNeeded, Reason: Leader election not needed for topic partition.` 

which is the desired result in case Leader Election is not required in the partitions.

Unit tests also ran fine.

`dotnet test --filter "FullyQualifiedName~Confluent.Kafka.UnitTests.ElectLeadersErrorTests"  

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     5, Skipped:     0, Total:     5, Duration: 2 s - Confluent.Kafka.UnitTests.dll (net6.0)`