### PR TITLE
Feature: Added Qualified and Custom reference name strategy approaches for protobuf references (Schema Registry)

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
@@ -52,7 +52,7 @@ namespace Confluent.SchemaRegistry.Serdes
     ///                            a single 0 byte as an optimization.
     ///                         2. The protobuf serialized data.
     /// </remarks>
-    public class ProtobufSerializer<T> : AsyncSerializer<T, FileDescriptorSet>  where T : IMessage<T>, new()
+    public class ProtobufSerializer<T> : AsyncSerializer<T, FileDescriptorSet> where T : IMessage<T>, new()
     {
         private bool skipKnownTypes;
         private bool useDeprecatedFormat;
@@ -70,11 +70,11 @@ namespace Confluent.SchemaRegistry.Serdes
         /// <summary>
         ///     Initialize a new instance of the ProtobufSerializer class.
         /// </summary>
-        public ProtobufSerializer(ISchemaRegistryClient schemaRegistryClient, ProtobufSerializerConfig config = null, 
+        public ProtobufSerializer(ISchemaRegistryClient schemaRegistryClient, ProtobufSerializerConfig config = null,
             RuleRegistry ruleRegistry = null) : base(schemaRegistryClient, config, ruleRegistry)
         {
             if (config == null)
-            { 
+            {
                 this.referenceSubjectNameStrategy = ReferenceSubjectNameStrategy.ReferenceName.ToDelegate();
                 return;
             }
@@ -96,7 +96,7 @@ namespace Confluent.SchemaRegistry.Serdes
             if (config.SubjectNameStrategy != null) { this.subjectNameStrategy = config.SubjectNameStrategy.Value.ToDelegate(); }
             this.referenceSubjectNameStrategy = config.ReferenceSubjectNameStrategy == null
                 ? ReferenceSubjectNameStrategy.ReferenceName.ToDelegate()
-                : config.ReferenceSubjectNameStrategy.Value.ToDelegate();
+                : config.ReferenceSubjectNameStrategy.Value.ToDelegate(config.CustomReferenceSubjectNameStrategy);
 
             if (this.useLatestVersion && this.autoRegisterSchema)
             {
@@ -115,7 +115,7 @@ namespace Confluent.SchemaRegistry.Serdes
                 var prevMd = currentMd;
                 currentMd = currentMd.ContainingType;
                 bool foundNested = false;
-                for (int i=0; i<currentMd.NestedTypes.Count; ++i)
+                for (int i = 0; i < currentMd.NestedTypes.Count; ++i)
                 {
                     if (currentMd.NestedTypes[i].ClrType == prevMd.ClrType)
                     {
@@ -132,7 +132,7 @@ namespace Confluent.SchemaRegistry.Serdes
 
             // Add the index of the root MessageDescriptor in the FileDescriptor.
             bool foundDescriptor = false;
-            for (int i=0; i<md.File.MessageTypes.Count; ++i)
+            for (int i = 0; i < md.File.MessageTypes.Count; ++i)
             {
                 if (md.File.MessageTypes[i].ClrType == currentMd.ClrType)
                 {
@@ -163,15 +163,15 @@ namespace Confluent.SchemaRegistry.Serdes
                     {
                         result.WriteVarint((uint)indices.Count);
                     }
-                    for (int i=0; i<indices.Count; ++i)
+                    for (int i = 0; i < indices.Count; ++i)
                     {
                         if (useDeprecatedFormat)
                         {
-                            result.WriteUnsignedVarint((uint)indices[indices.Count-i-1]);
+                            result.WriteUnsignedVarint((uint)indices[indices.Count - i - 1]);
                         }
                         else
                         {
-                            result.WriteVarint((uint)indices[indices.Count-i-1]);
+                            result.WriteVarint((uint)indices[indices.Count - i - 1]);
                         }
                     }
                 }
@@ -187,14 +187,14 @@ namespace Confluent.SchemaRegistry.Serdes
         private async Task<List<SchemaReference>> RegisterOrGetReferences(FileDescriptor fd, SerializationContext context, bool autoRegisterSchema, bool skipKnownTypes)
         {
             var tasks = new List<Task<SchemaReference>>();
-            for (int i=0; i<fd.Dependencies.Count; ++i)
+            for (int i = 0; i < fd.Dependencies.Count; ++i)
             {
                 FileDescriptor fileDescriptor = fd.Dependencies[i];
                 if (skipKnownTypes && fileDescriptor.Name.StartsWith("google/protobuf/"))
                 {
                     continue;
                 }
-                
+
                 Func<FileDescriptor, Task<SchemaReference>> t = async (dependency) => {
                     var dependencyReferences = await RegisterOrGetReferences(dependency, context, autoRegisterSchema, skipKnownTypes).ConfigureAwait(continueOnCapturedContext: false);
                     var subject = referenceSubjectNameStrategy(context, dependency.Name);
@@ -260,7 +260,7 @@ namespace Confluent.SchemaRegistry.Serdes
                     subject = GetSubjectName(context.Topic, context.Component == MessageComponentType.Key, fullname);
                     latestSchema = await GetReaderSchema(subject)
                         .ConfigureAwait(continueOnCapturedContext: false);
-                    
+
                     if (!subjectsRegistered.Contains(subject))
                     {
                         if (latestSchema != null)

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
@@ -274,5 +274,10 @@ namespace Confluent.SchemaRegistry.Serdes
             }
         }
 
+        /// <summary>
+        /// Custom reference subject name strategy resolver.
+        /// Ensure <seealso cref="ReferenceSubjectNameStrategy.Custom"/> is set for this to take effect.
+        /// </summary>
+        public ICustomReferenceSubjectNameStrategy CustomReferenceSubjectNameStrategy { get; set; } = null;
     }
 }


### PR DESCRIPTION
# Description
This feature allows producers to specify configuration for ReferenceSubjectNameStrategy the following enumeration values:
- `ReferenceName` -> (default): Use the reference name as the subject name.
- `Qualified` -> Given a reference name, replace slashes with dots, and remove the .proto suffix to obtain the subject name. For example, mypackage/myfile.proto becomes mypackage.myfile. (This provides feature parity with java client)
- `Custom` -> Use a custom reference subject name strategy resolver to determine the subject name. This is done by implementing ICustomReferenceSubjectNameStrategy and assigning instance to ProtobufSerializerConfig property CustomReferenceSubjectNameStrategy

## Background
An internal team is using java has implemented their Schema Registry with `QualifiedReferenceSubjectNameStrategy`. As a dotnet team we need to interoperate with that work. Unfortunately, we cannot without this proposed change (We require feature parity with java). Further, we are not allowed to auto register schemas.

## Other Information
- Addresses Issue: [ReferenceSubjectNameStrategy is missing option for QualifiedReferenceSubjectNameStrategy](https://github.com/confluentinc/confluent-kafka-dotnet/issues/2218)
- [Work inspired by](https://github.com/confluentinc/confluent-kafka-dotnet/pull/1656) 