### PR TITLE
Add missing SaslOauthbearerExtensions to OAuthOIDC example

### DIFF
--- a/examples/OAuthOIDC/Program.cs
+++ b/examples/OAuthOIDC/Program.cs
@@ -37,6 +37,8 @@ namespace Confluent.Kafka.Examples.OAuthOIDC
         private const String OAuthBearerClientSecret = "<oauthbearer_client_secret>";
         private const String OAuthBearerTokenEndpointURL = "<token_endpoint_url>";
         private const String OAuthBearerScope = "<scope>";
+        // Required for Confluent Cloud.
+        private const String OAuthBearerExtensions = "logicalCluster=<lkc-id>,identityPoolId=<pool-id>";
         public static async Task Main(string[] args)
         {
             if (args.Length != 1)
@@ -57,7 +59,8 @@ namespace Confluent.Kafka.Examples.OAuthOIDC
                 SaslOauthbearerClientId = OAuthBearerClientId,
                 SaslOauthbearerClientSecret = OAuthBearerClientSecret,
                 SaslOauthbearerTokenEndpointUrl = OAuthBearerTokenEndpointURL,
-                SaslOauthbearerScope = OAuthBearerScope
+                SaslOauthbearerScope = OAuthBearerScope,
+                SaslOauthbearerExtensions = OAuthBearerExtensions
             };
 
             var consumerConfig = new ConsumerConfig
@@ -70,6 +73,7 @@ namespace Confluent.Kafka.Examples.OAuthOIDC
                 SaslOauthbearerClientSecret = OAuthBearerClientSecret,
                 SaslOauthbearerTokenEndpointUrl = OAuthBearerTokenEndpointURL,
                 SaslOauthbearerScope = OAuthBearerScope,
+                SaslOauthbearerExtensions = OAuthBearerExtensions,
                 GroupId = groupId,
                 AutoOffsetReset = AutoOffsetReset.Earliest,
                 EnableAutoOffsetStore = false


### PR DESCRIPTION
When using OIDC authentication with Confluent Cloud, the logicalCluster and identityPoolId extensions are required but were missing from the example, causing authentication failures.

Fixes #2025

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
