### PR TITLE
add argument null check for oauth params

### DIFF
--- a/src/Confluent.Kafka/ClientExtensions.cs
+++ b/src/Confluent.Kafka/ClientExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Confluent.Kafka
 {
@@ -41,6 +42,9 @@ namespace Confluent.Kafka
         /// <seealso cref="OAuthBearerSetTokenFailure"/>
         public static void OAuthBearerSetToken(this IClient client, string tokenValue, long lifetimeMs, string principalName, IDictionary<string, string> extensions = null)
         {
+            ArgumentNullException.ThrowIfNull(tokenValue, nameof(tokenValue));
+            ArgumentNullException.ThrowIfNull(principalName, nameof(principalName));
+
             client.Handle.LibrdkafkaHandle.OAuthBearerSetToken(tokenValue, lifetimeMs, principalName, extensions);
         }
 


### PR DESCRIPTION
Add Argument Null checks for OAuthBearerSetToken. Especially if principalName is null, the librdkafka throws an segmentation fault. Did cost me about 8 hours to find :)