### PR TITLE
Minor change to pass array as type to rule

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
@@ -241,7 +241,6 @@ namespace Confluent.SchemaRegistry.Serdes
             if (field.IsRepeated)
             {
                 return RuleContext.Type.Array;
-
             }
 
             switch (field.FieldType)

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
@@ -238,6 +238,12 @@ namespace Confluent.SchemaRegistry.Serdes
                 return RuleContext.Type.Map;
             }
 
+            if (field.IsRepeated)
+            {
+                return RuleContext.Type.Array;
+
+            }
+
             switch (field.FieldType)
             {
                 case FieldType.Message:


### PR DESCRIPTION
Minor change to pass array as type to rule. This allows a rule to see that the type of the field is "ARRAY"