### PR TITLE
Add a UTF-8 statistics handler

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -17,6 +17,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -39,6 +40,9 @@ namespace Confluent.Kafka
             internal IEnumerable<KeyValuePair<string, string>> config;
             internal Action<Error> errorHandler;
             internal Action<LogMessage> logHandler;
+#if NET6_0_OR_GREATER
+            internal ReadOnlySpanAction<byte, object> statisticsUtf8Handler;
+#endif
             internal Action<string> statisticsHandler;
             internal Action<CommittedOffsets> offsetsCommittedHandler;
             internal Action<string> oAuthBearerTokenRefreshHandler;
@@ -104,6 +108,9 @@ namespace Confluent.Kafka
             }
         }
 
+#if NET6_0_OR_GREATER
+        private ReadOnlySpanAction<byte, object> statisticsUtf8Handler;
+#endif
         private Action<string> statisticsHandler;
         private Librdkafka.StatsDelegate statisticsCallbackDelegate;
         private int StatisticsCallback(IntPtr rk, IntPtr json, UIntPtr json_len, IntPtr opaque)
@@ -112,7 +119,20 @@ namespace Confluent.Kafka
             try
             {
                 // Ensure registered handlers are never called as a side-effect of Dispose/Finalize (prevents deadlocks in common scenarios).
-                statisticsHandler?.Invoke(Util.Marshal.PtrToStringUTF8(json, json_len));
+#if NET6_0_OR_GREATER
+                if (statisticsUtf8Handler != null)
+                {
+                    unsafe
+                    {
+                        statisticsUtf8Handler.Invoke(new ReadOnlySpan<byte>(json.ToPointer(), (int)json_len), null);
+                    }
+                }
+#endif
+
+                if (statisticsHandler != null)
+                {
+                    statisticsHandler.Invoke(Util.Marshal.PtrToStringUTF8(json, json_len));
+                }
             }
             catch (Exception e)
             {
@@ -628,6 +648,9 @@ namespace Confluent.Kafka
         {
             var baseConfig = builder.ConstructBaseConfig(this);
 
+#if NET6_0_OR_GREATER
+            this.statisticsUtf8Handler = baseConfig.statisticsUtf8Handler;
+#endif
             this.statisticsHandler = baseConfig.statisticsHandler;
             this.logHandler = baseConfig.logHandler;
             this.errorHandler = baseConfig.errorHandler;
@@ -710,7 +733,11 @@ namespace Confluent.Kafka
             {
                 Librdkafka.conf_set_log_cb(configPtr, logCallbackDelegate);
             }
+#if NET6_0_OR_GREATER
+            if (statisticsUtf8Handler != null || statisticsHandler != null)
+#else
             if (statisticsHandler != null)
+#endif
             {
                 Librdkafka.conf_set_stats_cb(configPtr, statisticsCallbackDelegate);
             }


### PR DESCRIPTION
The statistics payload can be quite large (several MB) and currently it can be copied twice in the managed code:
1. The payload is received from the C driver
2. [A .NET string is allocated for the JSON](https://github.com/confluentinc/confluent-kafka-dotnet/blob/32948fe3b70ce03a541fbd5026bb226848525f42/src/Confluent.Kafka/Consumer.cs#L115)
3. The statistics handler is called
4. The subscriber will likely call System.Text.Json.Serialize.Deserialize [which cause the string to be converted back to UTF-8](https://github.com/dotnet/runtime/blob/5c74f63871ed17624279ecbccd011de4d7dc5caa/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs#L426-L439)

This round-trip causes important memory fragmentation which puts pressure on the GC. In .NET 6, this can be avoided using `Span`.