### PR TITLE
Use array pooling to reduce GC pressure in the deserialization hot path

### DIFF
--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Memory" Version="4.5.0" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
This PR introduces array pooling to eliminate unnecessary array allocations from the deserialization flow.

| Method                          | Mean     | Error    | StdDev   | Gen0   | Allocated |
|-------------------------------- |---------:|---------:|---------:|-------:|----------:|
| Deserialize_WithoutArrayPooling | 127.7 ns | 2.33 ns  | 2.18 ns  | 0.3455 |   2.12 KB |
| Deserialize_WithArrayPooling    | 97.11 ns | 1.940 ns | 1.905 ns | 0.1785 |   1.09 KB |

Checklist
------------------
* [ ] Contains customer facing changes? Including API/behavior changes
  * No
* [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  * Not required — behavior remains unchanged and is already covered.

cc: @rayokota 