### PR TITLE
Temporarily revert NJsonSchema v11 changes

### DIFF
--- a/examples/JsonWithReferences/JsonWithReferences.csproj
+++ b/examples/JsonWithReferences/JsonWithReferences.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>JsonWithReferences</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/examples/JsonWithReferences/Program.cs
+++ b/examples/JsonWithReferences/Program.cs
@@ -22,9 +22,9 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NJsonSchema.Generation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using NJsonSchema.NewtonsoftJson.Generation;
 
 
 /// <summary>
@@ -150,7 +150,7 @@ namespace Confluent.Kafka.Examples.JsonWithReferences
             // from default one to camelCase.
             // It's also possible to add JsonProperty attributes to customize
             // serialization mapping and all available NJson attributes.
-            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -16,18 +16,14 @@
     <Title>Confluent.SchemaRegistry.Serdes.Json</Title>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.Json</AssemblyName>
     <VersionPrefix>2.5.2</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Confluent.SchemaRegistry.Serdes.Json.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
+  <ItemGroup>
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
   </ItemGroup>
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -25,11 +25,7 @@ using Confluent.Kafka;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NJsonSchema;
-#if NET8_0_OR_GREATER
-using NJsonSchema.NewtonsoftJson.Generation;
-#else
 using NJsonSchema.Generation;
-#endif
 using NJsonSchema.Validation;
 
 
@@ -57,11 +53,7 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </remarks>
     public class JsonDeserializer<T> : AsyncDeserializer<T, JsonSchema> where T : class
     {
-#if NET8_0_OR_GREATER
-        private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
-#else
         private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
-#endif
         
         private JsonSchemaValidator validator = new JsonSchemaValidator();
 
@@ -77,30 +69,18 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <param name="jsonSchemaGeneratorSettings">
         ///     JSON schema generator settings.
         /// </param>
-#if NET8_0_OR_GREATER
-        public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) :
-#else
         public JsonDeserializer(IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) :
-#endif
             this(null, config, jsonSchemaGeneratorSettings)
         {
         }
 
-#if NET8_0_OR_GREATER
-        public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) 
-#else
-        public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
-#endif
+        public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, IEnumerable<KeyValuePair<string, string>> config = null, JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) 
             : this(schemaRegistryClient, config != null ? new JsonDeserializerConfig(config) : null, jsonSchemaGeneratorSettings)
         {
         }
 
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, JsonDeserializerConfig config, 
-#if NET8_0_OR_GREATER
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
-#else 
             JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
-#endif
             : base(schemaRegistryClient, config, ruleExecutors)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -141,12 +121,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonDeserializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, IEnumerable<KeyValuePair<string, string>> config = null,
-#if NET8_0_OR_GREATER
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
-#else
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null)
-#endif
-            : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings)
+            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null) : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings)
         {
             JsonSchemaResolver utils = new JsonSchemaResolver(
                 schemaRegistryClient, schema, this.jsonSchemaGeneratorSettings);
@@ -231,11 +206,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         using (var jsonStream = new MemoryStream(array, headerSize, array.Length - headerSize))
                         using (var jsonReader = new StreamReader(jsonStream, Encoding.UTF8))
                         {
-#if NET8_0_OR_GREATER
-                            JToken json = Newtonsoft.Json.JsonConvert.DeserializeObject<JToken>(jsonReader.ReadToEnd(), this.jsonSchemaGeneratorSettings?.SerializerSettings);
-#else
                             JToken json = Newtonsoft.Json.JsonConvert.DeserializeObject<JToken>(jsonReader.ReadToEnd(), this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
-#endif
                             json = await ExecuteMigrations(migrations, isKey, subject, topic, context.Headers, json)
                                 .ContinueWith(t => (JToken)t.Result)
                                 .ConfigureAwait(continueOnCapturedContext: false);
@@ -272,11 +243,7 @@ namespace Confluent.SchemaRegistry.Serdes
                                 }
                             }
 
-#if NET8_0_OR_GREATER
-                            value = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.SerializerSettings);
-#else
                             value = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serializedString, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
-#endif
                         }
                     }
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSchemaResolver.cs
@@ -20,9 +20,6 @@ using System.Threading.Tasks;
 using NJsonSchema;
 using NJsonSchema.Generation;
 using Newtonsoft.Json.Linq;
