### PR TITLE
Re-enable deserialization optimization by removing unnecessary array allocation

### DIFF
--- a/src/Confluent.Kafka/Deserializers.cs
+++ b/src/Confluent.Kafka/Deserializers.cs
@@ -39,11 +39,11 @@ namespace Confluent.Kafka
                     return null;
                 }
 
-                #if NETCOREAPP2_1
+#if NET6_0_OR_GREATER
                     return Encoding.UTF8.GetString(data);
-                #else
+#else
                     return Encoding.UTF8.GetString(data.ToArray());
-                #endif
+#endif
             }
         }
 
@@ -171,11 +171,11 @@ namespace Confluent.Kafka
                 }
                 else
                 {
-                    #if NETCOREAPP2_1
+#if NET6_0_OR_GREATER
                         return BitConverter.ToSingle(data);
-                    #else
+#else
                         return BitConverter.ToSingle(data.ToArray(), 0);
-                    #endif
+#endif
                 }
             }
         }
@@ -219,11 +219,11 @@ namespace Confluent.Kafka
                 }
                 else
                 {
-                    #if NETCOREAPP2_1
+#if NET6_0_OR_GREATER
                                     return BitConverter.ToDouble(data);
-                    #else
+#else
                                     return BitConverter.ToDouble(data.ToArray(), 0);
-                    #endif
+#endif
                 }
             }
         }


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
We no longer build against NETCOREAPP2_1, so that conditional path was dead code and forced an extra array allocation on all targets. This change removes the redundant allocation and restores the original optimization.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
  - No
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - No, no functional changes

Review stakeholders
------------------
@rayokota could you please take a look? 
