### PR TITLE
Added new IProducer.ProduceAsync overload for produce with minimal allocations

### DIFF
--- a/src/Confluent.Kafka/IProducer.cs
+++ b/src/Confluent.Kafka/IProducer.cs
@@ -22,32 +22,32 @@ using System.Threading.Tasks;
 
 namespace Confluent.Kafka
 {
-	/// <summary>
-	/// Defines a high-level Apache Kafka producer client without serialization capable of producing pre-serialized messages. 
-	/// </summary>
-	public interface IProducer : IClient
-	{
-		/// <summary>
-		/// Asynchronously send a single <b>preserialized</b> message to a Kafka topic. 
-		/// </summary>
+    /// <summary>
+    /// Defines a high-level Apache Kafka producer client without serialization capable of producing pre-serialized messages. 
+    /// </summary>
+    public interface IProducer : IClient
+    {
+        /// <summary>
+        /// Asynchronously send a single <b>preserialized</b> message to a Kafka topic. 
+        /// </summary>
         /// <remarks>
         /// Use this method to produce with minimal allocations.
         /// </remarks>
-		/// <param name="topic">The topic to produce message to.</param>
-		/// <param name="partition">The partition to produce to or <c>Partition.Any</c> to use configured partitioner.</param>
-		/// <param name="key">Serialized message key or <c>null</c>.</param>
-		/// <param name="value">Serialized message value or <c>null</c>.</param>
-		/// <param name="headers">Message headers or <c>null</c> to produce message without headers.</param>
-		/// <param name="timestamp"></param>
-		/// <returns>Result of produce.</returns>
-		Task<ProduceResult> ProduceAsync(string topic, Partition partition, ArraySegment<byte>? key, ArraySegment<byte>? value, IReadOnlyList<IHeader> headers, Timestamp timestamp);
-	}
+        /// <param name="topic">The topic to produce message to.</param>
+        /// <param name="partition">The partition to produce to or <c>Partition.Any</c> to use configured partitioner.</param>
+        /// <param name="key">Serialized message key or <c>null</c>.</param>
+        /// <param name="value">Serialized message value or <c>null</c>.</param>
+        /// <param name="headers">Message headers or <c>null</c> to produce message without headers.</param>
+        /// <param name="timestamp"></param>
+        /// <returns>Result of produce.</returns>
+        Task<ProduceResult> ProduceAsync(string topic, Partition partition, ArraySegment<byte>? key, ArraySegment<byte>? value, IReadOnlyList<IHeader> headers, Timestamp timestamp);
+    }
 
-	/// <summary>
-	///     Defines a high-level Apache Kafka producer client
-	///     that provides key and value serialization.
-	/// </summary>
-	public interface IProducer<TKey, TValue> : IProducer
+    /// <summary>
+    ///     Defines a high-level Apache Kafka producer client
+    ///     that provides key and value serialization.
+    /// </summary>
+    public interface IProducer<TKey, TValue> : IProducer
     {
         /// <summary>
         ///     Asynchronously send a single message to a
@@ -122,42 +122,42 @@ namespace Confluent.Kafka
             Message<TKey, TValue> message,
             CancellationToken cancellationToken = default(CancellationToken));
 
-		/// <summary>
-		///     Asynchronously send a single message to a
-		///     Kafka topic. The partition the message is sent
-		///     to is determined by the partitioner defined
-		///     using the 'partitioner' configuration property.
-		/// </summary>
-		/// <param name="topic">
-		///     The topic to produce the message to.
-		/// </param>
-		/// <param name="message">
-		///     The message to produce.
-		/// </param>
-		/// <param name="deliveryHandler">
-		///     A delegate that will be called
-		///     with a delivery report corresponding to the
-		///     produce request (if enabled).
-		/// </param>
-		/// <exception cref="Confluent.Kafka.ProduceException{TKey,TValue}">
-		///     Thrown in response to any error that is known
-		///     immediately (excluding user application logic
-		///     errors), for example ErrorCode.Local_QueueFull.
-		///     Asynchronous notification of unsuccessful produce
-		///     requests is made available via the <paramref name="deliveryHandler" />
-		///     parameter (if specified). The Error property of
-		///     the exception / delivery report provides more
-		///     detailed information.
-		/// </exception>
-		/// <exception cref="System.ArgumentException">
-		///     Thrown in response to invalid argument values.
-		/// </exception>
-		/// <exception cref="System.InvalidOperationException">
-		///     Thrown in response to error conditions that
-		///     reflect an error in the application logic of
-		///     the calling application.
-		/// </exception>
-		void Produce(
+        /// <summary>
+        ///     Asynchronously send a single message to a
+        ///     Kafka topic. The partition the message is sent
+        ///     to is determined by the partitioner defined
+        ///     using the 'partitioner' configuration property.
+        /// </summary>
+        /// <param name="topic">
+        ///     The topic to produce the message to.
+        /// </param>
+        /// <param name="message">
+        ///     The message to produce.
+        /// </param>
+        /// <param name="deliveryHandler">
+        ///     A delegate that will be called
+        ///     with a delivery report corresponding to the
+        ///     produce request (if enabled).
+        /// </param>
+        /// <exception cref="Confluent.Kafka.ProduceException{TKey,TValue}">
+        ///     Thrown in response to any error that is known
+        ///     immediately (excluding user application logic
+        ///     errors), for example ErrorCode.Local_QueueFull.
+        ///     Asynchronous notification of unsuccessful produce
+        ///     requests is made available via the <paramref name="deliveryHandler" />
+        ///     parameter (if specified). The Error property of
+        ///     the exception / delivery report provides more
+        ///     detailed information.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        ///     Thrown in response to invalid argument values.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        ///     Thrown in response to error conditions that
+        ///     reflect an error in the application logic of
+        ///     the calling application.
+        /// </exception>
+        void Produce(
             string topic,
             Message<TKey, TValue> message,
             Action<DeliveryReport<TKey, TValue>> deliveryHandler = null);
@@ -561,5 +561,5 @@ namespace Confluent.Kafka
         ///     Thrown on all other errors.
         /// </exception>
         void SendOffsetsToTransaction(IEnumerable<TopicPartitionOffset> offsets, IConsumerGroupMetadata groupMetadata, TimeSpan timeout);
-	}
+    }
 }

