### PR TITLE
Modernise `librdkafka` library load

### DIFF
--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -152,10 +152,7 @@ namespace Confluent.Kafka.Impl
             public static void Load(string path)
             {
 #if NETCOREAPP3_0_OR_GREATER
-                if (NativeLibrary.Load(path) == IntPtr.Zero)
-                {
-                    throw new InvalidOperationException($"Failed to load librdkafka at location '{path}'.");
-                }
+                NativeLibrary.Load(path);
 #else
                 if (dlopen(path, RTLD_NOW) == IntPtr.Zero)
                 {


### PR DESCRIPTION
What
----
This PR modernizes how we load the native `librdkafka` library on Linux and macOS for modern .NET versions. 

Currently, the library relies on a direct P/Invoke of `libdl` (`dlopen`) to load `librdkafka`. This works on many systems but fails on distributions (like certain versions of Fedora, CentOS, Amazon Linux, or slim Docker containers) where `libdl.so` is missing, versioned (`libdl.so.2`), or merged into `libc`.

**The Fix:**
From .NET Core 3.0 and onwards the managed `NativeLibrary.Load` API is available; this API was specifically introduced to abstract away these platform-specific idiosyncrasies (like knowing whether to look for `libdl.so` or `libdl.so.2`).

For legacy targets (`netstandard2.0`, `net462`), the existing `dlopen` behavior is preserved to maintain backwards compatibility.

**Why:**
This resolves issues where applications crash with `DllNotFoundException: Unable to load shared library 'libdl'` despite the runtime being present. As noted in the [Red Hat Developer blog](https://developers.redhat.com/blog/2019/09/06/interacting-with-native-libraries-in-net-core-3-0#), `NativeLibrary` is the intended path forward for interop in the modern .NET.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
  - *Fixes a runtime crash on specific Linux distributions.*
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - *No. While I'd like to add unit tests, reliably reproducing the "missing libdl" environment in CI would require significant changes to the testing pipeline or the introduction of a custom, opaque build of `librdkafka`—and frankly, that looks a little too much like the XZ Utils saga for my liking. 🕵️‍♂️*

References
----------
**Issue Fixed:**
- https://github.com/confluentinc/confluent-kafka-dotnet/issues/2550

**Context & Validation:**
- [Dotnet Docker Discussion #4938](https://github.com/dotnet/dotnet-docker/discussions/4938) - "The proper fix is change the offending code to call NativeLibrary.Load"
- [Interacting with native libraries in .NET Core 3.0](https://developers.redhat.com/blog/2019/09/06/interacting-with-native-libraries-in-net-core-3-0#)
- Related Runtime Issues: [dotnet/runtime#20635](https://github.com/dotnet/runtime/issues/20635), [dotnet/runtime#27267](https://github.com/dotnet/runtime/issues/27267)

Test & Review
------------
This has been manually verified using custom compilations of `librdkafka` on the following distributions where the issue was previously observed:
- CentOS
- Fedora
- Amazon Linux

The application now successfully loads the library via `NativeLibrary.Load` instead of failing to find `libdl`.

Open questions / Follow-ups
--------------------------
- This targets the preprocessor directive `#if NETCOREAPP3_0_OR_GREATER` even though .NET 3.0 is long out of support, I figured I'd target it for specificities sake (seeing as the `NativeLibrary` API was introduce in .NET 3.0), and to lend a hand to the poor souls out there inevitably back-porting the lib to support their legacy apps.