### PR TITLE
Set skipKnownTypes default to be consistent with other clients

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializerConfig.cs
@@ -195,7 +195,7 @@ namespace Confluent.SchemaRegistry.Serdes
         ///     Specifies whether or not the Protobuf serializer should skip known types
         ///     when resolving dependencies.
         ///
-        ///     default: false
+        ///     default: true
         /// </summary>
         public bool? SkipKnownTypes
         {

--- a/src/Confluent.SchemaRegistry/AsyncSerde.cs
+++ b/src/Confluent.SchemaRegistry/AsyncSerde.cs
@@ -142,6 +142,11 @@ namespace Confluent.SchemaRegistry
                 .ConfigureAwait(continueOnCapturedContext: false);
             return result;
         }
+
+        protected virtual bool IgnoreReference(string name)
+        {
+            return false;
+        }
         
         private async Task<IDictionary<string, string>> ResolveReferences(
             Schema schema, IDictionary<string, string> schemas, ISet<string> visited)
@@ -149,7 +154,7 @@ namespace Confluent.SchemaRegistry
             IList<SchemaReference> references = schema.References;
             foreach (SchemaReference reference in references)
             {
-                if (visited.Contains(reference.Name))
+                if (IgnoreReference(reference.Name) || visited.Contains(reference.Name))
                 {
                     continue;
                 }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeGoogleRef.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeGoogleRef.cs
@@ -33,12 +33,13 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
+            var serializerConfig = new ProtobufSerializerConfig() { SkipKnownTypes = false };
 
             using (var topic = new TemporaryTopic(bootstrapServers, 1))
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
             using (var producer =
                 new ProducerBuilder<string, WithGoogleRefs.TheRecord>(producerConfig)
-                    .SetValueSerializer(new ProtobufSerializer<WithGoogleRefs.TheRecord>(schemaRegistry))
+                    .SetValueSerializer(new ProtobufSerializer<WithGoogleRefs.TheRecord>(schemaRegistry, serializerConfig))
                     .Build())
             {
                 var u = new WithGoogleRefs.TheRecord();


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
By default, skip known types when registering a Protobuf schema.  This is because these known types are builtin and not used when resolving a Protobuf schema.  The default is changed to match the default behavior of the other clients.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
  - Default of skipKnownTypes is changed to true to match other clients.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Existing tests provide sufficient coverage

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
