### PR TITLE
INIT-16828 : Drop net6.0, add net10.0 LTS support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -179,7 +179,7 @@ after_pipeline:
       - name: SonarQube
         commands:
           - checkout
-          - mise use dotnet@8
+          - mise use dotnet@10
           - dotnet tool install --tool-path $PWD dotnet-coverage
           - artifact pull workflow unit-coverage.xml || true
           - artifact pull workflow classic-coverage.xml || true

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,8 +23,8 @@ blocks:
       jobs:
         - name: 'Build and test'
           commands:
-            - mise use dotnet@6
             - mise use dotnet@8
+            - mise use dotnet@10
             - dotnet tool install --tool-path $PWD dotnet-coverage
             - dotnet restore
             - make build
@@ -42,13 +42,14 @@ blocks:
           commands:
             - ulimit -n 1024
             - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --install-dir ~/Applications/dotnet
+            - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 10.0 --install-dir ~/Applications/dotnet
             - export DOTNET_ROOT=~/Applications/dotnet
             - export PATH=~/Applications/dotnet:$PATH
             - export DOTNET_MULTILEVEL_LOOKUP=0
             - which dotnet
             - dotnet --version
             - dotnet --list-sdks
-            - dotnet restore -p:TargetFramework=net8.0
+            - dotnet restore -p:TargetFramework=net10.0
             - make test-latest  
   - name: 'Windows x64'
     dependencies: [ ]
@@ -61,11 +62,12 @@ blocks:
           commands:
             - wget https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
             - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 8.0 -Quality GA -InstallDir C:\dotnet
+            - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 10.0 -Quality GA -InstallDir C:\dotnet
             - $Env:Path += ";C:\dotnet"
             - dotnet restore
-            - dotnet test -f net8.0 -c ${CONFIGURATION} --no-build test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
-            - dotnet test -f net8.0 -c ${CONFIGURATION} --no-build test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
-            - dotnet test -f net8.0 -c ${CONFIGURATION} --no-build test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
+            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
   - name: 'Windows Artifacts on untagged commits'
     run:
       when: "tag !~ '.*'"
@@ -79,8 +81,8 @@ blocks:
         - name: 'Build and push artifacts'
           commands:
             - wget https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-            - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 6.0 -Quality GA -InstallDir C:\dotnet
             - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 8.0 -Quality GA -InstallDir C:\dotnet
+            - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 10.0 -Quality GA -InstallDir C:\dotnet
             - $Env:Path += ";C:\dotnet"
             - dotnet restore
             - dotnet build Confluent.Kafka.sln -c ${Env:CONFIGURATION}
@@ -109,8 +111,8 @@ blocks:
         - name: 'Build and push artifacts'
           commands:
             - wget https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-            - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 6.0 -Quality GA -InstallDir C:\dotnet
             - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 8.0 -Quality GA -InstallDir C:\dotnet
+            - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 10.0 -Quality GA -InstallDir C:\dotnet
             - $Env:Path += ";C:\dotnet"
             - dotnet restore
             - dotnet build Confluent.Kafka.sln -c ${Env:CONFIGURATION}
@@ -135,7 +137,7 @@ blocks:
       prologue:
         commands:
           - '[[ -z $DOCKERHUB_APIKEY ]] || docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY'
-          - mise use dotnet@8
+          - mise use dotnet@10
           - dotnet tool install --tool-path $PWD dotnet-coverage
           - export DOTNET_COVERAGE_TOOL=$PWD/dotnet-coverage
       jobs:
@@ -147,8 +149,8 @@ blocks:
           commands:
             - cd test/docker && docker-compose up -d && sleep 30 && cd ../..
             - export SEMAPHORE_SKIP_FLAKY_TESTS='true'
-            - dotnet restore -p:TargetFramework=net8.0
-            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net8.0 -l "console;verbosity=normal"' -f xml -o ../../classic-coverage.xml && cd ../..
+            - dotnet restore -p:TargetFramework=net10.0
+            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../classic-coverage.xml && cd ../..
             - artifact push workflow classic-coverage.xml || true
         - name: 'Build and test with "consumer" protocol'
           commands:
@@ -156,16 +158,16 @@ blocks:
             - sleep 300
             - export SEMAPHORE_SKIP_FLAKY_TESTS='true'
             - export TEST_CONSUMER_GROUP_PROTOCOL=consumer
