### PR TITLE
Fix ProtobufUtils Parse function (Showstopper defect) (#2297)

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/AssemblyInfo.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Confluent.SchemaRegistry.Serdes.UnitTests, " +
+                              "PublicKey=0024000004800000940000000602000000240000525341310004000001000100a9d95b0a1e" +
+                              "e3264dec3dff29931157b48768733b9ed4b1e8daba83d375872902c872ea4a79f389d51b574e000937c5" +
+                              "7d88952c128d4c156b8c2ac6fcd2a273e7ca3b2c0a29b5c30c81a9527f5fe7ef33d0a68040ae69f88c05" +
+                              "4181f81b1cbc2d429f0a054b1fe7d97bf32c6f781f2d483accf0faa54d1f502fad47744ddc4482")]

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>Confluent.SchemaRegistry.Serdes.UnitTests</AssemblyName>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\src\Confluent.SchemaRegistry.Serdes.Protobuf\Confluent.SchemaRegistry.Serdes.Protobuf.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes issues in the ProtobufUtils Parse function that prevented the ProtobufSerializer from serializing any message that contained well known types. This is a show stopper defect for all versions past 2.4.0 and should be prioritized