### PR TITLE
Implement IAsyncDisposable on AdminClient

### DIFF
--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -27,6 +27,9 @@ namespace Confluent.Kafka
     ///     Defines an Apache Kafka admin client.
     /// </summary>
     public interface IAdminClient : IClient
+#if NET6_0_OR_GREATER
+        , IAsyncDisposable
+#endif
     {
         /// <summary>
         ///     DEPRECATED.

--- a/test/Confluent.Kafka.UnitTests/Admin/DisposeAsync.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/DisposeAsync.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Confluent.Kafka.UnitTests;
+
+public class DisposeAsync
+{
+    [Fact]
+    public async Task TestDisposeAsyncDoesNotThrow()
+    {
+        var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build();
+
+        await adminClient.DisposeAsync();
+    }
+}


### PR DESCRIPTION
What
----

AdminClient.Dispose does sync-over-async which impacts the throughput of the thread pool. There is a comment on the method that says
> In the current implementation, this method may block for up to 100ms. This will be replaced with a non-blocking version in the future.

This change fixes that by implementing [IAsyncDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.iasyncdisposable).

The AdminClient class partially implemented a dispose pattern (`Dispose(bool)` + `GC.SuppressFinalize(this)`) but it was missing a finalizer. Anyway, this class doesn't own any native resources so this is not needed.

Checklist
------------------
- [X] Contains customer facing changes? A new method is added to `IAdminClient`
- [X] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required