### PR TITLE
Use registered trademark symbol in first mention of Kafka in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Confluent's .NET Client for Apache Kafka<sup>TM</sup>
-=====================================================
+Confluent's .NET Client for Apache Kafka®
+=========================================
 
 [![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-7A5979.svg)](https://launchpass.com/confluentcommunity)
 


### PR DESCRIPTION
What
----
Apache Kafka should be followed by registered trademark symbol, not TM, in first mention

Checklist
------------------
simple README fix, no breaking changes