-#if NET8_0_OR_GREATER
-using NJsonSchema.NewtonsoftJson.Generation;
-#endif
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -115,11 +112,7 @@ namespace Confluent.SchemaRegistry.Serdes
             {
                 NJsonSchema.Generation.JsonSchemaResolver schemaResolver =
                     new NJsonSchema.Generation.JsonSchemaResolver(rootObject, this.jsonSchemaGeneratorSettings ??
-#if NET8_0_OR_GREATER
-                        new NewtonsoftJsonSchemaGeneratorSettings());
-#else
                         new JsonSchemaGeneratorSettings());
-#endif
 
                 JsonReferenceResolver referenceResolver =
                     new JsonReferenceResolver(schemaResolver);

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -24,13 +24,9 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using NJsonSchema;
+using NJsonSchema.Generation;
 using NJsonSchema.Validation;
 using Confluent.Kafka;
-#if NET8_0_OR_GREATER
-using NJsonSchema.NewtonsoftJson.Generation;
-#else
-using NJsonSchema.Generation;
-#endif
 
 
 namespace Confluent.SchemaRegistry.Serdes
@@ -58,11 +54,7 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </remarks>
     public class JsonSerializer<T> : AsyncSerializer<T, JsonSchema> where T : class
     {
-#if NET8_0_OR_GREATER
-        private readonly NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
-#else
         private readonly JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings;
-#endif
         private readonly List<SchemaReference> ReferenceList = new List<SchemaReference>();
         
         private JsonSchemaValidator validator = new JsonSchemaValidator();
@@ -90,11 +82,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, JsonSerializerConfig config = null, 
-#if NET8_0_OR_GREATER
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
-#else
             JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
-#endif
             : base(schemaRegistryClient, config, ruleExecutors)
         {
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
@@ -148,11 +136,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     JSON schema generator settings.
         /// </param>
         public JsonSerializer(ISchemaRegistryClient schemaRegistryClient, Schema schema, JsonSerializerConfig config = null, 
-#if NET8_0_OR_GREATER
-            NewtonsoftJsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
-#else
-            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null)
-#endif
+            JsonSchemaGeneratorSettings jsonSchemaGeneratorSettings = null, IList<IRuleExecutor> ruleExecutors = null) 
             : this(schemaRegistryClient, config, jsonSchemaGeneratorSettings, ruleExecutors)
         {
             foreach (var reference in schema.References)
@@ -170,7 +154,7 @@ namespace Confluent.SchemaRegistry.Serdes
 
         /// <summary>
         ///     Serialize an instance of type <typeparamref name="T"/> to a UTF8 encoded JSON 
-        ///     representation. The serialized data is preceded by:
+        ///     represenation. The serialized data is preceeded by:
         ///       1. A "magic byte" (1 byte) that identifies this as a message with
         ///          Confluent Platform framing.
         ///       2. The id of the schema as registered in Confluent's Schema Registry
@@ -249,11 +233,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         .ConfigureAwait(continueOnCapturedContext: false);
                 }
 
-#if NET8_0_OR_GREATER
-                var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.SerializerSettings);
-#else
                 var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(value, this.jsonSchemaGeneratorSettings?.ActualSerializerSettings);
