### PR TITLE
Update NJsonSchema to v11

### DIFF
--- a/examples/JsonWithReferences/JsonWithReferences.csproj
+++ b/examples/JsonWithReferences/JsonWithReferences.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>JsonWithReferences</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/examples/JsonWithReferences/Program.cs
+++ b/examples/JsonWithReferences/Program.cs
@@ -22,9 +22,9 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NJsonSchema.Generation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 /// <summary>
@@ -150,7 +150,7 @@ namespace Confluent.Kafka.Examples.JsonWithReferences
             // from default one to camelCase.
             // It's also possible to add JsonProperty attributes to customize
             // serialization mapping and all available NJson attributes.
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.9.0" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -16,15 +16,19 @@
     <Title>Confluent.SchemaRegistry.Serdes.Json</Title>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.Json</AssemblyName>
     <VersionPrefix>2.5.2</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Confluent.SchemaRegistry.Serdes.Json.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
+    <PackageReference Include="NJsonSchema" Version="10.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -25,7 +25,7 @@ using Confluent.Kafka;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NJsonSchema;
-using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
 using NJsonSchema.Validation;
 
 
@@ -53,7 +53,7 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </remarks>
     public class JsonDeserializer<T> : AsyncDeserializer<T, JsonSchema> where T : class
     {
-        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+        private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
         
         private JsonSchemaValidator validator = new JsonSchemaValidator();
 
@@ -69,18 +69,18 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="jsonSchemaGeneratorSettings">
         ///     JSON schema generator settings.
         /// </param>
-        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) :
+        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) :
             this(null, config, jsonSchemaGeneratorSettings)
         {
         }
 
-        public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) 
+        public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) 
             : this(schemaRegistryClient, config != null ? new JsonDeserializerConfig(config) : null, jsonSchemaGeneratorSettings)
         {
         }
 
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, JsonDeserializerConfig config, 
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
             : base(schemaRegistryClient, config, ruleExecutors)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -121,7 +121,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, IEnumerable<KeyValuePair<string, string>> config = null,
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings)
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings)
         {
             JsonSchemaResolver utils = new JsonSchemaResolver(
                 schemaRegistryClient, schema, this.jsonSchemaGeneratorSettings);
@@ -206,7 +206,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         using (var jsonStream = new MemoryStream(array, headerSize, array.Length - headerSize))
                         using (var jsonReader = new StreamReader(jsonStream, Encoding.UTF8))
                         {
-                            JToken json = Newtonsoft.Json.JsonConvert.DeserializeObject<JToken>(jsonReader.ReadToEnd(), this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+                            JToken json = Newtonsoft.Json.JsonConvert.DeserializeObject<JToken>(jsonReader.ReadToEnd(), this.jsonSchemaGeneratorSettings?.SerializerSettings);
                             json = await ExecuteMigrations(migrations, isKey, subject, topic, context.Headers, json)
                                 .ContinueWith(t => (JToken)t.Result)
                                 .ConfigureAwait(continueOnCapturedContext: false);
@@ -243,7 +243,7 @@ namespace Confluent.SchemaRegistry.Serdes
                                 }
                             }
 
-                            value = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+                            value = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.SerializerSettings);
                         }
                     }
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -25,7 +25,11 @@ using Confluent.Kafka;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NJsonSchema;
+#if NET8_0_OR_GREATER
 using NJsonSchema.NewtonsoftJson.Generation;
+#else
+using NJsonSchema.Generation;
+#endif
 using NJsonSchema.Validation;
 
 
@@ -53,7 +57,11 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </remarks>
     public class JsonDeserializer<T> : AsyncDeserializer<T, JsonSchema> where T : class
     {
+#if NET8_0_OR_GREATER
         private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+#else
+        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+#endif
         
         private JsonSchemaValidator validator = new JsonSchemaValidator();
 
@@ -69,18 +77,30 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="jsonSchemaGeneratorSettings">
         ///     JSON schema generator settings.
         /// </param>
+#if NET8_0_OR_GREATER
         public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) :
+#else
+        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) :
+#endif
             this(null, config, jsonSchemaGeneratorSettings)
         {
         }
 
