### PR TITLE
Fix Azure algorithm to RsaOaep256

### DIFF
--- a/src/Confluent.SchemaRegistry.Encryption.Azure/AzureKmsClient.cs
+++ b/src/Confluent.SchemaRegistry.Encryption.Azure/AzureKmsClient.cs
@@ -31,14 +31,14 @@ namespace Confluent.SchemaRegistry.Encryption.Azure
         public async Task<byte[]> Encrypt(byte[] plaintext)
         {
             var client = GetCryptographyClient();
-            var result = await client.EncryptAsync(EncryptionAlgorithm.RsaOaep, plaintext).ConfigureAwait(false);
+            var result = await client.EncryptAsync(EncryptionAlgorithm.RsaOaep256, plaintext).ConfigureAwait(false);
             return result.Ciphertext;
         }
 
         public async Task<byte[]> Decrypt(byte[] ciphertext)
         {
             var client = GetCryptographyClient();
-            var result = await client.DecryptAsync(EncryptionAlgorithm.RsaOaep, ciphertext).ConfigureAwait(false);
+            var result = await client.DecryptAsync(EncryptionAlgorithm.RsaOaep256, ciphertext).ConfigureAwait(false);
             return result.Plaintext;
         }
         

--- a/src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj
+++ b/src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.11.3" />
+        <PackageReference Include="Azure.Identity" Version="1.11.4" />
         <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     </ItemGroup>
 

--- a/src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj
+++ b/src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.11.4" />
+        <PackageReference Include="Azure.Identity" Version="1.11.3" />
         <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Fix algorithm used by Azure Key Vault to be RsaOaep256, to be consistent with the Java and golang clients, so that the dotnet client can interoperate with them.