### PR TITLE
Fix incorrect netcore flag for Deserializers to enable ReadOnlySpan<byte> usage

### DIFF
--- a/src/Confluent.Kafka/Deserializers.cs
+++ b/src/Confluent.Kafka/Deserializers.cs
@@ -39,7 +39,7 @@ namespace Confluent.Kafka
                     return null;
                 }
 
-                #if NETCOREAPP2_1
+                #if NET6_0_OR_GREATER
                     return Encoding.UTF8.GetString(data);
                 #else
                     return Encoding.UTF8.GetString(data.ToArray());
@@ -171,7 +171,7 @@ namespace Confluent.Kafka
                 }
                 else
                 {
-                    #if NETCOREAPP2_1
+                    #if NET6_0_OR_GREATER
                         return BitConverter.ToSingle(data);
                     #else
                         return BitConverter.ToSingle(data.ToArray(), 0);
@@ -219,7 +219,7 @@ namespace Confluent.Kafka
                 }
                 else
                 {
-                    #if NETCOREAPP2_1
+                    #if NET6_0_OR_GREATER
                                     return BitConverter.ToDouble(data);
                     #else
                                     return BitConverter.ToDouble(data.ToArray(), 0);


### PR DESCRIPTION
Changed NETCOREAPP2_1 to NET6_0_OR_GREATER in Deserializers.cs to enable ReadOnlySpan<byte> usage
For predefined directives see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives