### PR TITLE
v2.14.2-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-# 2.x.0
+# 2.14.2
+
+## Enhancements
+
+* References librdkafka.redist 2.14.2. Refer to the [librdkafka v2.14.2 release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.2) for more information.
+* Add IHeader overload to Headers.Add() method (#2604)
 
 ## Fixes
 
 * Handle anyOf/allOf in JSON transforms (#2611)
 * Allow encrypting enum for JObject in dotnet (#2615)
+* Fix 'occured' -> 'occurred' typo in ConsumeException XML doc comments (#2609)
 
 
 # 2.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * Fix 'occured' -> 'occurred' typo in ConsumeException XML doc comments (#2609)
 
 
+# 2.14.1
+
+There was no 2.14.1 release of the .NET Client.
+
+
 # 2.14.0
 
 ## Enhancements

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ confluent-kafka-dotnet is distributed via NuGet. We provide the following  packa
 To install Confluent.Kafka from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
 
 ```
-Install-Package Confluent.Kafka -Version 2.14.2-RC1
+Install-Package Confluent.Kafka -Version 2.14.0
 ```
 
 To add a reference to a dotnet core project, execute the following at the command line:
 
 ```
-dotnet add package -v 2.14.2-RC1 Confluent.Kafka
+dotnet add package -v 2.14.0 Confluent.Kafka
 ```
 
 Note: `Confluent.Kafka` depends on the `librdkafka.redist` package which provides a number of different builds of `librdkafka` that are compatible with [common platforms](https://github.com/edenhill/librdkafka/wiki/librdkafka.redist-NuGet-package-runtime-libraries). If you are on one of these platforms this will all work seamlessly (and you don't need to explicitly reference `librdkafka.redist`). If you are on a different platform, you may need to [build librdkafka](https://github.com/edenhill/librdkafka#building) manually (or acquire it via other means) and load it using the [Library.Load](https://docs.confluent.io/current/clients/confluent-kafka-dotnet/api/Confluent.Kafka.Library.html#Confluent_Kafka_Library_Load_System_String_) method.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ confluent-kafka-dotnet is distributed via NuGet. We provide the following  packa
 To install Confluent.Kafka from within Visual Studio, search for Confluent.Kafka in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
 
 ```
-Install-Package Confluent.Kafka -Version 2.14.0
+Install-Package Confluent.Kafka -Version 2.14.2-RC1
 ```
 
 To add a reference to a dotnet core project, execute the following at the command line:
 
 ```
-dotnet add package -v 2.14.0 Confluent.Kafka
+dotnet add package -v 2.14.2-RC1 Confluent.Kafka
 ```
 
 Note: `Confluent.Kafka` depends on the `librdkafka.redist` package which provides a number of different builds of `librdkafka` that are compatible with [common platforms](https://github.com/edenhill/librdkafka/wiki/librdkafka.redist-NuGet-package-runtime-libraries). If you are on one of these platforms this will all work seamlessly (and you don't need to explicitly reference `librdkafka.redist`). If you are on a different platform, you may need to [build librdkafka](https://github.com/edenhill/librdkafka#building) manually (or acquire it via other means) and load it using the [Library.Load](https://docs.confluent.io/current/clients/confluent-kafka-dotnet/api/Confluent.Kafka.Library.html#Confluent_Kafka_Library_Load_System_String_) method.

--- a/examples/AdminClient/AdminClient.csproj
+++ b/examples/AdminClient/AdminClient.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/AvroBlogExamples/AvroBlogExamples.csproj
+++ b/examples/AvroBlogExamples/AvroBlogExamples.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
   </ItemGroup>
 

--- a/examples/AvroGenericEncryption/AvroGenericEncryption.csproj
+++ b/examples/AvroGenericEncryption/AvroGenericEncryption.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Aws/Confluent.SchemaRegistry.Encryption.Aws.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj" />

--- a/examples/AvroGenericMigration/AvroGenericMigration.csproj
+++ b/examples/AvroGenericMigration/AvroGenericMigration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Rules/Confluent.SchemaRegistry.Rules.csproj" />
   </ItemGroup>

--- a/examples/AvroSpecific/AvroSpecific.csproj
+++ b/examples/AvroSpecific/AvroSpecific.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
   </ItemGroup>
 

--- a/examples/AvroSpecificEncryption/AvroSpecificEncryption.csproj
+++ b/examples/AvroSpecificEncryption/AvroSpecificEncryption.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Avro/Confluent.SchemaRegistry.Serdes.Avro.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Aws/Confluent.SchemaRegistry.Encryption.Aws.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj" />

--- a/examples/Configuration/Configuration.csproj
+++ b/examples/Configuration/Configuration.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/examples/ConfluentCloud/ConfluentCloud.csproj
+++ b/examples/ConfluentCloud/ConfluentCloud.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Consumer/Consumer.csproj
+++ b/examples/Consumer/Consumer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/ExactlyOnce/ExactlyOnce.csproj
+++ b/examples/ExactlyOnce/ExactlyOnce.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
     <PackageReference Include="Microsoft.FASTER.Core" Version="1.8.0" />
   </ItemGroup>

--- a/examples/ExactlyOnceOldBroker/ExactlyOnceOldBroker.csproj
+++ b/examples/ExactlyOnceOldBroker/ExactlyOnceOldBroker.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
     <PackageReference Include="RocksDbNative" Version="6.2.2" />

--- a/examples/JsonEncryption/JsonSerializationEncryption.csproj
+++ b/examples/JsonEncryption/JsonSerializationEncryption.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Aws/Confluent.SchemaRegistry.Encryption.Aws.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj" />

--- a/examples/JsonSerialization/JsonSerialization.csproj
+++ b/examples/JsonSerialization/JsonSerialization.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj" />
   </ItemGroup>
 

--- a/examples/JsonWithReferences/JsonWithReferences.csproj
+++ b/examples/JsonWithReferences/JsonWithReferences.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Json/Confluent.SchemaRegistry.Serdes.Json.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry/Confluent.SchemaRegistry.csproj" />
   </ItemGroup>

--- a/examples/MultiProducer/MultiProducer.csproj
+++ b/examples/MultiProducer/MultiProducer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/OAuthConsumer/OAuthConsumer.csproj
+++ b/examples/OAuthConsumer/OAuthConsumer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/OAuthOIDC/OAuthOIDC.csproj
+++ b/examples/OAuthOIDC/OAuthOIDC.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
+++ b/examples/OAuthOIDCAzureIMDS/OAuthOIDCAzureIMDS.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/OAuthProducer/OAuthProducer.csproj
+++ b/examples/OAuthProducer/OAuthProducer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Producer/Producer.csproj
+++ b/examples/Producer/Producer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Protobuf/Protobuf.csproj
+++ b/examples/Protobuf/Protobuf.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj" />
   </ItemGroup>
 

--- a/examples/ProtobufEncryption/ProtobufEncryption.csproj
+++ b/examples/ProtobufEncryption/ProtobufEncryption.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Serdes.Protobuf/Confluent.SchemaRegistry.Serdes.Protobuf.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Aws/Confluent.SchemaRegistry.Encryption.Aws.csproj" />
     <ProjectReference Include="../../src/Confluent.SchemaRegistry.Encryption.Azure/Confluent.SchemaRegistry.Encryption.Azure.csproj" />

--- a/examples/SchemaRegistryOAuth/SchemaRegistryOAuth.csproj
+++ b/examples/SchemaRegistryOAuth/SchemaRegistryOAuth.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-      <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry" Version="2.14.0" /> -->
+      <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry" Version="2.14.2-RC1" /> -->
       <ProjectReference Include="..\..\src\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
     </ItemGroup>
 

--- a/examples/SchemaRegistryOAuthAzureIMDS/SchemaRegistryOAuthAzureIMDS.csproj
+++ b/examples/SchemaRegistryOAuthAzureIMDS/SchemaRegistryOAuthAzureIMDS.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.SchemaRegistry" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="..\..\src\Confluent.SchemaRegistry\Confluent.SchemaRegistry.csproj" />
   </ItemGroup>
 

--- a/examples/TlsAuth/TlsAuth.csproj
+++ b/examples/TlsAuth/TlsAuth.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/examples/Web/Web.csproj
+++ b/examples/Web/Web.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.0" /> -->
+    <!-- nuget package reference: <PackageReference Include="Confluent.Kafka" Version="2.14.2-RC1" /> -->
     <ProjectReference Include="../../src/Confluent.Kafka/Confluent.Kafka.csproj" />
   </ItemGroup>
 

--- a/src/Confluent.Kafka/Config_gen.cs
+++ b/src/Confluent.Kafka/Config_gen.cs
@@ -1,4 +1,4 @@
-// *** Auto-generated from librdkafka v2.14.0 *** - do not modify manually.
+// *** Auto-generated from librdkafka v2.14.2-RC3 *** - do not modify manually.
 //
 // Copyright 2018-2022 Confluent Inc.
 //

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="2.14.0">
+    <PackageReference Include="librdkafka.redist" Version="2.14.2-RC3">
       <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.14.0</VersionPrefix>
+    <VersionPrefix>2.14.2-RC1</VersionPrefix>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Release v2.14.2-RC1.

References `librdkafka.redist` 2.14.2-RC3. The csproj pin will be re-bumped to `librdkafka.redist` 2.14.2 in the follow-up final-release PR once librdkafka v2.14.2 final ships to NuGet.

Mirrors the file scope of #2600 (v2.14.0-RC1).

Changelog entries: see CHANGELOG.md (#2604, #2609, #2611, #2615 + librdkafka.redist 2.14.2 reference).