### PR TITLE
Mark some deprecated properties as obsolete in Schema

### DIFF
--- a/src/Confluent.SchemaRegistry/Rest/DataContracts/RegisteredSchema.cs
+++ b/src/Confluent.SchemaRegistry/Rest/DataContracts/RegisteredSchema.cs
@@ -41,19 +41,19 @@ namespace Confluent.SchemaRegistry
         ///     The subject the schema is registered against.
         /// </summary>
         [DataMember(Name = "subject")]
-        public override string Subject { get; set; }
+        public new string Subject { get; set; }
 
         /// <summary>
         ///     The schema version.
         /// </summary>
         [DataMember(Name = "version")]
-        public override int Version { get; set; }
+        public new int Version { get; set; }
 
         /// <summary>
         ///     Unique identifier of the schema.
         /// </summary>
         [DataMember(Name = "id")]
-        public override int Id { get; set; }
+        public new int Id { get; set; }
 
         /// <summary>
         ///     The unregistered schema corresponding to this schema.

--- a/src/Confluent.SchemaRegistry/Rest/DataContracts/Schema.cs
+++ b/src/Confluent.SchemaRegistry/Rest/DataContracts/Schema.cs
@@ -30,19 +30,22 @@ namespace  Confluent.SchemaRegistry
         #region API backwards-compatibility hack
 
         /// <summary>
-        ///     The subject the schema is registered against.
+        ///     DEPRECATED. The subject the schema is registered against.
         /// </summary>
-        public virtual string Subject { get; set; }
+        [Obsolete("Included to maintain API backwards compatibility only. Use RegisteredSchema instead. This property will be removed in a future version of the library.")]
+        public string Subject { get; set; }
 
         /// <summary>
-        ///     The schema version.
+        ///     DEPRECATED. The schema version.
         /// </summary>
-        public virtual int Version { get; set; }
+        [Obsolete("Included to maintain API backwards compatibility only. Use RegisteredSchema instead. This property will be removed in a future version of the library.")]
+        public int Version { get; set; }
 
         /// <summary>
-        ///     Unique identifier of the schema.
+        ///     DEPRECATED. Unique identifier of the schema.
         /// </summary>
-        public virtual int Id { get; set; }
+        [Obsolete("Included to maintain API backwards compatibility only. Use RegisteredSchema instead. This property will be removed in a future version of the library.")]
+        public int Id { get; set; }
 
         /// <summary>
         ///     DEPRECATED. Initializes a new instance of the Schema class.


### PR DESCRIPTION
These properties will be removed in a future major release. These were actually marked as obsolete in the past, but were temporarily removed.  This just re-adds the obsolete annotations.