+#if NET8_0_OR_GREATER
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) 
+#else
+        public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+#endif
             : this(schemaRegistryClient, config != null ? new JsonDeserializerConfig(config) : null, jsonSchemaGeneratorSettings)
         {
         }
 
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, JsonDeserializerConfig config, 
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
+#if NET8_0_OR_GREATER
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
+#else 
+            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
+#endif
             : base(schemaRegistryClient, config, ruleExecutors)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -121,7 +141,12 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, IEnumerable<KeyValuePair<string, string>> config = null,
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings)
+#if NET8_0_OR_GREATER
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+#else
+            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
+#endif
+            : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings)
         {
             JsonSchemaResolver utils = new JsonSchemaResolver(
                 schemaRegistryClient, schema, this.jsonSchemaGeneratorSettings);
@@ -206,7 +231,11 @@ namespace Confluent.SchemaRegistry.Serdes
                         using (var jsonStream = new MemoryStream(array, headerSize, array.Length - headerSize))
                         using (var jsonReader = new StreamReader(jsonStream, Encoding.UTF8))
                         {
+#if NET8_0_OR_GREATER
                             JToken json = Newtonsoft.Json.JsonConvert.DeserializeObject<JToken>(jsonReader.ReadToEnd(), this.jsonSchemaGeneratorSettings?.SerializerSettings);
+#else
+                            JToken json = Newtonsoft.Json.JsonConvert.DeserializeObject<JToken>(jsonReader.ReadToEnd(), this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+#endif
                             json = await ExecuteMigrations(migrations, isKey, subject, topic, context.Headers, json)
                                 .ContinueWith(t => (JToken)t.Result)
                                 .ConfigureAwait(continueOnCapturedContext: false);
@@ -243,7 +272,11 @@ namespace Confluent.SchemaRegistry.Serdes
                                 }
                             }
 
+#if NET8_0_OR_GREATER
                             value = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.SerializerSettings);
+#else
+                            value = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+#endif
                         }
                     }
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
@@ -20,7 +20,9 @@ using System.Threading.Tasks;
 using NJsonSchema;
 using NJsonSchema.Generation;
 using Newtonsoft.Json.Linq;
+#if NET8_0_OR_GREATER
 using NJsonSchema.NewtonsoftJson.Generation;
+#endif
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -113,7 +115,11 @@ namespace Confluent.SchemaRegistry.Serdes
             {
                 NJsonSchema.Generation.JsonSchemaResolver schemaResolver =
                     new NJsonSchema.Generation.JsonSchemaResolver(rootObject, this.jsonSchemaGeneratorSettings ??
+#if NET8_0_OR_GREATER
                         new NewtonsoftJsonSchemaGeneratorSettings());
+#else
+                        new JsonSchemaGeneratorSettings());
+#endif
 
                 JsonReferenceResolver referenceResolver =
                     new JsonReferenceResolver(schemaResolver);

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using NJsonSchema;
 using NJsonSchema.Generation;
 using Newtonsoft.Json.Linq;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -112,7 +113,7 @@ namespace Confluent.SchemaRegistry.Serdes
             {
                 NJsonSchema.Generation.JsonSchemaResolver schemaResolver =
                     new NJsonSchema.Generation.JsonSchemaResolver(rootObject, this.jsonSchemaGeneratorSettings ??
-                        new JsonSchemaGeneratorSettings());
+                        new NewtonsoftJsonSchemaGeneratorSettings());
 
                 JsonReferenceResolver referenceResolver =
                     new JsonReferenceResolver(schemaResolver);

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -26,7 +26,11 @@ using System.Threading.Tasks;
 using NJsonSchema;
 using NJsonSchema.Validation;
 using Confluent.Kafka;
+#if NET8_0_OR_GREATER
 using NJsonSchema.NewtonsoftJson.Generation;
