### PR TITLE
Remove redundant ConfigureAwait

### DIFF
--- a/src/Confluent.Kafka/SyncOverAsyncDeserializer.cs
+++ b/src/Confluent.Kafka/SyncOverAsyncDeserializer.cs
@@ -73,7 +73,6 @@ namespace Confluent.Kafka.SyncOverAsync
         /// </returns>
         public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)
             => asyncDeserializer.DeserializeAsync(new ReadOnlyMemory<byte>(data.ToArray()), isNull, context)
-                    .ConfigureAwait(continueOnCapturedContext: false)
                     .GetAwaiter()
                     .GetResult();
     }

--- a/src/Confluent.Kafka/SyncOverAsyncSerializer.cs
+++ b/src/Confluent.Kafka/SyncOverAsyncSerializer.cs
@@ -71,7 +71,6 @@ namespace Confluent.Kafka.SyncOverAsync
         /// </returns>
         public byte[] Serialize(T data, SerializationContext context)
             => asyncSerializer.SerializeAsync(data, context)
-                .ConfigureAwait(continueOnCapturedContext: false)
                 .GetAwaiter()
                 .GetResult();
     }


### PR DESCRIPTION
What
----
This PR removes a redundant call to .ConfigureAwait(false) in a blocking context (.GetAwaiter().GetResult()), as it has no effect in such cases.
See Stephen Cleary’s [article](https://blog.stephencleary.com/2023/11/configureawait-in-net-8.html) on ConfigureAwait in .NET 8 for detailed explanation.


Checklist
------------------
* [ ] Contains customer facing changes? Including API/behavior changes
  * No
* [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  * Not required — behavior remains unchanged and is already covered.

@rayokota Could you please take a look?