--- a/src/Confluent.Kafka/IProducer.cs
+++ b/src/Confluent.Kafka/IProducer.cs
@@ -22,11 +22,32 @@ using System.Threading.Tasks;
 
 namespace Confluent.Kafka
 {
-    /// <summary>
-    ///     Defines a high-level Apache Kafka producer client
-    ///     that provides key and value serialization.
-    /// </summary>
-    public interface IProducer<TKey, TValue> : IClient
+	/// <summary>
+	/// Defines a high-level Apache Kafka producer client without serialization capable of producing pre-serialized messages. 
+	/// </summary>
+	public interface IProducer : IClient
+	{
+		/// <summary>
+		/// Asynchronously send a single <b>preserialized</b> message to a Kafka topic. 
+		/// </summary>
+        /// <remarks>
+        /// Use this method to produce with minimal allocations.
+        /// </remarks>
+		/// <param name="topic">The topic to produce message to.</param>
+		/// <param name="partition">The partition to produce to or <c>Partition.Any</c> to use configured partitioner.</param>
+		/// <param name="key">Serialized message key or <c>null</c>.</param>
+		/// <param name="value">Serialized message value or <c>null</c>.</param>
+		/// <param name="headers">Message headers or <c>null</c> to produce message without headers.</param>
+		/// <param name="timestamp"></param>
+		/// <returns>Result of produce.</returns>
+		Task<ProduceResult> ProduceAsync(string topic, Partition partition, ArraySegment<byte>? key, ArraySegment<byte>? value, IReadOnlyList<IHeader> headers, Timestamp timestamp);
+	}
+
+	/// <summary>
+	///     Defines a high-level Apache Kafka producer client
+	///     that provides key and value serialization.
+	/// </summary>
+	public interface IProducer<TKey, TValue> : IProducer
     {
         /// <summary>
         ///     Asynchronously send a single message to a
@@ -101,43 +122,42 @@ namespace Confluent.Kafka
             Message<TKey, TValue> message,
             CancellationToken cancellationToken = default(CancellationToken));
 
-
-        /// <summary>
-        ///     Asynchronously send a single message to a
-        ///     Kafka topic. The partition the message is sent
-        ///     to is determined by the partitioner defined
-        ///     using the 'partitioner' configuration property.
-        /// </summary>
-        /// <param name="topic">
-        ///     The topic to produce the message to.
-        /// </param>
-        /// <param name="message">
-        ///     The message to produce.
-        /// </param>
-        /// <param name="deliveryHandler">
-        ///     A delegate that will be called
-        ///     with a delivery report corresponding to the
-        ///     produce request (if enabled).
-        /// </param>
-        /// <exception cref="Confluent.Kafka.ProduceException{TKey,TValue}">
-        ///     Thrown in response to any error that is known
-        ///     immediately (excluding user application logic
-        ///     errors), for example ErrorCode.Local_QueueFull.
-        ///     Asynchronous notification of unsuccessful produce
-        ///     requests is made available via the <paramref name="deliveryHandler" />
-        ///     parameter (if specified). The Error property of
-        ///     the exception / delivery report provides more
-        ///     detailed information.
-        /// </exception>
-        /// <exception cref="System.ArgumentException">
-        ///     Thrown in response to invalid argument values.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        ///     Thrown in response to error conditions that
-        ///     reflect an error in the application logic of
-        ///     the calling application.
-        /// </exception>
-        void Produce(
+		/// <summary>
+		///     Asynchronously send a single message to a
+		///     Kafka topic. The partition the message is sent
+		///     to is determined by the partitioner defined
+		///     using the 'partitioner' configuration property.
+		/// </summary>
+		/// <param name="topic">
+		///     The topic to produce the message to.
+		/// </param>
+		/// <param name="message">
+		///     The message to produce.
+		/// </param>
+		/// <param name="deliveryHandler">
+		///     A delegate that will be called
+		///     with a delivery report corresponding to the
+		///     produce request (if enabled).
+		/// </param>
+		/// <exception cref="Confluent.Kafka.ProduceException{TKey,TValue}">
+		///     Thrown in response to any error that is known
+		///     immediately (excluding user application logic
+		///     errors), for example ErrorCode.Local_QueueFull.
+		///     Asynchronous notification of unsuccessful produce
+		///     requests is made available via the <paramref name="deliveryHandler" />
+		///     parameter (if specified). The Error property of
+		///     the exception / delivery report provides more
+		///     detailed information.
+		/// </exception>
+		/// <exception cref="System.ArgumentException">
+		///     Thrown in response to invalid argument values.
+		/// </exception>
+		/// <exception cref="System.InvalidOperationException">
+		///     Thrown in response to error conditions that
+		///     reflect an error in the application logic of
+		///     the calling application.
+		/// </exception>
+		void Produce(
             string topic,
             Message<TKey, TValue> message,
             Action<DeliveryReport<TKey, TValue>> deliveryHandler = null);
@@ -541,5 +561,5 @@ namespace Confluent.Kafka
         ///     Thrown on all other errors.
         /// </exception>
         void SendOffsetsToTransaction(IEnumerable<TopicPartitionOffset> offsets, IConsumerGroupMetadata groupMetadata, TimeSpan timeout);
-    }
+	}
 }

