### PR TITLE
Revert re-entrant lock attempt during LookupSchemaAsync

### DIFF
--- a/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs
@@ -534,7 +534,7 @@ namespace Confluent.SchemaRegistry
                     CleanCacheIfFull();
 
                     // throws SchemaRegistryException if schema is not known.
-                    var registeredSchema = await LookupSchemaAsync(subject, schema, true, normalize)
+                    var registeredSchema = await restService.LookupSchemaAsync(subject, schema, true, normalize)
                         .ConfigureAwait(continueOnCapturedContext: false);
                     idBySchema[schema] = registeredSchema.Id;
                     schemaById[registeredSchema.Id] = registeredSchema.Schema;


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

A recent [PR](https://github.com/confluentinc/confluent-kafka-dotnet/pull/2429) added a re-entrant lock attempt.  This PR reverts it.

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
