### PR TITLE
  fix: support multi-certificate PEM bundles in Schema Registry SslCa…

### DIFF
--- a/src/Confluent.SchemaRegistry.Encryption/CachedDekRegistryClient.cs
+++ b/src/Confluent.SchemaRegistry.Encryption/CachedDekRegistryClient.cs
@@ -246,9 +246,9 @@ namespace Confluent.SchemaRegistry.Encryption
             }
 
             var sslCaLocation = config.FirstOrDefault(prop => prop.Key.ToLower() == SchemaRegistryConfig.PropertyNames.SslCaLocation).Value;
-            var sslCaCertificate = string.IsNullOrEmpty(sslCaLocation) ? null : new X509Certificate2(sslCaLocation);
+            var sslCaCertificates = CachedSchemaRegistryClient.LoadCaCertificates(sslCaLocation);
             this.restService = new DekRestService(schemaRegistryUris, timeoutMs, authenticationHeaderValueProvider,
-                    SetSslConfig(config), sslVerify, sslCaCertificate, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs, maxConnectionsPerServer);
+                    SetSslConfig(config), sslVerify, sslCaCertificates, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs, maxConnectionsPerServer);
         }
 
         /// <summary>

--- a/src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs
+++ b/src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs
@@ -30,11 +30,11 @@ namespace Confluent.SchemaRegistry.Encryption
         /// </summary>
         public DekRestService(string schemaRegistryUrl, int timeoutMs,
             IAuthenticationHeaderValueProvider authenticationHeaderValueProvider, List<X509Certificate2> certificates,
-            bool enableSslCertificateVerification, X509Certificate2 sslCaCertificate = null, IWebProxy proxy = null,
+            bool enableSslCertificateVerification, List<X509Certificate2> sslCaCertificates = null, IWebProxy proxy = null,
             int maxRetries = DefaultMaxRetries, int retriesWaitMs = DefaultRetriesWaitMs,
             int retriesMaxWaitMs = DefaultRetriesMaxWaitMs, int maxConnectionsPerServer = DefaultMaxConnectionsPerServer) :
             base(schemaRegistryUrl, timeoutMs, authenticationHeaderValueProvider, certificates,
-                enableSslCertificateVerification, sslCaCertificate, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs, maxConnectionsPerServer)
+                enableSslCertificateVerification, sslCaCertificates, proxy, maxRetries, retriesWaitMs, retriesMaxWaitMs, maxConnectionsPerServer)
         {
         }
 


### PR DESCRIPTION
## Summary                                                                              
                                                                                          
  `SslCaLocation` accepts a path to CA certificate(s), but the implementation only loaded 
  the first certificate from the file using `new X509Certificate2(path)`. This caused SSL 
  validation failures when using PEM files containing a full certificate chain (root CA + 
  intermediate CAs).                     

  The SSL validation callback compared a single root CA hash against
  `chain.ChainElements[1]` (the intermediate CA in the server's chain). Since root CA hash
   ≠ intermediate CA hash, validation always failed for multi-certificate PEM bundles.

  ## Changes

  - Load all certificates from PEM files using
  `X509Certificate2Collection.ImportFromPemFile()` on .NET 5+ and manual PEM parsing on
  older frameworks (netstandard2.0, net462)
  - Update the SSL validation callback to check if **any** certificate in the server's
  chain matches **any** of the trusted CA certificates from the PEM bundle
  - Update `RestService`, `DekRestService`, `CachedSchemaRegistryClient`, and
  `CachedDekRegistryClient` to use `List<X509Certificate2>` instead of a single cert
  - Falls back to single cert loading (e.g. DER format) for backwards compatibility

  ## Files changed

  - `src/Confluent.SchemaRegistry/Rest/RestService.cs`
  - `src/Confluent.SchemaRegistry/CachedSchemaRegistryClient.cs`
  - `src/Confluent.SchemaRegistry.Encryption/Rest/DekRestService.cs`
  - `src/Confluent.SchemaRegistry.Encryption/CachedDekRegistryClient.cs`

  Fixes #2140
  Fixes #2546
