### PR TITLE
Implement IComparable for Offset and Partition

### DIFF
--- a/src/Confluent.Kafka/Offset.cs
+++ b/src/Confluent.Kafka/Offset.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka
     ///     its purpose is to add some syntactical sugar 
     ///     related to special values.
     /// </remarks>
-    public struct Offset : IEquatable<Offset>
+    public struct Offset : IEquatable<Offset>, IComparable<Offset>
     {
         private const long RD_KAFKA_OFFSET_BEGINNING = -2;
         private const long RD_KAFKA_OFFSET_END = -1;
@@ -287,5 +287,31 @@ namespace Confluent.Kafka
                     return Value.ToString();
             }
         }
+
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.</summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        /// <returns>
+        ///     <para>A value that indicates the relative order of the objects being compared. The return value has these meanings:</para>
+        ///     <list type="table">
+        ///         <listheader>
+        ///             <term>Value</term>
+        ///             <description>Meaning</description>
+        ///         </listheader>
+        ///         <item>
+        ///             <term>Less than zero</term>
+        ///             <description>This instance precedes <paramref name="other" /> in the sort order.</description>
+        ///         </item>
+        ///         <item>
+        ///             <term>Zero</term>
+        ///             <description>This instance occurs in the same position in the sort order as <paramref name="other" />.</description>
+        ///         </item>
+        ///         <item>
+        ///             <term>Greater than zero</term>
+        ///             <description>This instance follows <paramref name="other" /> in the sort order.</description>
+        ///         </item>
+        ///     </list>
+        /// </returns>
+        public int CompareTo(Offset other)
+            => Value.CompareTo(other.Value);
     }
 }

--- a/src/Confluent.Kafka/Partition.cs
+++ b/src/Confluent.Kafka/Partition.cs
@@ -28,7 +28,7 @@ namespace Confluent.Kafka
     ///     its purpose is to add some syntactical sugar 
     ///     related to special values.
     /// </remarks>
-    public struct Partition : IEquatable<Partition>
+    public struct Partition : IEquatable<Partition>, IComparable<Partition>
     {
         private const int RD_KAFKA_PARTITION_UA = -1;
 
@@ -224,5 +224,31 @@ namespace Confluent.Kafka
                     return $"[{Value}]";
             }
         }
+
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.</summary>
+        /// <param name="other">An object to compare with this instance.</param>
+        /// <returns>
+        ///     <para>A value that indicates the relative order of the objects being compared. The return value has these meanings:</para>
+        ///     <list type="table">
+        ///         <listheader>
+        ///             <term>Value</term>
+        ///             <description>Meaning</description>
+        ///         </listheader>
+        ///         <item>
+        ///             <term>Less than zero</term>
+        ///             <description>This instance precedes <paramref name="other" /> in the sort order.</description>
+        ///         </item>
+        ///         <item>
+        ///             <term>Zero</term>
+        ///             <description>This instance occurs in the same position in the sort order as <paramref name="other" />.</description>
+        ///         </item>
+        ///         <item>
+        ///             <term>Greater than zero</term>
+        ///             <description>This instance follows <paramref name="other" /> in the sort order.</description>
+        ///         </item>
+        ///     </list>
+        /// </returns>
+        public int CompareTo(Partition other)
+            => Value.CompareTo(other.Value);
     }
 }

--- a/test/Confluent.Kafka.UnitTests/Offset.cs
+++ b/test/Confluent.Kafka.UnitTests/Offset.cs
@@ -70,6 +70,17 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
+        public void CompareTo()
+        {
+            Offset a = new Offset(42);
+            Offset a2 = new Offset(42);
+            Offset b = new Offset(37);
+            Assert.True(a.CompareTo(b) > 0);
+            Assert.True(b.CompareTo(a) < 0);
+            Assert.True(a.CompareTo(a2) == 0);
+        }
+
+        [Fact]
         public void Addition_Int()
         {
             Offset a = new Offset(42);

--- a/test/Confluent.Kafka.UnitTests/Partition.cs
+++ b/test/Confluent.Kafka.UnitTests/Partition.cs
@@ -67,6 +67,17 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
+        public void CompareTo()
+        {
+            Partition a = new Partition(42);
+            Partition a2 = new Partition(42);
+            Partition b = new Partition(37);
+            Assert.True(a.CompareTo(b) > 0);
+            Assert.True(b.CompareTo(a) < 0);
+            Assert.True(a.CompareTo(a2) == 0);
+        }
+
+        [Fact]
         public void Hash()
         {
             Partition partition = new Partition(42);


### PR DESCRIPTION
Today I have realized that the code like this fails:
```csharp
messages.Max(message => message.Offset);
```

Despite having `<` or `>` operators, Offset does not implement IComparable, so this code fails with an exception:
```
  Message: 
System.ArgumentException : At least one object must implement IComparable.

  Stack Trace: 
Comparer.Compare(Object a, Object b)
ObjectComparer`1.Compare(T x, T y)
Enumerable.Max[TSource,TResult](IEnumerable`1 source, Func`2 selector)
```

I decided to submit a PR fixing that.

Checklist
------------------
- [x] Contains customer facing changes? (Interface implemented)
- [ ] Including API/behavior changes 
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?