### PR TITLE
Remove FieldContext Stack and instead always pass the current fieldContext

### DIFF
--- a/src/Confluent.SchemaRegistry.Serdes.Avro/AvroUtils.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/AvroUtils.cs
@@ -80,7 +80,7 @@ namespace Confluent.SchemaRegistry.Serdes
             return namedSchemas;
         }
 
-        public static async Task<object> Transform(RuleContext ctx, Avro.Schema schema, object message,
+        public static async Task<object> Transform(RuleContext ctx, RuleContext.FieldContext fieldContext, Avro.Schema schema, object message,
             IFieldTransform fieldTransform)
         {
             if (schema == null || message == null)
@@ -88,7 +88,6 @@ namespace Confluent.SchemaRegistry.Serdes
                 return message;
             }
 
-            RuleContext.FieldContext fieldContext = ctx.CurrentField();
             if (fieldContext != null)
             {
                 fieldContext.Type = GetType(schema);
@@ -101,16 +100,16 @@ namespace Confluent.SchemaRegistry.Serdes
                     writer = GetResolver(schema, message);
                     UnionSchema us = (UnionSchema)schema;
                     int unionIndex = writer.Resolve(us, message);
-                    return await Transform(ctx, us[unionIndex], message, fieldTransform).ConfigureAwait(false);
+                    return await Transform(ctx, fieldContext, us[unionIndex], message, fieldTransform).ConfigureAwait(false);
                 case Avro.Schema.Type.Array:
                     ArraySchema a = (ArraySchema)schema;
                     var arrayTransformer = (int index, object elem) =>
-                        Transform(ctx, a.ItemSchema, elem, fieldTransform);
+                        Transform(ctx, fieldContext, a.ItemSchema, elem, fieldTransform);
                     return await Utils.TransformEnumerableAsync(message, arrayTransformer).ConfigureAwait(false);
                 case Avro.Schema.Type.Map:
                     MapSchema ms = (MapSchema)schema;
                     var mapTransformer = (object key, object value) =>
-                        Transform(ctx, ms.ValueSchema, value, fieldTransform);
+                        Transform(ctx, fieldContext, ms.ValueSchema, value, fieldTransform);
                     return await Utils.TransformDictionaryAsync(message, mapTransformer).ConfigureAwait(false);
                 case Avro.Schema.Type.Record:
                     RecordSchema rs = (RecordSchema)schema;
@@ -133,13 +132,14 @@ namespace Confluent.SchemaRegistry.Serdes
                         }
 
                         string fullName = rs.Fullname + "." + f.Name;
-                        using (ctx.EnterField(message, fullName, f.Name, GetType(originalField.Schema), GetInlineTags(originalField)))
                         {
+                            var newFieldContext = ctx.EnterField(message, fullName, f.Name,
+                                GetType(originalField.Schema), GetInlineTags(originalField));
                             if (message is ISpecificRecord)
                             {
                                 ISpecificRecord specificRecord = (ISpecificRecord)message;
                                 object value = specificRecord.Get(f.Pos);
-                                object newValue = await Transform(ctx, originalField.Schema, value, fieldTransform).ConfigureAwait(false);
+                                object newValue = await Transform(ctx, newFieldContext, originalField.Schema, value, fieldTransform).ConfigureAwait(false);
                                 if (ctx.Rule.Kind == RuleKind.Condition)
                                 {
                                     if (newValue is bool b && !b)
@@ -156,7 +156,7 @@ namespace Confluent.SchemaRegistry.Serdes
                             {
                                 GenericRecord genericRecord = (GenericRecord)message;
                                 object value = genericRecord.GetValue(f.Pos);
-                                object newValue = await Transform(ctx, originalField.Schema, value, fieldTransform).ConfigureAwait(false);
+                                object newValue = await Transform(ctx, newFieldContext, originalField.Schema, value, fieldTransform).ConfigureAwait(false);
                                 if (ctx.Rule.Kind == RuleKind.Condition)
                                 {
                                     if (newValue is bool b && !b)

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/GenericDeserializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/GenericDeserializerImpl.cs
@@ -161,9 +161,9 @@ namespace Confluent.SchemaRegistry.Serdes
                     }
                 }
 
-                FieldTransformer fieldTransformer = async (ctx, transform, message) => 
+                FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) => 
                 {
-                    return await AvroUtils.Transform(ctx, readerSchema, message, transform).ConfigureAwait(false);
+                    return await AvroUtils.Transform(ctx, fieldContext, readerSchema, message, transform).ConfigureAwait(false);
                 };
                 data = await ExecuteRules(isKey, subject, topic, headers, RuleMode.Read,
                         null, readerSchemaJson, data, fieldTransformer)

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/GenericSerializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/GenericSerializerImpl.cs
@@ -165,9 +165,9 @@ namespace Confluent.SchemaRegistry.Serdes
                 if (latestSchema != null)
                 {
                     writerSchema = await GetParsedSchema(latestSchema).ConfigureAwait(false);
-                    FieldTransformer fieldTransformer = async (ctx, transform, message) => 
+                    FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) => 
                     {
-                        return await AvroUtils.Transform(ctx, writerSchema, message, transform).ConfigureAwait(false);
+                        return await AvroUtils.Transform(ctx, fieldContext, writerSchema, message, transform).ConfigureAwait(false);
                     };
                     data = await ExecuteRules(isKey, subject, topic, headers, RuleMode.Write,
                             null, latestSchema, data, fieldTransformer)

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificDeserializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificDeserializerImpl.cs
@@ -216,9 +216,9 @@ namespace Confluent.SchemaRegistry.Serdes
                 Avro.Schema readerSchema = latestSchema != null
                     ? await GetParsedSchema(latestSchema).ConfigureAwait(false)
                     : writerSchema;
-                FieldTransformer fieldTransformer = async (ctx, transform, message) =>
+                FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) =>
                 {
-                    return await AvroUtils.Transform(ctx, readerSchema, message, transform).ConfigureAwait(false);
+                    return await AvroUtils.Transform(ctx, fieldContext, readerSchema, message, transform).ConfigureAwait(false);
                 };
                 data = await ExecuteRules(isKey, subject, topic, headers, RuleMode.Read,
                         null, readerSchemaJson, data, fieldTransformer)

--- a/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Avro/SpecificSerializerImpl.cs
@@ -207,9 +207,9 @@ namespace Confluent.SchemaRegistry.Serdes
                 if (latestSchema != null)
                 {
                     var schema = await GetParsedSchema(latestSchema).ConfigureAwait(false);
-                    FieldTransformer fieldTransformer = async (ctx, transform, message) => 
+                    FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) => 
                     {
-                        return await AvroUtils.Transform(ctx, schema, message, transform).ConfigureAwait(false);
+                        return await AvroUtils.Transform(ctx, fieldContext, schema, message, transform).ConfigureAwait(false);
                     };
                     data = await ExecuteRules(isKey, subject, topic, headers, RuleMode.Write,
                             null, latestSchema, data, fieldTransformer)

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonDeserializer.cs
@@ -284,9 +284,9 @@ namespace Confluent.SchemaRegistry.Serdes
 
                 if (readerSchema != null)
                 {
-                    FieldTransformer fieldTransformer = async (ctx, transform, message) =>
+                    FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) =>
                     {
-                        return await JsonUtils.Transform(ctx, readerSchema, readerSchema, "$", message, transform).ConfigureAwait(false);
+                        return await JsonUtils.Transform(ctx, fieldContext, readerSchema, readerSchema, "$", message, transform).ConfigureAwait(false);
                     };
                     value = await ExecuteRules(context.Component == MessageComponentType.Key,
                             subject, context.Topic, context.Headers, RuleMode.Read,

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonSerializer.cs
@@ -269,9 +269,9 @@ namespace Confluent.SchemaRegistry.Serdes
 
                 if (latestSchema != null)
                 {
-                    FieldTransformer fieldTransformer = async (ctx, transform, message) =>
+                    FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) =>
                     {
-                        return await JsonUtils.Transform(ctx, parsedSchema, parsedSchema, "$", message, transform).ConfigureAwait(false);
+                        return await JsonUtils.Transform(ctx, fieldContext, parsedSchema, parsedSchema, "$", message, transform).ConfigureAwait(false);
                     };
                     value = await ExecuteRules(context.Component == MessageComponentType.Key,
                             subject, context.Topic, context.Headers, RuleMode.Write,

--- a/src/Confluent.SchemaRegistry.Serdes.Json/JsonUtils.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/JsonUtils.cs
@@ -34,13 +34,13 @@ namespace Confluent.SchemaRegistry.Serdes
     /// </summary>
     public static class JsonUtils
     {
-        public static Task<object> Transform(RuleContext ctx, JsonSchema rootSchema, JsonSchema schema, string path, object message,
+        public static Task<object> Transform(RuleContext ctx, RuleContext.FieldContext fieldContext, JsonSchema rootSchema, JsonSchema schema, string path, object message,
             IFieldTransform fieldTransform)
         {
-            return Transform(ctx, rootSchema, schema, path, message, fieldTransform, null);
+            return Transform(ctx, fieldContext, rootSchema, schema, path, message, fieldTransform, null);
         }
 
-        private static async Task<object> Transform(RuleContext ctx, JsonSchema rootSchema, JsonSchema schema, string path, object message,
+        private static async Task<object> Transform(RuleContext ctx, RuleContext.FieldContext fieldContext, JsonSchema rootSchema, JsonSchema schema, string path, object message,
             IFieldTransform fieldTransform, JsonObjectType? typeOverride)
         {
             if (schema == null || message == null)
@@ -51,7 +51,6 @@ namespace Confluent.SchemaRegistry.Serdes
             // Use typeOverride if provided, otherwise use schema.Type (thread-safe read)
             JsonObjectType effectiveType = typeOverride ?? GetSchemaType(rootSchema, schema);
 
-            RuleContext.FieldContext fieldContext = ctx.CurrentField();
             if (fieldContext != null)
             {
                 fieldContext.Type = GetType(effectiveType);
@@ -87,7 +86,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         if (isValid)
                         {
                             // Pass flag as typeOverride - recursive call uses resolved type
-                            return await Transform(ctx, rootSchema, schema, path, message,
+                            return await Transform(ctx, fieldContext, rootSchema, schema, path, message,
                                 fieldTransform, flag).ConfigureAwait(false);
                         }
                     }
@@ -121,7 +120,7 @@ namespace Confluent.SchemaRegistry.Serdes
                     if (isValid)
                     {
                         // New subschema, no type override needed
-                        return await Transform(ctx, rootSchema, subschema, path, message, fieldTransform, null).ConfigureAwait(false);
+                        return await Transform(ctx, fieldContext, rootSchema, subschema, path, message, fieldTransform, null).ConfigureAwait(false);
                     }
                 }
 
@@ -140,7 +139,7 @@ namespace Confluent.SchemaRegistry.Serdes
 
                 JsonSchema subschema = schema.Item;
                 var transformer = (int index, object elem) =>
-                    Transform(ctx, rootSchema, subschema, path + '[' + index + ']', elem, fieldTransform, null);
+                    Transform(ctx, fieldContext, rootSchema,subschema, path + '[' + index + ']', elem, fieldTransform, null);
                 return await Utils.TransformEnumerableAsync(message, transformer).ConfigureAwait(false);
             }
             else if (effectiveType.HasFlag(JsonObjectType.Object) || schema.Properties.Count > 0)
@@ -148,8 +147,9 @@ namespace Confluent.SchemaRegistry.Serdes
                 foreach (var it in schema.Properties)
                 {
                     string fullName = path + '.' + it.Key;
-                    using (ctx.EnterField(message, fullName, it.Key, GetType(rootSchema, it.Value), GetInlineTags(it.Value)))
                     {
+                        var newFieldContext = ctx.EnterField(message, fullName, it.Key, GetType(rootSchema, it.Value),
+                            GetInlineTags(it.Value));
                         FieldAccessor fieldAccessor;
                         try
                         {
@@ -163,7 +163,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         }
                         object value = fieldAccessor.GetFieldValue(message);
                         // New field schema, no type override needed
-                        object newValue = await Transform(ctx, rootSchema, it.Value, fullName, value, fieldTransform, null).ConfigureAwait(false);
+                        object newValue = await Transform(ctx, newFieldContext, rootSchema, it.Value, fullName, value, fieldTransform, null).ConfigureAwait(false);
                         if (ctx.Rule.Kind == RuleKind.Condition)
                         {
                             if (newValue is bool b && !b)
@@ -183,11 +183,10 @@ namespace Confluent.SchemaRegistry.Serdes
             else if (schema.HasReference)
             {
                 // Follow reference, no type override needed
-                return await Transform(ctx, rootSchema, schema.ActualTypeSchema, path, message, fieldTransform, null).ConfigureAwait(false);
+                return await Transform(ctx, fieldContext, rootSchema, schema.ActualTypeSchema, path, message, fieldTransform, null).ConfigureAwait(false);
             }
             else
             {
-                fieldContext = ctx.CurrentField();
                 if (fieldContext != null)
                 {
                     switch (effectiveType)

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufDeserializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufDeserializer.cs
@@ -151,9 +151,9 @@ namespace Confluent.SchemaRegistry.Serdes
 
                 if (writerSchema != null)
                 {
-                    FieldTransformer fieldTransformer = async (ctx, transform, messageToTransform) =>
+                    FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, messageToTransform) =>
                     {
-                        return await ProtobufUtils.Transform(ctx, fdSet, messageToTransform, transform).ConfigureAwait(false);
+                        return await ProtobufUtils.Transform(ctx, fieldContext, fdSet, messageToTransform, transform).ConfigureAwait(false);
                     };
                     message = await ExecuteRules(context.Component == MessageComponentType.Key,
                             subject, context.Topic, context.Headers, RuleMode.Read,

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufSerializer.cs
@@ -274,9 +274,9 @@ namespace Confluent.SchemaRegistry.Serdes
                 if (latestSchema != null)
                 {
                     var fdSet = await GetParsedSchema(latestSchema).ConfigureAwait(false);
-                    FieldTransformer fieldTransformer = async (ctx, transform, message) =>
+                    FieldTransformer fieldTransformer = async (ctx, fieldContext, transform, message) =>
                     {
-                        return await ProtobufUtils.Transform(ctx, fdSet, message, transform).ConfigureAwait(false);
+                        return await ProtobufUtils.Transform(ctx, fieldContext, fdSet, message, transform).ConfigureAwait(false);
                     };
                     value = await ExecuteRules(context.Component == MessageComponentType.Key,
                             subject, context.Topic, context.Headers, RuleMode.Write,

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
@@ -86,7 +86,7 @@ namespace Confluent.SchemaRegistry.Serdes
             }
         }
 
-        internal static async Task<object> Transform(RuleContext ctx, object desc, object message,
+        internal static async Task<object> Transform(RuleContext ctx, RuleContext.FieldContext fieldContext, object desc, object message,
             IFieldTransform fieldTransform)
         {
             if (desc == null || message == null)
@@ -94,7 +94,6 @@ namespace Confluent.SchemaRegistry.Serdes
                 return message;
             }
 
-            RuleContext.FieldContext fieldContext = ctx.CurrentField();
 
             if (typeof(IList).IsAssignableFrom(message.GetType())
                 || (message.GetType().IsGenericType
@@ -102,7 +101,7 @@ namespace Confluent.SchemaRegistry.Serdes
                         || message.GetType().GetGenericTypeDefinition() == typeof(IList<>))))
             {
                 var transformer = (int index, object elem) =>
-                    Transform(ctx, desc, elem, fieldTransform);
+                    Transform(ctx, fieldContext, desc, elem, fieldTransform);
                 return await Utils.TransformEnumerableAsync(message, transformer).ConfigureAwait(false);
             }
             else if (typeof(IDictionary).IsAssignableFrom(message.GetType())
@@ -125,8 +124,9 @@ namespace Confluent.SchemaRegistry.Serdes
                 foreach (FieldDescriptor fd in copy.Descriptor.Fields.InDeclarationOrder())
                 {
                     FieldDescriptorProto schemaFd = FindFieldByName(messageType, fd.Name);
-                    using (ctx.EnterField(copy, fd.FullName, fd.Name, GetType(fd), GetInlineTags(schemaFd)))
                     {
+                        var newFieldContext = ctx.EnterField(copy, fd.FullName, fd.Name, GetType(fd),
+                            GetInlineTags(schemaFd));
                         if (fd.ContainingOneof != null && !fd.Accessor.HasValue(copy)) {
                             // Skip oneof fields that are not set
                             continue;
@@ -139,7 +139,7 @@ namespace Confluent.SchemaRegistry.Serdes
                             d = schemaFd.GetMessageType();
                         }
 
-                        object newValue = await Transform(ctx, d, value, fieldTransform).ConfigureAwait(false);
+                        object newValue = await Transform(ctx, newFieldContext, d, value, fieldTransform).ConfigureAwait(false);
                         if (ctx.Rule.Kind == RuleKind.Condition)
                         {
                             if (newValue is bool b && !b)

--- a/src/Confluent.SchemaRegistry/FieldRuleExecutor.cs
+++ b/src/Confluent.SchemaRegistry/FieldRuleExecutor.cs
@@ -32,7 +32,7 @@ namespace Confluent.SchemaRegistry
         {
             using (IFieldTransform transform = NewTransform(ctx))
             {
-                return await ctx.FieldTransformer.Invoke(ctx, transform, message)
+                return await ctx.FieldTransformer.Invoke(ctx, null, transform, message)
                     .ConfigureAwait(continueOnCapturedContext: false);
             }
         }

--- a/src/Confluent.SchemaRegistry/IFieldTransform.cs
+++ b/src/Confluent.SchemaRegistry/IFieldTransform.cs
@@ -20,7 +20,7 @@ using System.Threading.Tasks;
 
 namespace Confluent.SchemaRegistry
 {
-    public delegate Task<object> FieldTransformer(RuleContext ctx, IFieldTransform fieldTransform, object message);
+    public delegate Task<object> FieldTransformer(RuleContext ctx, RuleContext.FieldContext fieldContext, IFieldTransform fieldTransform, object message);
 
     public interface IFieldTransform : IDisposable
     {

--- a/src/Confluent.SchemaRegistry/RuleContext.cs
+++ b/src/Confluent.SchemaRegistry/RuleContext.cs
@@ -50,7 +50,6 @@ namespace Confluent.SchemaRegistry
         public FieldTransformer FieldTransformer { get; set; }
         public IDictionary<object, object> CustomData { get; } = new Dictionary<object, object>();
 
-        private Stack<FieldContext> fieldContexts = new Stack<FieldContext>();
 
         public RuleContext(string enabledEnv, Schema source, Schema target, string subject, string topic, Headers headers, bool isKey,
             RuleMode ruleMode, Rule rule, int index, IList<Rule> rules, FieldTransformer fieldTransformer)
@@ -100,22 +99,16 @@ namespace Confluent.SchemaRegistry
         }
 
 
-        public FieldContext CurrentField()
-        {
-            return fieldContexts.Count != 0 ? fieldContexts.Peek() : null;
-        }
-
         public FieldContext EnterField(object containingMessage,
             string fullName, string name, Type type, ISet<string> tags)
         {
             ISet<string> allTags = new HashSet<string>(tags);
             allTags.UnionWith(GetTags(fullName));
-            return new FieldContext(this, containingMessage, fullName, name, type, allTags);
+            return new FieldContext(containingMessage, fullName, name, type, allTags);
         }
 
-        public class FieldContext : IDisposable
+        public class FieldContext
         {
-            public RuleContext RuleContext { get; set; }
 
             public object ContainingMessage { get; set; }
 
@@ -127,27 +120,20 @@ namespace Confluent.SchemaRegistry
 
             public ISet<string> Tags { get; set; }
 
-            public FieldContext(RuleContext ruleContext, object containingMessage, string fullName, string name,
+            public FieldContext(object containingMessage, string fullName, string name,
                 Type type, ISet<string> tags)
             {
-                RuleContext = ruleContext;
                 ContainingMessage = containingMessage;
                 FullName = fullName;
                 Name = name;
                 Type = type;
                 Tags = tags;
-                RuleContext.fieldContexts.Push(this);
             }
 
             public bool IsPrimitive()
             {
                 return Type == Type.String || Type == Type.Bytes || Type == Type.Int || Type == Type.Long ||
                        Type == Type.Float || Type == Type.Double || Type == Type.Boolean || Type == Type.Null;
-            }
-
-            public void Dispose()
-            {
-                RuleContext.fieldContexts.Pop();
             }
         }
 


### PR DESCRIPTION


<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Refactor the code so it does not use an IDisposal pattern to pop values of a Stack. Fixes #2607 

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required
    - Code should already be covered by current unit/integration tests (just a refactoring)
    - Regression test not possible as the issue was a design flaw and caused by how .NET handles Dispose internally 

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