-#endif
                 var validationResult = validator.Validate(serializedString, this.schema);
                 if (validationResult.Count > 0)
                 {

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -100,13 +100,8 @@ namespace Confluent.SchemaRegistry.Serdes
             this.jsonSchemaGeneratorSettings = jsonSchemaGeneratorSettings;
 
             this.schema = this.jsonSchemaGeneratorSettings == null
-#if NET8_0_OR_GREATER
-                ? NewtonsoftJsonSchemaGenerator.FromType<T>()
-                : NewtonsoftJsonSchemaGenerator.FromType<T>(this.jsonSchemaGeneratorSettings);
-#else
                 ? JsonSchema.FromType<T>()
                 : JsonSchema.FromType<T>(this.jsonSchemaGeneratorSettings);
-#endif
             this.schemaText = schema.ToJson();
             this.schemaFullname = schema.Title;
             
@@ -190,7 +185,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     Context relevant to the serialize operation.
         /// </param>
         /// <returns>
-        ///     A <see cref="System.Threading.Tasks.Task" /> that completes with
+        ///     A <see cref="System.Threading.Tasks.Task" /> that completes with 
         ///     <paramref name="value" /> serialized as a byte array.
         /// </returns>
         public override async Task<byte[]> SerializeAsync(T value, SerializationContext context)

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.IntegrationTests</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
@@ -22,7 +22,7 @@ using Confluent.Kafka.SyncOverAsync;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Linq;
-using NJsonSchema.NewtonsoftJson.Generation;
+using NJsonSchema.Generation;
 
 
 namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
@@ -139,7 +139,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
             var sr = new CachedSchemaRegistryClient(schemaRegistryConfig);
 
-            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
+            var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -209,7 +209,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 // Test producing and consuming directly a JObject
                 var serializedString = Newtonsoft.Json.JsonConvert.SerializeObject(order,
-                    jsonSchemaGeneratorSettings.SerializerSettings);
+                    jsonSchemaGeneratorSettings.ActualSerializerSettings);
                 var jsonObject = JObject.Parse(serializedString);
                 
                 using (var producer =

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -4,7 +4,7 @@
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
     <AssemblyName>Confluent.SchemaRegistry.Serdes.UnitTests</AssemblyName>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
@@ -21,18 +21,13 @@ using Confluent.Kafka;
 using Confluent.SchemaRegistry.Encryption;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using NJsonSchema.Generation;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-#if NET8_0_OR_GREATER
-using Newtonsoft.Json.Converters;
-using NJsonSchema.NewtonsoftJson.Generation;
-#else
-using NJsonSchema.Generation;
-#endif
 
 
 namespace Confluent.SchemaRegistry.Serdes.UnitTests
@@ -181,11 +176,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         {
             const int value = 1234;
             var expectedJson = $"{{\"Value\":{value * 2}}}";
-#if NET8_0_OR_GREATER
-            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
-#else
             var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
-#endif
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -236,11 +227,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 SubjectNameStrategy = SubjectNameStrategy.TopicRecord
             };
             
-#if NET8_0_OR_GREATER
-            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
-#else
             var jsonSchemaGeneratorSettings = new JsonSchemaGeneratorSettings
-#endif
             {
                 SerializerSettings = new JsonSerializerSettings
                 {
@@ -269,44 +256,6 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             Assert.Equal(v.Field3, actual.Field3);
         }
 
-#if NET8_0_OR_GREATER
-        [Theory]
-        [InlineData("CamelCaseString", EnumType.EnumValue, "{\"Value\":\"enumValue\"}")]
-        [InlineData("String", EnumType.None, "{\"Value\":\"None\"}")]
-        [InlineData("Integer", EnumType.OtherValue, "{\"Value\":5678}")]
-        public async Task WithJsonSchemaGeneratorSettingsSerDe(string enumHandling, EnumType value,
-            string expectedJson)
-        {
-            var serializerSettings = enumHandling switch
-            {
-                "CamelCaseString" => new JsonSerializerSettings { Converters = { new StringEnumConverter(new CamelCaseNamingStrategy()) } },
-                "String" => new JsonSerializerSettings { Converters = { new StringEnumConverter() } },
-                "Integer" => new JsonSerializerSettings(),
-                _ => throw new ArgumentException("Invalid enumHandling value", nameof(enumHandling)),
-            };
-            
-            var jsonSchemaGeneratorSettings = new NewtonsoftJsonSchemaGeneratorSettings
-            {
-                SerializerSettings = serializerSettings,
-            };
-
-            var jsonSerializer = new JsonSerializer<EnumObject>(schemaRegistryClient,
-                jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings);
-            var jsonDeserializer =
-                new JsonDeserializer<EnumObject>(jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings);
-
-            var v = new EnumObject { Value = value };
-            var bytes = await jsonSerializer.SerializeAsync(v,
-                new SerializationContext(MessageComponentType.Value, testTopic));
-            Assert.NotNull(bytes);
-            Assert.Equal(expectedJson, Encoding.UTF8.GetString(bytes.AsSpan().Slice(5)));
-
-            var actual = await jsonDeserializer.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic));
-            Assert.NotNull(actual);
-            Assert.Equal(actual.Value, value);
-        }
-#else
         [Theory]
         [InlineData(EnumHandling.CamelCaseString, EnumType.EnumValue, "{\"Value\":\"enumValue\"}")]
         [InlineData(EnumHandling.String, EnumType.None, "{\"Value\":\"None\"}")]
@@ -335,7 +284,6 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             Assert.NotNull(actual);
             Assert.Equal(actual.Value, value);
         }
-#endif
 
         [Fact]
         public async Task ValidationFailureReturnsPath()


### PR DESCRIPTION
We'll add these back once we get our build system Semaphore working with dotnet 8.0