### PR TITLE
fix: Update the Schema GetHashCode for Dictionary lookups

### DIFF
--- a/src/Confluent.SchemaRegistry/Rest/DataContracts/Schema.cs
+++ b/src/Confluent.SchemaRegistry/Rest/DataContracts/Schema.cs
@@ -271,10 +271,35 @@ namespace  Confluent.SchemaRegistry
             unchecked
             {
                 var hashCode = SchemaString.GetHashCode();
-                hashCode = (hashCode * 397) ^ (References != null ? References.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (References != null ? GetListHashCode(References) : 0); 
                 hashCode = (hashCode * 397) ^ (Metadata != null ? Metadata.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (RuleSet != null ? RuleSet.GetHashCode() : 0);
                 return hashCode;
+            }
+        }
+        
+        /// <summary>
+        ///     Returns a hash code for a list of objects.
+        /// </summary>
+        /// <param name="list">
+        ///     The list to get the hash code for.
+        /// </param> 
+        /// <returns>
+        ///     An integer that specifies a hash value for this instance.
+        /// </returns>
+        private int GetListHashCode<T>(IList<T> list)
+        {
+            if (list == null || list.Count == 0)
+                return 0;
+
+            unchecked
+            {
+                int hash = 0;
+                foreach (var item in list)
+                {
+                    hash += item?.GetHashCode() ?? 0;
+                }
+                return hash;
             }
         }
 


### PR DESCRIPTION
 

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

The `GetHashCode` for the `Schema` data contract was updated in June with additional properties to accomodate the DataContract work.  However, the `CachedSchemaRegistryClient` is not able to retrieve items stored in its dictionary cache because of the `References` addition and how List<>'s are handled.  

We saw severe slow down (around 15 seconds at times) registering a schema with 13 references (and their recursive references) because it was trying to query schemas that it already had in the Dictionary.  When the changes proposed were made, the schemas that had been already retrieved were able to be pulled from the cache again (down to 1-2 seconds for large schemas, under a second for most).

Feel free to update as you wish but the code you need to ensure works is at `src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs`

```
 if (!idBySchema.TryGetValue(schema, out int schemaId))
  {
      CleanCacheIfFull();

      schemaId = await restService.RegisterSchemaAsync(subject, schema, normalize)
          .ConfigureAwait(continueOnCapturedContext: false);
      idBySchema[schema] = schemaId;
  }
```
The if statement above would never get a schemaId from the `idBySchema` lookup.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

I don't see any unit tests surrounding this code anywhere or I would.

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Serialize an object and debug the CachedSchemaRegistryClient to ensure that when a schema has been retrieved and/or registered it is able to be pulled from the dictionary.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