+#else
+using NJsonSchema.Generation;
+#endif
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -54,7 +58,11 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </remarks>
     public class JsonSerializer<T> : AsyncSerializer<T, JsonSchema> where T : class
     {
+#if NET8_0_OR_GREATER
         private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+#else
+        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+#endif
         private readonly List<SchemaReference> ReferenceList = new List<SchemaReference>();
         
         private JsonSchemaValidator validator = new JsonSchemaValidator();
@@ -82,7 +90,11 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, JsonSerializerConfig config = null, 
+#if NET8_0_OR_GREATER
             NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
+#else
+            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
+#endif
             : base(schemaRegistryClient, config, ruleExecutors)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -136,7 +148,11 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, JsonSerializerConfig config = null, 
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
+#if NET8_0_OR_GREATER
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
+#else
+            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
+#endif
             : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings, ruleExecutors)
         {
             foreach (var reference in schema.References)
@@ -233,7 +249,11 @@ namespace Confluent.SchemaRegistry.Serdes
                         .ConfigureAwait(continueOnCapturedContext: false);
                 }
 
+#if NET8_0_OR_GREATER
                 var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.SerializerSettings);
+#else
+                var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+#endif
                 var validationResult = validator.Validate(serializedString, this.schema);
                 if (validationResult.Count > 0)
                 {

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -24,9 +24,9 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using NJsonSchema;
-using NJsonSchema.Generation;
 using NJsonSchema.Validation;
 using Confluent.Kafka;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -54,7 +54,7 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </remarks>
     public class JsonSerializer<T> : AsyncSerializer<T, JsonSchema> where T : class
     {
-        private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
+        private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
         private readonly List<SchemaReference> ReferenceList = new List<SchemaReference>();
         
         private JsonSchemaValidator validator = new JsonSchemaValidator();
@@ -82,7 +82,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, JsonSerializerConfig config = null, 
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
             : base(schemaRegistryClient, config, ruleExecutors)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -136,7 +136,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, JsonSerializerConfig config = null, 
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
+            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
             : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings, ruleExecutors)
         {
             foreach (var reference in schema.References)
@@ -154,7 +154,7 @@ namespace Confluent.SchemaRegistry.Serdes
 
         /// <summary>
         ///     Serialize an instance of type <typeparamref name="T"/> to a UTF8 encoded JSON 
-        ///     represenation. The serialized data is preceeded by:
+        ///     representation. The serialized data is preceded by:
         ///       1. A "magic byte" (1 byte) that identifies this as a message with
         ///          Confluent Platform framing.
         ///       2. The id of the schema as registered in Confluent's Schema Registry
@@ -233,7 +233,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         .ConfigureAwait(continueOnCapturedContext: false);
                 }
 
-                var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
+                var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.SerializerSettings);
                 var validationResult = validator.Validate(serializedString, this.schema);
                 if (validationResult.Count > 0)
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.IntegrationTests</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
@@ -22,7 +22,7 @@ using Confluent.Kafka.SyncOverAsync;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.Generation;
+using NJsonSchema.NewtonsoftJson.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
@@ -139,7 +139,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
             var sr = new CachedSchemaRegistryClient(schemaRegistryConfig);
 
-            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -209,7 +209,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 // Test producing and consuming directly a JObject
                 var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(order,
-                    jsonSchemaGeneratorSettings.ActualSerializerSettings);
+                    jsonSchemaGeneratorSettings.SerializerSettings);
                 var jsonObject = JObject.Parse(serializedString);
                 
                 using (var producer =

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.UnitTests</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.UnitTests</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 


### PR DESCRIPTION
(Original PR: https://github.com/confluentinc/confluent-kafka-dotnet/pull/2185)

Fixes https://github.com/confluentinc/confluent-kafka-dotnet/issues/2169

A few notes:
- This is a breaking change, and should be included in a major version release only, as we're dropping support for NJsonSchema v10. This change **will** impact users that manage their own references to NJsonSchema v10.
- Newtonsoft.Json-based generators have been moved to a separate NuGet package, so the reference to NJsonSchema has been replaced with a reference to NJsonSchema.NewtonsoftJson. See [NSwag 14 announcement](https://github.com/RicoSuter/NSwag/issues/4524) and [NJsonSchema v11 release notes](https://github.com/RicoSuter/NJsonSchema/releases/tag/v11.0.0).
- `EnumHandling` no longer exists, so the `WithJsonSchemaGeneratorSettingsSerDe` unit test has been updated to use `JsonSerializerSettings` instead.