--- a/src/Confluent.Kafka/ProduceResult.cs
+++ b/src/Confluent.Kafka/ProduceResult.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2016-2018 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+namespace Confluent.Kafka
+{
+    /// <summary>
+    /// Models the result of a call to ProduceAsync.
+    /// </summary>
+	public readonly record struct ProduceResult
+    {
+        /// <summary>
+        /// The partition message was produced to.
+        /// </summary>
+        public Partition Partition { get; }
+
+		/// <summary>
+		/// The offset message was persisted at.
+		/// </summary>
+		public Offset Offset { get; }
+
+		/// <summary>
+		/// The persistence status of the message.
+		/// </summary>
+		public PersistenceStatus PersistenceStatus { get; }
+
+        /// <summary>
+        /// Creates new result.
+        /// </summary>
+        /// <param name="partition"></param>
+        /// <param name="offset"></param>
+        /// <param name="persistenceStatus"></param>
+        public ProduceResult(Partition partition, Offset offset, PersistenceStatus persistenceStatus)
+        {
+            Partition = partition;
+            Offset = offset;
+            PersistenceStatus = persistenceStatus;
+		}
+    }
+}

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -26,10 +26,10 @@ using Confluent.Kafka.Internal;
 
 namespace Confluent.Kafka
 {
-    /// <summary>
-    ///     A high level producer with serialization capability.
-    /// </summary>
-    internal class Producer<TKey, TValue> : IProducer<TKey, TValue>, IClient
+	/// <summary>
+	///     A high level producer with serialization capability.
+	/// </summary>
+	internal class Producer<TKey, TValue> : IProducer<TKey, TValue>
     {
         internal class Config
         {
@@ -57,8 +57,8 @@ namespace Confluent.Kafka
             { typeof(double), Serializers.Double },
             { typeof(byte[]), Serializers.ByteArray }
         };
-
-        private int cancellationDelayMaxMs;
+		
+		private int cancellationDelayMaxMs;
         private bool disposeHasBeenCalled = false;
         private object disposeHasBeenCalledLockObj = new object();
 
@@ -327,7 +327,7 @@ namespace Confluent.Kafka
                     topic,
                     val, valOffset, valLength,
                     key, keyOffset, keyLength,
-                    partition.Value,
+					partition.Value,
                     timestamp.UnixTimestampMs,
                     headers,
                     IntPtr.Zero);
@@ -741,9 +741,43 @@ namespace Confluent.Kafka
                 builder.AsyncKeySerializer, builder.AsyncValueSerializer);
         }
 
