### PR TITLE
Add Kafka Core to Third-Party Libraries

### DIFF
--- a/3RD_PARTY.md
+++ b/3RD_PARTY.md
@@ -5,6 +5,7 @@ A (very incomplete) list of libraries that make use of or expand on the capabili
 
 To add your project, open a pull request!
 
+- [Kafka Core](https://github.com/ffernandolima/confluent-kafka-core-dotnet) - Kafka Core empowers developers to build robust .NET applications on top of Confluent Kafka, focusing on simplicity, maintainability, and extensibility with intuitive abstractions and builders.
 - [Streamiz Kafka .NET](https://github.com/LGouellec/kafka-streams-dotnet) - .NET Stream Processing Library for Apache Kafka.
 - [Chr.Avro](https://github.com/ch-robinson/dotnet-avro) - A modern and flexible Avro implementation for .NET. Integrates seamlessly with Confluent.Kafka and Schema Registry.
 - [Multi Schema Avro Deserializer](https://github.com/ycherkes/multi-schema-avro-desrializer) - Avro deserializer for reading messages serialized with multiple schemas.


### PR DESCRIPTION
This PR introduces the Kafka Core library to the list of third-party libraries.

Kafka Core empowers developers to effortlessly build robust .NET applications on top of Confluent Kafka, focusing on simplicity, maintainability, and extensibility. With intuitive abstractions and builders, it introduces powerful features that enhance functionality and extend the official library's capabilities.