-            - dotnet restore -p:TargetFramework=net8.0
-            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net8.0 -l "console;verbosity=normal"' -f xml -o ../../consumer-coverage.xml && cd ../..
+            - dotnet restore -p:TargetFramework=net10.0
+            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../consumer-coverage.xml && cd ../..
             - artifact push workflow consumer-coverage.xml || true
         - name: 'Schema registry and serdes integration tests'
           commands:
             - cd test/docker && docker-compose up -d && cd ../..
             - export SEMAPHORE_SKIP_FLAKY_TESTS='true'
-            - dotnet restore -p:TargetFramework=net8.0
-            - cd test/Confluent.SchemaRegistry.Serdes.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net8.0 -l "console;verbosity=normal"' -f xml -o ../../sr-target/serdes-coverage.xml && cd ../..
-            - cd test/Confluent.SchemaRegistry.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net8.0 -l "console;verbosity=normal"' -f xml -o ../../sr-target/coverage.xml && cd ../..
+            - dotnet restore -p:TargetFramework=net10.0
+            - cd test/Confluent.SchemaRegistry.Serdes.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../sr-target/serdes-coverage.xml && cd ../..
+            - cd test/Confluent.SchemaRegistry.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../sr-target/coverage.xml && cd ../..
             - artifact push workflow sr-target || true
 
 after_pipeline:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Ensure you're not calling `StoreOffset` with an EOF message.
 As when calling `Commit` with an EOF message, it will throw an `InvalidOperationException`.
 Previously this could cause skipping an offset (<2.1.0) or message reprocessing (>=2.1.0).
 