+		/// <inheritdoc/>
+		public async Task<ProduceResult> ProduceAsync(
+            string topic, 
+            Partition partition, 
+            ArraySegment<byte>? key, 
+            ArraySegment<byte>? value, 
+            IReadOnlyList<IHeader> headers, 
+            Timestamp timestamp)
+        {
+			// Start produce request
+			DeliveryHandlerSlim deliveryHandler = new();
+            ProduceImpl(topic, 
+                value?.Array, value?.Offset ?? 0, value?.Count ?? 0, 
+                key?.Array, key?.Offset ?? 0, key?.Count ?? 0, 
+                timestamp, 
+                partition, 
+                headers ?? Array.Empty<IHeader>(), 
+                deliveryHandler);
 
-        /// <inheritdoc/>
-        public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
+            // Wait for response
+            DeliveryReport<Null, Null> deliveryReport = await deliveryHandler.Task.ConfigureAwait(false);
+
+            // Return response
+            return new(deliveryReport.Partition, deliveryReport.Offset, deliveryReport.Status);
+		}
+
+		/// <summary>
+		/// Implements light-weight delivery handler for produce requests.
+		/// </summary>
+		class DeliveryHandlerSlim : TaskCompletionSource<DeliveryReport<Null, Null>>, IDeliveryHandler
+		{
+            public DeliveryHandlerSlim() : base(TaskCreationOptions.RunContinuationsAsynchronously) {}
+            public void HandleDeliveryReport(DeliveryReport<Null, Null> deliveryReport) => TrySetResult(deliveryReport);
+		}
+
+		/// <inheritdoc/>
+		public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             TopicPartition topicPartition,
             Message<TKey, TValue> message,
             CancellationToken cancellationToken)
