### PR TITLE
Improve perf of base64 encoding check on a consumer hot path

### DIFF
--- a/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
@@ -592,16 +592,8 @@ namespace Confluent.SchemaRegistry
             // if a format isn't specified, then assume text is desired.
             if (format == null)
             {
-                try
-                {
-                    Convert.FromBase64String(schemaString);
-                }
-                catch (Exception)
-                {
-                    return true; // Base64 conversion failed, infer the schemaString format is text.
-                }
-
-                return false; // Base64 conversion succeeded, so infer the schamaString format is base64.
+                // If schemaString is not Base64, infer the schemaString format is text.
+                return !Utils.IsBase64String(schemaString);
             }
             else
             {
@@ -609,17 +601,8 @@ namespace Confluent.SchemaRegistry
                 {
                     throw new ArgumentException($"Invalid schema format was specified: {format}.");
                 }
-
-                try
-                {
-                    Convert.FromBase64String(schemaString);
-                }
-                catch (Exception)
-                {
-                    return false;
-                }
-
-                return true;
+                
+                return Utils.IsBase64String(schemaString);
             }
         }
 

--- a/src/Confluent.SchemaRegistry/Utils.cs
+++ b/src/Confluent.SchemaRegistry/Utils.cs
@@ -20,6 +20,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Confluent.Kafka;
 
+#if NET8_0_OR_GREATER
+using System.Buffers.Text;
+#endif
 
 namespace Confluent.SchemaRegistry
 {
@@ -69,6 +72,23 @@ namespace Confluent.SchemaRegistry
             if (ReferenceEquals(a, b)) return true;
             if (a == null || b == null) return false;
             return a.SequenceEqual(b);
+        }
+        
+        internal static bool IsBase64String(string value)
+        {
+#if NET8_0_OR_GREATER
+            return Base64.IsValid(value);
+#else
+            try
+            {
+                _ = Convert.FromBase64String(value);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+#endif
         }
     }
 }


### PR DESCRIPTION
This PR improves the performance of the Base64 encoding check, which is performed for every message processed by the consumer. This change complements the work done in #2370.

Below are the results of benchmarking the new implementation (Base64.IsValid) against the existing Convert.FromBase64String approach:

```
| Method           | Mean          | Error        | StdDev       |
|----------------- |--------------:|-------------:|-------------:|
| IsBase64         |      24.52 ns |     0.074 ns |     0.066 ns |
| FromBase64String | 138,883.49 ns | 2,535.710 ns | 2,247.841 ns |

```

The code used to produce the benchmark results::
```csharp
class Program
{
    static void Main(string[] args)
    {
        BenchmarkRunner.Run<IsBase64StringBenchmark>();
    }
}

public class IsBase64StringBenchmark
{
    private readonly string _invalidBase64 = string.Join("", Enumerable.Repeat("This is not base64!", 10000));

    [Benchmark]
    public bool IsBase64()
    {
        return Base64.IsValid(_invalidBase64);
    }

    [Benchmark]
    public bool FromBase64String()
    {
        try
        {
            _ = Convert.FromBase64String(_invalidBase64);
            return true;
        }
        catch (FormatException)
        {
            return false;
        }
    }
}
```