### PR TITLE
Validate inputs in `OAuthBearerSetToken`

### DIFF
--- a/src/Confluent.Kafka/ClientExtensions.cs
+++ b/src/Confluent.Kafka/ClientExtensions.cs
@@ -41,6 +41,9 @@ namespace Confluent.Kafka
         /// <seealso cref="OAuthBearerSetTokenFailure"/>
         public static void OAuthBearerSetToken(this IClient client, string tokenValue, long lifetimeMs, string principalName, IDictionary<string, string> extensions = null)
         {
+            if (tokenValue == null) throw new System.ArgumentNullException(nameof(tokenValue));
+            if (principalName == null) throw new System.ArgumentNullException(nameof(principalName));
+
             client.Handle.LibrdkafkaHandle.OAuthBearerSetToken(tokenValue, lifetimeMs, principalName, extensions);
         }
 


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

The documentation for `OAuthBearerSetToken` notes that `tokenValue` and `principalName` are required parameters but doesn't check them for null values. As seen in this [issue](https://github.com/confluentinc/confluent-kafka-dotnet/issues/2158), if `principalName` is `null`, the underlying library call will segfault (and do so silently in a Docker/Kubernetes environment. To keep from segfaulting, we can simply check those values for `null` and throw accordingly.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
Issue: https://github.com/confluentinc/confluent-kafka-dotnet/issues/2158 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