@@ -815,10 +849,10 @@ namespace Confluent.Kafka
                 else
                 {
                     ProduceImpl(
-                        topicPartition.Topic, 
+                        topicPartition.Topic,
                         valBytes, 0, valBytes == null ? 0 : valBytes.Length, 
                         keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, 
-                        message.Timestamp, topicPartition.Partition, headers.BackingList, 
+						message.Timestamp, topicPartition.Partition, headers.BackingList, 
                         null);
 
                     var result = new DeliveryResult<TKey, TValue>

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -26,10 +26,10 @@ using Confluent.Kafka.Internal;
 
 namespace Confluent.Kafka
 {
-	/// <summary>
-	///     A high level producer with serialization capability.
-	/// </summary>
-	internal class Producer<TKey, TValue> : IProducer<TKey, TValue>
+    /// <summary>
+    ///     A high level producer with serialization capability.
+    /// </summary>
+    internal class Producer<TKey, TValue> : IProducer<TKey, TValue>
     {
         internal class Config
         {
@@ -57,8 +57,8 @@ namespace Confluent.Kafka
             { typeof(double), Serializers.Double },
             { typeof(byte[]), Serializers.ByteArray }
         };
-		
-		private int cancellationDelayMaxMs;
+        
+        private int cancellationDelayMaxMs;
         private bool disposeHasBeenCalled = false;
         private object disposeHasBeenCalledLockObj = new object();
 
@@ -327,7 +327,7 @@ namespace Confluent.Kafka
                     topic,
                     val, valOffset, valLength,
                     key, keyOffset, keyLength,
-					partition.Value,
+                    partition.Value,
                     timestamp.UnixTimestampMs,
                     headers,
                     IntPtr.Zero);
@@ -741,8 +741,8 @@ namespace Confluent.Kafka
                 builder.AsyncKeySerializer, builder.AsyncValueSerializer);
         }
 
-		/// <inheritdoc/>
-		public async Task<ProduceResult> ProduceAsync(
+        /// <inheritdoc/>
+        public async Task<ProduceResult> ProduceAsync(
             string topic, 
             Partition partition, 
             ArraySegment<byte>? key, 
@@ -750,8 +750,8 @@ namespace Confluent.Kafka
             IReadOnlyList<IHeader> headers, 
             Timestamp timestamp)
         {
-			// Start produce request
-			DeliveryHandlerSlim deliveryHandler = new();
+            // Start produce request
+            DeliveryHandlerSlim deliveryHandler = new();
             ProduceImpl(topic, 
                 value?.Array, value?.Offset ?? 0, value?.Count ?? 0, 
                 key?.Array, key?.Offset ?? 0, key?.Count ?? 0, 
@@ -765,19 +765,19 @@ namespace Confluent.Kafka
 
             // Return response
             return new(deliveryReport.Partition, deliveryReport.Offset, deliveryReport.Status);
-		}
+        }
 
-		/// <summary>
-		/// Implements light-weight delivery handler for produce requests.
-		/// </summary>
-		class DeliveryHandlerSlim : TaskCompletionSource<DeliveryReport<Null, Null>>, IDeliveryHandler
-		{
+        /// <summary>
+        /// Implements light-weight delivery handler for produce requests.
+        /// </summary>
+        class DeliveryHandlerSlim : TaskCompletionSource<DeliveryReport<Null, Null>>, IDeliveryHandler
+        {
             public DeliveryHandlerSlim() : base(TaskCreationOptions.RunContinuationsAsynchronously) {}
             public void HandleDeliveryReport(DeliveryReport<Null, Null> deliveryReport) => TrySetResult(deliveryReport);
-		}
+        }
 
-		/// <inheritdoc/>
-		public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
+        /// <inheritdoc/>
+        public async Task<DeliveryResult<TKey, TValue>> ProduceAsync(
             TopicPartition topicPartition,
             Message<TKey, TValue> message,
             CancellationToken cancellationToken)
@@ -852,7 +852,7 @@ namespace Confluent.Kafka
                         topicPartition.Topic,
                         valBytes, 0, valBytes == null ? 0 : valBytes.Length, 
                         keyBytes, 0, keyBytes == null ? 0 : keyBytes.Length, 
-						message.Timestamp, topicPartition.Partition, headers.BackingList, 
+                        message.Timestamp, topicPartition.Partition, headers.BackingList, 
                         null);
 
                     var result = new DeliveryResult<TKey, TValue>


### PR DESCRIPTION
This PR adds new `IProducer` as new base interface for `IProducer<TKey, TValue>`. New interface has single `ProduceAsync` method that takes all message properties as primitive types include the key and value as pre-serialized bytes.

Compared to existing produce flows this changes:
1. Lets caller serialize key and value up front allowing caller to reuse buffers etc.
2. Avoids the wrapping of all message properties in a temporary `Message` instance.
3. Avoids the wrapping of produce result properties in an allocated class.