### PR TITLE
Added Akka.Streams.Kafka to `3RD_PARTY.md`

### DIFF
--- a/3RD_PARTY.md
+++ b/3RD_PARTY.md
@@ -11,3 +11,4 @@ To add your project, open a pull request!
 - [OpenSleigh.Transport.Kafka](https://github.com/mizrael/OpenSleigh/tree/develop/src/OpenSleigh.Transport.Kafka) - A Kafka Transport for OpenSleigh, a distributed saga management library.
 - [SlimMessageBus.Host.Kafka](https://github.com/zarusz/SlimMessageBus) - Apache Kafka transport for SlimMessageBus (lightweight message bus for .NET)
 - [Kafka Core](https://github.com/ffernandolima/confluent-kafka-core-dotnet) - Kafka Core empowers developers to build robust .NET applications on top of Confluent Kafka, focusing on simplicity, maintainability, and extensibility with intuitive abstractions and builders.
+- [Akka.Streams.Kafka](https://github.com/akkadotnet/Akka.Streams.Kafka) - [Akka.NET](https://getakka.net/) streams support for Apache Kafka. Makes it feasible to build rich, high performance Kafka applications using a LINQ-like syntax.


### PR DESCRIPTION
What
----

Added reference to https://github.com/akkadotnet/Akka.Streams.Kafka in the `3RD_PARTY.md` documentation.

Checklist
------------------
- No API changes; only markdown documents in this repository