### PR TITLE
Fix protobuf serialization - Normalize config not taken into account since 2.10.1

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
@@ -250,7 +250,7 @@ namespace Confluent.SchemaRegistry.Serdes
                                 .ConfigureAwait(continueOnCapturedContext: false)
                             : await schemaRegistryClient.LookupSchemaAsync(subject,
                                     new Schema(value.Descriptor.File.SerializedData.ToBase64(), references,
-                                        SchemaType.Protobuf), normalizeSchemas)
+                                        SchemaType.Protobuf), true, normalizeSchemas)
                                 .ConfigureAwait(continueOnCapturedContext: false);
 
                         // note: different values for schemaId should never be seen here.

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
@@ -173,7 +173,7 @@ namespace Confluent.SchemaRegistry.Serdes
                     var schemaId = autoRegisterSchema
                         ? await schemaRegistryClient.RegisterSchemaAsync(subject, schema, normalizeSchemas).ConfigureAwait(continueOnCapturedContext: false)
                         : await schemaRegistryClient.GetSchemaIdAsync(subject, schema, normalizeSchemas).ConfigureAwait(continueOnCapturedContext: false);
-                    var registeredDependentSchema = await schemaRegistryClient.LookupSchemaAsync(subject, schema, true, normalizeSchemas).ConfigureAwait(continueOnCapturedContext: false);
+                    var registeredDependentSchema = await schemaRegistryClient.LookupSchemaAsync(subject, schema, ignoreDeletedSchemas: true, normalize: normalizeSchemas).ConfigureAwait(continueOnCapturedContext: false);
                     return new SchemaReference(dependency.Name, subject, registeredDependentSchema.Version);
                 };
                 tasks.Add(t(fileDescriptor));
@@ -250,7 +250,7 @@ namespace Confluent.SchemaRegistry.Serdes
                                 .ConfigureAwait(continueOnCapturedContext: false)
                             : await schemaRegistryClient.LookupSchemaAsync(subject,
                                     new Schema(value.Descriptor.File.SerializedData.ToBase64(), references,
-                                        SchemaType.Protobuf), true, normalizeSchemas)
+                                        SchemaType.Protobuf), ignoreDeletedSchemas: true, normalize: normalizeSchemas)
                                 .ConfigureAwait(continueOnCapturedContext: false);
 
                         // note: different values for schemaId should never be seen here.


### PR DESCRIPTION
Fixes normalize schema passed at the wrong position in the parameter arguments in the ProtobufSerializer.cs SerializeAsync call to schemaRegistryClient.LookupSchemaAsync.

This bug was introduced with the 2.10.1, breaking our schema validation from this version while it is working fine with previous version.
After analysis the normalized parameter passed into the http call was changed from this version and I was able to trace back the issue to this change in the diff.

It might be missing a test, considering the change at the moment I only did minimal setup on my local, but if it's needed we can cover the case.

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