+## Enhancements
+
+* Added support for .NET 10 (LTS) and dropped support for .NET 6 (end of support since November 2024). The library now multi-targets `net8.0` and `net10.0` alongside `netstandard2.0` and `net462`. Builds on the approach proposed in #2545 by @ffernandolima, adapted for the centralized `Directory.Build.props` structure on current master.
+
 ## Fixes
 
 * Throw an `InvalidOperationException` when calling `StoreOffset` with an EOF consume result, to match `Commit` behavior (#2621)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_DIRS=$(shell find ./test -name '*.csproj' -exec dirname {} \;)
 UNIT_TEST_DIRS=$(shell find . -type d -regex '.*UnitTests$$' -exec basename {} \;)
 
 # We want to run tests by default with latest version of .NET
-DEFAULT_TEST_FRAMEWORK?=net8.0
+DEFAULT_TEST_FRAMEWORK?=net10.0
 
 all:
 	@echo "Usage:   make <dotnet-command>"

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ client. Thanks Andreas!
 
 confluent-kafka-dotnet is distributed via NuGet. We provide the following  packages:
 
-- [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) *[netstandard2.0, net462, net6.0, net8.0]* - The core client library.
-- [Confluent.SchemaRegistry.Serdes.Avro](https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes.Avro/) *[netstandard2.0, net6.0, net8.0]* - Provides a serializer and deserializer for working with Avro serialized data with Confluent Schema Registry integration.
-- [Confluent.SchemaRegistry.Serdes.Protobuf](https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes.Protobuf/) *[netstandard2.0, net6.0, net8.0]* - Provides a serializer and deserializer for working with Protobuf serialized data with Confluent Schema Registry integration.
-- [Confluent.SchemaRegistry.Serdes.Json](https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes.Json/) *[netstandard2.0, net6.0, net8.0]* - Provides a serializer and deserializer for working with Json serialized data with Confluent Schema Registry integration.
-- [Confluent.SchemaRegistry](https://www.nuget.org/packages/Confluent.SchemaRegistry/) *[netstandard2.0, net6.0, net8.0]* - Confluent Schema Registry client (a dependency of the Confluent.SchemaRegistry.Serdes packages).
-- [Confluent.SchemaRegistry.Encryption](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption/) *[net6.0, net8.0]* - Confluent Schema Registry client-side field-level encryption client (a dependency of the other Confluent.SchemaRegistry.Encryption.* packages).
-- [Confluent.SchemaRegistry.Encryption.Aws](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.Aws/) *[net6.0, net8.0]* - Confluent Schema Registry client-side field-level encryption client for AWS KMS.
-- [Confluent.SchemaRegistry.Encryption.Azure](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.Azure/) *[net6.0, net8.0]* - Confluent Schema Registry client-side field-level encryption client for Azure Key Vault.
-- [Confluent.SchemaRegistry.Encryption.Gcp](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.Gcp/) *[net6.0, net8.0]* - Confluent Schema Registry client-side field-level encryption client for Google Cloud KMS.
-- [Confluent.SchemaRegistry.Encryption.HcVault](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.HcVault/) *[net6.0, net8.0]* - Confluent Schema Registry client-side field-level encryption client for Hashicorp Vault.
-- [Confluent.SchemaRegistry.Rules](https://www.nuget.org/packages/Confluent.SchemaRegistry.Rules/) *[net6.0, net8.0]* - Confluent Schema Registry client-side support for data quality rules (via the Common Expression Language) and schema migration rules (via JSONata).
+- [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) *[netstandard2.0, net462, net8.0, net10.0]* - The core client library.
+- [Confluent.SchemaRegistry.Serdes.Avro](https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes.Avro/) *[netstandard2.0, net8.0, net10.0]* - Provides a serializer and deserializer for working with Avro serialized data with Confluent Schema Registry integration.
+- [Confluent.SchemaRegistry.Serdes.Protobuf](https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes.Protobuf/) *[netstandard2.0, net8.0, net10.0]* - Provides a serializer and deserializer for working with Protobuf serialized data with Confluent Schema Registry integration.
+- [Confluent.SchemaRegistry.Serdes.Json](https://www.nuget.org/packages/Confluent.SchemaRegistry.Serdes.Json/) *[netstandard2.0, net8.0, net10.0]* - Provides a serializer and deserializer for working with Json serialized data with Confluent Schema Registry integration.
+- [Confluent.SchemaRegistry](https://www.nuget.org/packages/Confluent.SchemaRegistry/) *[netstandard2.0, net8.0, net10.0]* - Confluent Schema Registry client (a dependency of the Confluent.SchemaRegistry.Serdes packages).
+- [Confluent.SchemaRegistry.Encryption](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption/) *[net8.0, net10.0]* - Confluent Schema Registry client-side field-level encryption client (a dependency of the other Confluent.SchemaRegistry.Encryption.* packages).
+- [Confluent.SchemaRegistry.Encryption.Aws](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.Aws/) *[net8.0, net10.0]* - Confluent Schema Registry client-side field-level encryption client for AWS KMS.
+- [Confluent.SchemaRegistry.Encryption.Azure](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.Azure/) *[net8.0, net10.0]* - Confluent Schema Registry client-side field-level encryption client for Azure Key Vault.
+- [Confluent.SchemaRegistry.Encryption.Gcp](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.Gcp/) *[net8.0, net10.0]* - Confluent Schema Registry client-side field-level encryption client for Google Cloud KMS.
+- [Confluent.SchemaRegistry.Encryption.HcVault](https://www.nuget.org/packages/Confluent.SchemaRegistry.Encryption.HcVault/) *[net8.0, net10.0]* - Confluent Schema Registry client-side field-level encryption client for Hashicorp Vault.
+- [Confluent.SchemaRegistry.Rules](https://www.nuget.org/packages/Confluent.SchemaRegistry.Rules/) *[net8.0, net10.0]* - Confluent Schema Registry client-side support for data quality rules (via the Common Expression Language) and schema migration rules (via JSONata).
 
 To install Confluent.Kafka from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ configuration:
 - Release
 
 install:
+- ps: Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+- ps: .\dotnet-install.ps1 -Channel 10.0 -InstallDir "$env:ProgramFiles\dotnet"
 - cinst docfx -y
 
 environment:

--- a/doc/docfx.json
+++ b/doc/docfx.json
@@ -12,7 +12,7 @@
       ],
       "dest": "api",
       "properties": {
-              "TargetFramework": "net6.0"
+              "TargetFramework": "net10.0"
       }
     }
   ],

--- a/examples/Configuration/Configuration.csproj
+++ b/examples/Configuration/Configuration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Configuration</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/Configuration/Configuration.csproj
+++ b/examples/Configuration/Configuration.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>Configuration</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="../Directory.Build.props"/>

--- a/examples/JsonWithReferences/JsonWithReferences.csproj
+++ b/examples/JsonWithReferences/JsonWithReferences.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>JsonWithReferences</AssemblyName>
 
     <!-- Temporary: Direct target framework reference required due to NJsonSchema dependencies -->
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/JsonWithReferences/JsonWithReferences.csproj
+++ b/examples/JsonWithReferences/JsonWithReferences.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>JsonWithReferences</AssemblyName>
-
-    <!-- Temporary: Direct target framework reference required due to NJsonSchema dependencies -->
-    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>MultiProducer</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>MultiProducer</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/OAuthConsumer/OAuthConsumer.csproj
+++ b/examples/OAuthConsumer/OAuthConsumer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthConsumer</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/OAuthConsumer/OAuthConsumer.csproj
+++ b/examples/OAuthConsumer/OAuthConsumer.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthConsumer</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/OAuthOIDC/OAuthOIDC.csproj
+++ b/examples/OAuthOIDC/OAuthOIDC.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthOIDC</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/OAuthOIDC/OAuthOIDC.csproj
+++ b/examples/OAuthOIDC/OAuthOIDC.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthOIDC</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
+++ b/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthOIDCAzureIMDS</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
+++ b/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>OAuthOIDCAzureIMDS</AssemblyName>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
+++ b/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthOIDCAzureIMDS</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/OAuthProducer/OAuthProducer.csproj
+++ b/examples/OAuthProducer/OAuthProducer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthProducer</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/OAuthProducer/OAuthProducer.csproj
+++ b/examples/OAuthProducer/OAuthProducer.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>OAuthProducer</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SchemaRegistryOAuth/SchemaRegistryOAuth.csproj
+++ b/examples/SchemaRegistryOAuth/SchemaRegistryOAuth.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/SchemaRegistryOAuth/SchemaRegistryOAuth.csproj
+++ b/examples/SchemaRegistryOAuth/SchemaRegistryOAuth.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/SchemaRegistryOAuthAzureIMDS/SchemaRegistryOAuthAzureIMDS.csproj
+++ b/examples/SchemaRegistryOAuthAzureIMDS/SchemaRegistryOAuthAzureIMDS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/SchemaRegistryOAuthAzureIMDS/SchemaRegistryOAuthAzureIMDS.csproj
+++ b/examples/SchemaRegistryOAuthAzureIMDS/SchemaRegistryOAuthAzureIMDS.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/TlsAuth/TlsAuth.csproj
+++ b/examples/TlsAuth/TlsAuth.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>TlsAuth</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/TlsAuth/TlsAuth.csproj
+++ b/examples/TlsAuth/TlsAuth.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyName>TlsAuth</AssemblyName>
-    <TargetFramework>net10.0</TargetFramework>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Web/Web.csproj
+++ b/examples/Web/Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Web/Web.csproj
+++ b/examples/Web/Web.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />

--- a/src/Confluent.SchemaRegistry.Encryption/Vendored/README.md
+++ b/src/Confluent.SchemaRegistry.Encryption/Vendored/README.md
@@ -43,7 +43,7 @@ The `Confluent.SchemaRegistry.Encryption` project requires all dependencies to b
   - Changed namespace from `HkdfStandard` to `Confluent.SchemaRegistry.Encryption.Vendored.HkdfStandard`
   - **Simplified implementation**: The original library had complex conditional compilation for different .NET versions and Span<T> support. Since the Confluent.SchemaRegistry.Encryption project only uses the `Hkdf.DeriveKey()` method, a simplified implementation was created that:
     - Implements only the `DeriveKey()` method
-    - Works across all target frameworks (netstandard2.1, net462, net6.0, net8.0)
+    - Works across all supported target frameworks
     - Uses standard byte[] arrays instead of Span<T> for compatibility
     - Maintains full RFC 5869 compliance for the DeriveKey operation
 

--- a/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
+++ b/src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj
@@ -22,10 +22,10 @@
     <AssemblyOriginatorKeyFile>Confluent.SchemaRegistry.Serdes.Json.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' And '$(TargetFramework)' != 'net10.0' ">
     <PackageReference Include="NJsonSchema" Version="10.9.0" />
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.14.2</VersionPrefix>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="../Directory.Build.props"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="../Directory.Build.props"/>


### PR DESCRIPTION
---
What
----

Drop support for .NET 6 (end-of-life since November 2024) and add support for .NET 10 (the new LTS, supported through November 2028). The library now multi-targets `net8.0` and `net10.0` alongside the existing `netstandard2.0` and `net462`. `net8.0` is kept until its EOL on November 10, 2026.

The change is mostly mechanical . Highlights:

- `src/Directory.Build.props` and `test/Directory.Build.props` centrally flip the TFM list from `net6.0;net8.0` to `net8.0;net10.0`. This cascades to every library and test project.
- `src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj` extends a target-framework-conditional `PackageReference` so `NJsonSchema.NewtonsoftJson` v11 is loaded on both `net8.0` and `net10.0` (previously only `net8.0`). Without this, three source files in the Json serdes fail to compile on `net10.0`. **This is the only non-mechanical change.**
- All example projects (single-target) are bumped from `net8.0` to `net10.0`. One drive-by: `examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj` had `<LangVersion>7.1</LangVersion>` lingering — bumped to `latest` to match the rest of the examples cleaned up earlier.
- `Makefile` defaults `DEFAULT_TEST_FRAMEWORK` to `net10.0`.
- `appveyor.yml` installs the .NET 10 SDK explicitly via `dotnet-install.ps1` (the AppVeyor "Visual Studio 2022" image does not yet ship it).
- `README.md` and `CHANGELOG.md` updated.

**No `.cs` source files are touched.** Existing `#if NET6_0_OR_GREATER` shims work unchanged on `net10.0`.

Builds on the approach proposed in [#2545](https://github.com/confluentinc/confluent-kafka-dotnet/pull/2545) by @ffernandolima — credit to him for the original effort and for the `LangVersion=latest` idea. This PR adapts the approach to the centralized `Directory.Build.props` structure on current master (#2545 predates that refactor and now conflicts with it) and fills in the missing `Makefile` / `appveyor.yml` / `README` / `CHANGELOG` updates.

Checklist
---------

- [x] Contains customer facing changes? Including API/behavior changes
  - **Yes**: consumers on `.NET 6` will not pick up future versions of these packages. `net6.0` is already past end-of-support, so consumers should already be migrating. No public API or behavior changes for consumers on supported TFMs (`net8.0`, `netstandard2.0`, `net462`, and now `net10.0`).
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - No new tests added. The existing unit + integration suites are TFM-parameterized and exercise both `net8.0` and `net10.0` automatically. 583 of 584 tests pass locally on `net10.0` (1 skip is pre-existing). 

References
----------

JIRA:
https://confluentinc.atlassian.net/browse/INIT-16828


Test & Review
-------------

**Local validation** (macOS arm64, .NET 10 SDK 10.0.202, Kafka + Schema Registry 7.9.0 via `test/docker/docker-compose.yaml`):

| Suite | Target | Result |
|---|---|---|
| Confluent.Kafka.UnitTests | net10.0 | 210 / 210 passed |
| Confluent.SchemaRegistry.UnitTests | net10.0 | 92 / 92 passed |
| Confluent.SchemaRegistry.Serdes.UnitTests | net10.0 | 133 / 133 passed |
| Confluent.Kafka.IntegrationTests | net10.0 | 98 / 99 passed (1 pre-existing skip) — 21m 41s |
| Confluent.SchemaRegistry.IntegrationTests | net10.0 | 19 / 19 passed |
| Confluent.SchemaRegistry.Serdes.IntegrationTests | net10.0 | 31 / 31 passed |
| `Confluent.Kafka` library compile | net8.0 | builds clean (0 warnings) |
| All 11 example projects | net10.0 | each builds clean |

**Aggregate: 583 / 584 passing on `net10.0`, 0 failures.**

**To reproduce locally:**
```bash
# 1. Install .NET 10 SDK (macOS)
brew install --cask dotnet-sdk

# 2. Bring up Kafka + Schema Registry
cd test/docker && docker compose up -d

# 3. Run unit tests
make test-latest                                 # defaults to net10.0 after this PR

# 4. Run integration tests
dotnet test -f net10.0 test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
dotnet test -f net10.0 test/Confluent.SchemaRegistry.IntegrationTests/Confluent.SchemaRegistry.IntegrationTests.csproj
dotnet test -f net10.0 test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj

Verifying both TFMs are produced after a clean build of src/Confluent.Kafka/Confluent.Kafka.csproj, bin/Debug/ contains exactly net8.0/, net10.0/, net462/, netstandard2.0/ — no net6.0/.



---