### PR TITLE
fix(service.yml): set sonarqube.languages

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -16,5 +16,7 @@ semaphore:
     - global_job_config
 sonarqube:
   enable: true
+  languages:
+    - cs
   scanner_config:
     sonar.cs.vscoveragexml.reportsPaths: "**/*coverage.xml"


### PR DESCRIPTION
## Why
The cc-service-bot nightly run ([job 7c09131f](https://semaphore.ci.confluent.io/jobs/7c09131f-626d-46e1-94dd-bda46c23e361), 2026-05-28) failed for this repo:

> Invalid service-bot manifest for 'sonarqube.languages': You must either set 'lang' at the top level of your service.yaml or 'languages' in the 'sonarqube' block.

This repo has `lang: unknown` and enables sonarqube without specifying scan languages.

## Change
Set `sonarqube.languages` to the repo's primary language (derived from the repo's GitHub language statistics).

## Safety
Draft PR for the owning team to review — please confirm the scan language(s) are correct for this repo. Part of a sweep fixing the service-bot nightly; systemic regressions affecting ~262 other repos are fixed in confluentinc/cc-service-bot#2030.
