### PR TITLE
Add retry logic to RestService

### DIFF
--- a/src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs
+++ b/src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs
@@ -30,9 +30,11 @@ namespace Confluent.SchemaRegistry.Encryption
         /// </summary>
         public DekRestService(string schemaRegistryUrl, int timeoutMs,
             IAuthenticationHeaderValueProvider authenticationHeaderValueProvider, List<X509Certificate2> certificates,
-            bool enableSslCertificateVerification, X509Certificate2 sslCaCertificate = null, IWebProxy proxy = null) :
+            bool enableSslCertificateVerification, X509Certificate2 sslCaCertificate = null, IWebProxy proxy = null,
+            int maxRetries = DefaultMaxRetries, int retriesWaitMs = DefaultRetriesWaitMs,
+            int retriesMaxWaitMs = DefaultRetriesMaxWaitMs) :
             base(schemaRegistryUrl, timeoutMs, authenticationHeaderValueProvider, certificates,
-                enableSslCertificateVerification, sslCaCertificate, proxy)
+                enableSslCertificateVerification, sslCaCertificate, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs)
         {
         }
 

--- a/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
@@ -430,7 +430,7 @@ namespace Confluent.SchemaRegistry
             var sslCaLocation = config.FirstOrDefault(prop => prop.Key.ToLower() == SchemaRegistryConfig.PropertyNames.SslCaLocation).Value;
             var sslCaCertificate = string.IsNullOrEmpty(sslCaLocation) ? null : new X509Certificate2(sslCaLocation);
             this.restService = new RestService(schemaRegistryUris, timeoutMs, authenticationHeaderValueProvider,
-                SetSslConfig(config), sslVerify, sslCaCertificate, proxy, maxRetries, retriesWaitMs);
+                SetSslConfig(config), sslVerify, sslCaCertificate, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs);
         }
 
         /// <summary>

--- a/src/Confluent.SchemaRegistry/Rest/RestService.cs
+++ b/src/Confluent.SchemaRegistry/Rest/RestService.cs
@@ -72,11 +72,12 @@ namespace Confluent.SchemaRegistry
             IAuthenticationHeaderValueProvider authenticationHeaderValueProvider, List<X509Certificate2> certificates,
             bool enableSslCertificateVerification, X509Certificate2 sslCaCertificate = null, IWebProxy proxy = null,
             int maxRetries = DefaultMaxRetries, int retriesWaitMs = DefaultRetriesWaitMs,
-            int retriesMaxWaithMs = DefaultRetriesMaxWaitMs)
+            int retriesMaxWaitMs = DefaultRetriesMaxWaitMs)
         {
             this.authenticationHeaderValueProvider = authenticationHeaderValueProvider;
             this.maxRetries = maxRetries;
             this.retriesWaitMs = retriesWaitMs;
+            this.retriesMaxWaitMs = retriesMaxWaitMs;
 
             this.clients = schemaRegistryUrl
                 .Split(',')

--- a/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
+++ b/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
@@ -45,6 +45,28 @@ namespace Confluent.SchemaRegistry
             public const string SchemaRegistryRequestTimeoutMs = "schema.registry.request.timeout.ms";
 
             /// <summary>
+            ///     Specifies the maximum number of retries for a request.
+            ///
+            ///     default: 3
+            /// </summary>
+            public const string SchemaRegistryMaxRetries = "schema.registry.max.retries";
+
+            /// <summary>
+            ///     Specifies the maximum time to wait for the first retry.
+            ///     When jitter is applied, the actual wait may be less.
+            ///
+            ///     default: 1000
+            /// </summary>
+            public const string SchemaRegistryRetriesWaitMs = "schema.registry.retries.wait.ms";
+
+            /// <summary>
+            ///     Specifies the maximum time to wait any retry.
+            ///
+            ///     default: 20000
+            /// </summary>
+            public const string SchemaRegistryRetriesMaxWaitMs = "schema.registry.retries.max.wait.ms";
+
+            /// <summary>
             ///     Specifies the maximum number of schemas CachedSchemaRegistryClient
             ///     should cache locally.
             ///
@@ -185,6 +207,39 @@ namespace Confluent.SchemaRegistry
         {
             get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryRequestTimeoutMs); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryRequestTimeoutMs, value?.ToString()); }
+        }
+
+        /// <summary>
+        ///     Specifies the maximum number of retries for a request.
+        ///
+        ///     default: 3
+        /// </summary>
+        public int? MaxRetries
+        {
+            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxRetries); }
+            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxRetries, value?.ToString()); }
+        }
+
+        /// <summary>
+        ///     Specifies the time to wait for the first retry.
+        ///
+        ///     default: 1000
+        /// </summary>
+        public int? RetriesWaitMs
+        {
+            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryRetriesWaitMs); }
+            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryRetriesWaitMs, value?.ToString()); }
+        }
+
+        /// <summary>
+        ///     Specifies the time to wait for any retry.
+        ///
+        ///     default: 20000
+        /// </summary>
+        public int? RetriesMaxWaitMs
+        {
+            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryRetriesMaxWaitMs); }
+            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryRetriesMaxWaitMs, value?.ToString()); }
         }
 
         ///    <summary>


### PR DESCRIPTION
Add retry logic to RestService. We implement exponential backoff with full jitter per https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/