### PR TITLE
DGS-21472: use SocketsHttpHandler to support connection pooling for Schema Registry client, for .NET 6.0+

### DIFF
--- a/src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs
+++ b/src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs
@@ -32,9 +32,9 @@ namespace Confluent.SchemaRegistry.Encryption
             IAuthenticationHeaderValueProvider authenticationHeaderValueProvider, List<X509Certificate2> certificates,
             bool enableSslCertificateVerification, X509Certificate2 sslCaCertificate = null, IWebProxy proxy = null,
             int maxRetries = DefaultMaxRetries, int retriesWaitMs = DefaultRetriesWaitMs,
-            int retriesMaxWaitMs = DefaultRetriesMaxWaitMs) :
+            int retriesMaxWaitMs = DefaultRetriesMaxWaitMs, int maxConnectionsPerServer = DefaultMaxConnectionsPerServer) :
             base(schemaRegistryUrl, timeoutMs, authenticationHeaderValueProvider, certificates,
-                enableSslCertificateVerification, sslCaCertificate, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs)
+                enableSslCertificateVerification, sslCaCertificate, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs, maxConnectionsPerServer)
         {
         }
 

--- a/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
+++ b/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
@@ -86,7 +86,7 @@ namespace Confluent.SchemaRegistry
             ///     USER_INFO: Credentials are specified via the `schema.registry.basic.auth.user.info` config property in the form username:password.
             ///                If `schema.registry.basic.auth.user.info` is not set, authentication is disabled.
             ///     SASL_INHERIT: Credentials are specified via the `sasl.username` and `sasl.password` configuration properties.
-            /// 
+            ///
             ///     default: USER_INFO
             /// </summary>
             public const string SchemaRegistryBasicAuthCredentialsSource =
@@ -94,7 +94,7 @@ namespace Confluent.SchemaRegistry
 
             /// <summary>
             ///     Basic auth credentials in the form {username}:{password}.
-            /// 
+            ///
             ///     default: "" (no authentication).
             /// </summary>
             public const string SchemaRegistryBasicAuthUserInfo = "schema.registry.basic.auth.user.info";
@@ -111,7 +111,7 @@ namespace Confluent.SchemaRegistry
             ///     Specifies the bearer authentication token.
             /// </summary>
             public const string SchemaRegistryBearerAuthToken = "schema.registry.bearer.auth.token";
-            
+
             /// <summary>
             ///     Specifies the logical cluster for the bearer authentication credentials.
             /// </summary>
@@ -243,7 +243,7 @@ namespace Confluent.SchemaRegistry
 
         /// <summary>
         ///     Specifies the timeout for requests to Confluent Schema Registry.
-        /// 
+        ///
         ///     default: 30000
         /// </summary>
         public int? RequestTimeoutMs
@@ -307,7 +307,7 @@ namespace Confluent.SchemaRegistry
         {
             get { return Get(SchemaRegistryConfig.PropertyNames.SslKeystoreLocation); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SslKeystoreLocation, value?.ToString()); }
-            
+
         }
 
         ///    <summary>
@@ -337,7 +337,7 @@ namespace Confluent.SchemaRegistry
         /// <summary>
         ///     Specifies the maximum number of schemas CachedSchemaRegistryClient
         ///     should cache locally.
-        /// 
+        ///
         ///     default: 1000
         /// </summary>
         public int? MaxCachedSchemas
@@ -349,7 +349,7 @@ namespace Confluent.SchemaRegistry
 
         /// <summary>
         ///     Specifies the TTL for caches holding latest schemas, or -1 for no TTL.
-        /// 
+        ///
         ///     default: -1
         /// </summary>
         public int? LatestCacheTtlSecs
@@ -442,7 +442,7 @@ namespace Confluent.SchemaRegistry
             get { return Get(SchemaRegistryConfig.PropertyNames.SchemaRegistryBearerAuthLogicalCluster); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryBearerAuthLogicalCluster, value); }
         }
-        
+
         /// <summary>
         ///     Specifies the identity pool for the bearer authentication credentials.
         /// </summary>
@@ -450,7 +450,7 @@ namespace Confluent.SchemaRegistry
         {
             get { return Get(SchemaRegistryConfig.PropertyNames.SchemaRegistryBearerAuthIdentityPoolId); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryBearerAuthIdentityPoolId, value); }
-        } 
+        }
 
         /// <summary>
         ///     Specifies the client ID for the bearer authentication credentials.
@@ -478,7 +478,7 @@ namespace Confluent.SchemaRegistry
             get { return Get(SchemaRegistryConfig.PropertyNames.SchemaRegistryBearerAuthScope); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryBearerAuthScope, value); }
         }
-        
+
         /// <summary>
         ///     Specifies the token endpoint for the bearer authentication credentials.
         /// </summary>
@@ -490,7 +490,7 @@ namespace Confluent.SchemaRegistry
 
         /// <summary>
         ///     Key subject name strategy.
-        ///     
+        ///
         ///     default: SubjectNameStrategy.Topic
         /// </summary>
         [Obsolete(
@@ -595,7 +595,7 @@ namespace Confluent.SchemaRegistry
         }
 
         /// <summary>
-        ///     Gets a configuration property value given a key. Returns null if 
+        ///     Gets a configuration property value given a key. Returns null if
         ///     the property has not been set.
         /// </summary>
         /// <param name="key">

--- a/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
+++ b/src/Confluent.SchemaRegistry/SchemaRegistryConfig.cs
@@ -67,6 +67,13 @@ namespace Confluent.SchemaRegistry
             public const string SchemaRegistryRetriesMaxWaitMs = "schema.registry.retries.max.wait.ms";
 
             /// <summary>
+            ///     Specifies the maximum number of connections per server.
+            ///
+            ///     default: 20
+            /// </summary>
+            public const string SchemaRegistryMaxConnectionsPerServer = "schema.registry.connections.max.per.server";
+
+            /// <summary>
             ///     Specifies the maximum number of schemas CachedSchemaRegistryClient
             ///     should cache locally.
             ///
@@ -283,6 +290,17 @@ namespace Confluent.SchemaRegistry
         {
             get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryRetriesMaxWaitMs); }
             set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryRetriesMaxWaitMs, value?.ToString()); }
+        }
+
+        /// <summary>
+        ///     Specifies the maximum number of connections per server.
+        ///
+        ///     default: 20
+        /// </summary>
+        public int? MaxConnectionsPerServer
+        {
+            get { return GetInt(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxConnectionsPerServer); }
+            set { SetObject(SchemaRegistryConfig.PropertyNames.SchemaRegistryMaxConnectionsPerServer, value?.ToString()); }
         }
 
         ///    <summary>


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Previously there have been issues reported on using Schema Registry client in .NET, particularly when running it in serverless environments (e.g. AWS Lambda) where opening too many connections could exceed the file descriptor limit

For build targets .NET 6.0 and .NET 8.0, use `SocketsHttpHandler` to support connection pooling, via the fields:
- `MaxConnectionsPerServer` (https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.maxconnectionsperserver?view=net-8.0): max number of connections per host
- `ConnectTimeout` (https://learn.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.connecttimeout?view=net-8.0): timespan to wait before the connection establishing times out

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-21472
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
