### PR TITLE
Fix DescribeConsumerGroupsAsync null parameter handling

### DIFF
--- a/src/Confluent.Kafka/IAdminClient.cs
+++ b/src/Confluent.Kafka/IAdminClient.cs
@@ -456,12 +456,19 @@ namespace Confluent.Kafka
         ///    Describes consumer groups in the cluster.
         /// </summary>
         /// <param name="groups">
-        ///     The list of groups to describe. This can be set
-        ///     to null to describe all groups.
+        ///     The list of groups to describe. Must contain at
+        ///     least one group. To list all groups, use
+        ///     <see cref="ListConsumerGroupsAsync(ListConsumerGroupsOptions)"/> first.
         /// </param>
         /// <param name="options">
         ///     The options to use while describing consumer groups.
         /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        ///     Thrown if <paramref name="groups"/> is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        ///     Thrown if <paramref name="groups"/> is empty.
+        /// </exception>
         /// <exception cref="Confluent.Kafka.KafkaException">
         ///     Thrown if there is any client-level error.
         /// </exception>

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -2370,8 +2370,15 @@ namespace Confluent.Kafka.Impl
         {
             ThrowIfHandleClosed();
 
-            if (groups.Count() == 0) {
-                throw new ArgumentException("at least one group should be provided to DescribeConsumerGroups");
+            if (groups == null)
+            {
+                throw new ArgumentNullException(nameof(groups));
+            }
+
+            var groupArray = groups as string[] ?? groups.ToArray();
+            if (groupArray.Length == 0)
+            {
+                throw new ArgumentException("At least one group must be provided to DescribeConsumerGroups.", nameof(groups));
             }
 
             var optionsPtr = IntPtr.Zero;
@@ -2386,7 +2393,7 @@ namespace Confluent.Kafka.Impl
 
                 // Call DescribeConsumerGroups (async).
                 Librdkafka.DescribeConsumerGroups(
-                    handle, groups.ToArray(), (UIntPtr)(groups.Count()),
+                    handle, groupArray, (UIntPtr)groupArray.Length,
                     optionsPtr, resultQueuePtr);
             }
             finally


### PR DESCRIPTION
The XML documentation claimed that passing null to the groups parameter would describe all groups, but the implementation threw a NullReferenceException. The underlying librdkafka API requires explicit group names, so this corrects the docs and adds a proper null guard with ArgumentNullException.

Fixes #2152

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
