### PR TITLE
Added new IConsumer.Consume overload taking target ConsumeResult/Message as param for low-alloc flows.

### DIFF
--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -766,6 +766,19 @@ namespace Confluent.Kafka
         /// </summary>
         public ConsumeResult<TKey, TValue> Consume(int millisecondsTimeout)
         {
+            ConsumeResult<TKey, TValue> result = new();
+            if (!Consume(millisecondsTimeout, result))
+                return null;
+            return result;
+        }
+
+
+        /// <inheritdoc/>
+        public bool Consume(int millisecondsTimeout, ConsumeResult<TKey, TValue> result)
+        {
+            if (result == null)
+                throw new ArgumentNullException(nameof(result));
+
             var msgPtr = kafkaHandle.ConsumerPoll((IntPtr)millisecondsTimeout);
 
             if (this.handlerException != null)
@@ -781,7 +794,7 @@ namespace Confluent.Kafka
 
             if (msgPtr == IntPtr.Zero)
             {
-                return null;
+                return false;
             }
 
             try
@@ -806,14 +819,12 @@ namespace Confluent.Kafka
 
                 if (msg.err == ErrorCode.Local_PartitionEOF)
                 {
-                    return new ConsumeResult<TKey, TValue>
-                    {
-                        TopicPartitionOffset = new TopicPartitionOffset(topic,
-                            msg.partition, msg.offset,
-                            msgLeaderEpoch),
-                        Message = null,
-                        IsPartitionEOF = true
-                    };
+                    result.IsPartitionEOF = true;
+                    result.Topic = topic;
+                    result.Partition = msg.partition;
+                    result.Offset = msg.offset;
+                    result.LeaderEpoch = msgLeaderEpoch;
+                    return true;
                 }
 
                 long timestampUnix = 0;
@@ -827,7 +838,9 @@ namespace Confluent.Kafka
                 Headers headers = null;
                 if (enableHeaderMarshaling)
                 {
-                    headers = new Headers();
+                    headers = result.Message?.Headers ?? new Headers();
+                    headers.Clear();
+
                     Librdkafka.message_headers(msgPtr, out IntPtr hdrsPtr);
                     if (hdrsPtr != IntPtr.Zero)
                     {
@@ -938,20 +951,18 @@ namespace Confluent.Kafka
                         ex);
                 }
 
-                return new ConsumeResult<TKey, TValue> 
-                {
-                    TopicPartitionOffset = new TopicPartitionOffset(topic,
-                        msg.partition, msg.offset,
-                        msgLeaderEpoch),
-                    Message = new Message<TKey, TValue>
-                    {
-                        Timestamp = timestamp,
-                        Headers = headers,
-                        Key = key,
-                        Value = val
-                    },
-                    IsPartitionEOF = false
-                };
+                result.Topic = topic;
+                result.Partition = msg.partition;
+                result.Offset = msg.offset;
+                result.LeaderEpoch = msgLeaderEpoch;
+
+                result.Message ??= new Message<TKey, TValue>();
+                result.Message.Timestamp = timestamp;
+                result.Message.Headers = headers;
+                result.Message.Key = key;
+                result.Message.Value = val;
+                result.IsPartitionEOF = false;
+                return true;
             }
             finally
             {

--- a/src/Confluent.Kafka/Header.cs
+++ b/src/Confluent.Kafka/Header.cs
@@ -27,20 +27,17 @@ namespace Confluent.Kafka
     /// </remarks>
     public class Header : IHeader
     {
-        private byte[] val;
+        private readonly byte[] val;
 
         /// <summary>
         ///     The header key.
         /// </summary>
-        public string Key { get; private set; }
+        public string Key { get; }
 
         /// <summary>
         ///     Get the serialized header value data.
         /// </summary>
-        public byte[] GetValueBytes()
-        {
-            return val;
-        }
+        public byte[] GetValueBytes() => val;
         
         /// <summary>
         ///     Create a new Header instance.
@@ -53,12 +50,7 @@ namespace Confluent.Kafka
         /// </param>
         public Header(string key, byte[] value)
         {
-            if (key == null) 
-            {
-                throw new ArgumentNullException("Kafka message header key cannot be null.");
-            }
-
-            Key = key;
+            Key = key ?? throw new ArgumentNullException(nameof(key), "Kafka message header key cannot be null.");
             val = value;
         }
     }

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -54,6 +54,18 @@ namespace Confluent.Kafka
         ConsumeResult<TKey, TValue> Consume(int millisecondsTimeout);
 
         /// <summary>
+        /// Poll for new messages / events. Blocks until a consume result is availble or until timeout period has elapsed.
+        /// </summary>
+        /// <remarks>
+        /// This overload takes the result instance as parameter to allow reuse of result and contained message instances.
+        /// </remarks>
+        /// <param name="millisecondsTimeout"></param>
+        /// <param name="result">Mandatory result instance to be filled with next message/EOF.</param>
+        /// <returns>True if <c>result</c> was filled with message or EOF, false if timeout elapsed.</returns>
+        bool Consume(int millisecondsTimeout, ConsumeResult<TKey, TValue> result);
+
+
+        /// <summary>
         ///     Poll for new messages / events. Blocks
         ///     until a consume result is available or the
         ///     operation has been cancelled.

--- a/test/Confluent.Kafka.UnitTests/Headers.cs
+++ b/test/Confluent.Kafka.UnitTests/Headers.cs
@@ -83,6 +83,8 @@ namespace Confluent.Kafka.UnitTests
         public void TryGetLast_NotExist()
         {
             var hdrs = new Headers();
+            Assert.False(hdrs.TryGetLastBytes("my-header-2", out byte[] _));
+
             hdrs.Add(new Header("my-header", new byte[] { 42 }));
 
             Assert.False(hdrs.TryGetLastBytes("my-header-2", out byte[] val));
@@ -107,6 +109,8 @@ namespace Confluent.Kafka.UnitTests
         public void Remove()
         {
             var hdrs = new Headers();
+            hdrs.Remove("not-present");
+
             hdrs.Add(new Header("my-header", new byte[] { 42 }));
             hdrs.Add(new Header("my-header", new byte[] { 44 }));
             hdrs.Add(new Header("my-header-2", new byte[] { 45 }));
@@ -151,6 +155,9 @@ namespace Confluent.Kafka.UnitTests
         public void Enumerator()
         {
             var hdrs = new Headers();
+
+            Assert.Empty(hdrs);
+
             hdrs.Add(new Header("my-header", new byte[] { 42 }));
             hdrs.Add(new Header("my-header", new byte[] { 44 }));
             hdrs.Add(new Header("my-header-2", new byte[] { 45 }));
@@ -176,5 +183,16 @@ namespace Confluent.Kafka.UnitTests
             Assert.Equal(3, cnt);
         }
 
+        [Fact]
+        public void BackingList()
+        {
+            var hdrs = new Headers();
+            hdrs.Clear();
+            Assert.Empty(hdrs.BackingList);
+            hdrs.Add("A", null);
+            Assert.Single(hdrs.BackingList);
+            hdrs.Clear();
+            Assert.Empty(hdrs);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new `IConsumer.Consume(int, ConsumeResult)` overload that allows caller to bring his own (likely reused) `ConsumeResult` with embedded `Message`.

This makes it easy for caller to reuse single `ConsumeResult` instance and single `Message` instance and thereby reduce overall allocations.

`Headers` class has also been optimized internally to only create the backing list when first header is added. This avoids allocating an empty list for all messages without headers.