### PR TITLE
Throw InvalidOperationException when storing an EOF result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 Ensure you're not calling `StoreOffset` with an EOF message.
 As when calling `Commit` with an EOF message, it will throw an `InvalidOperationException`.
-Without an exception it can cause skipping an offset (<2.1.0) or message reprocessing (>=2.1.0).
+Previously this could cause skipping an offset (<2.1.0) or message reprocessing (>=2.1.0).
 
 ## Fixes
 
-* Storing an EOF message throws an `InvalidOperationException` as when committing it (#)
+* Throw an `InvalidOperationException` when calling `StoreOffset` with an EOF consume result, to match `Commit` behavior (#2621)
 
 
 # 2.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Unreleased
+
+## Upgrade considerations
+
+Ensure you're not calling `StoreOffset` with an EOF message.
+As when calling `Commit` with an EOF message, it will throw an `InvalidOperationException`.
+Without an exception it can cause skipping an offset (<2.1.0) or message reprocessing (>=2.1.0).
+
+## Fixes
+
+* Storing an EOF message throws an `InvalidOperationException` as when committing it (#)
+
+
 # 2.14.2
 
 ## Enhancements

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -454,8 +454,14 @@ namespace Confluent.Kafka
 
         /// <inheritdoc/>
         public void StoreOffset(ConsumeResult<TKey, TValue> result)
-            => StoreOffset(new TopicPartitionOffset(result.TopicPartition,
-                    result.Offset + 1, result.LeaderEpoch));
+        {
+            if (result.Message == null)
+            {
+                throw new InvalidOperationException("Attempt was made to store offset corresponding to an empty consume result");
+            }
+            StoreOffset(new TopicPartitionOffset(result.TopicPartition,
+                result.Offset + 1, result.LeaderEpoch));
+        }
 
 
         /// <inheritdoc/>

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -325,7 +325,7 @@ namespace Confluent.Kafka
         ///     the topic/partition/offset of a consume result.
         ///
         ///     EOF messages must not be stored as they are control messages and
-        ///     have and an invalid leader epoch, it's throwing an InvalidOperationException
+        ///     have an invalid leader epoch, it's throwing an InvalidOperationException
         ///     in that case.
         ///
         ///     The offset will be committed according to
@@ -426,7 +426,7 @@ namespace Confluent.Kafka
         ///     topic/partition/offset of a ConsumeResult.
         ///
         ///     EOF messages must not be committed as they are control messages and
-        ///     have and an invalid leader epoch, it's throwing an InvalidOperationException
+        ///     have an invalid leader epoch, it's throwing an InvalidOperationException
         ///     in that case.
         /// </summary>
         /// <param name="result">

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -325,7 +325,7 @@ namespace Confluent.Kafka
         ///     the topic/partition/offset of a consume result.
         ///
         ///     EOF messages must not be stored as they are control messages and
-        ///     have an invalid leader epoch, it's throwing an InvalidOperationException
+        ///     have an invalid leader epoch. This method throws an `InvalidOperationException`
         ///     in that case.
         ///
         ///     The offset will be committed according to
@@ -336,8 +336,7 @@ namespace Confluent.Kafka
         /// <remarks>
         ///     `enable.auto.offset.store` must be set to
         ///     "false" when using this API.
-        /// </remarks>
-        /// <remarks>
+        ///
         ///     A consumer at position N has consumed
         ///     messages with offsets up to N-1 and will
         ///     next receive the message with offset N.
@@ -426,7 +425,7 @@ namespace Confluent.Kafka
         ///     topic/partition/offset of a ConsumeResult.
         ///
         ///     EOF messages must not be committed as they are control messages and
-        ///     have an invalid leader epoch, it's throwing an InvalidOperationException
+        ///     have an invalid leader epoch. This method throws an `InvalidOperationException`
         ///     in that case.
         /// </summary>
         /// <param name="result">

--- a/src/Confluent.Kafka/IConsumer.cs
+++ b/src/Confluent.Kafka/IConsumer.cs
@@ -323,7 +323,11 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Store offsets for a single partition based on
         ///     the topic/partition/offset of a consume result.
-        /// 
+        ///
+        ///     EOF messages must not be stored as they are control messages and
+        ///     have and an invalid leader epoch, it's throwing an InvalidOperationException
+        ///     in that case.
+        ///
         ///     The offset will be committed according to
         ///     `auto.commit.interval.ms` (and
         ///     `enable.auto.commit`) or manual offset-less
@@ -332,6 +336,13 @@ namespace Confluent.Kafka
         /// <remarks>
         ///     `enable.auto.offset.store` must be set to
         ///     "false" when using this API.
+        /// </remarks>
+        /// <remarks>
+        ///     A consumer at position N has consumed
+        ///     messages with offsets up to N-1 and will
+        ///     next receive the message with offset N.
+        ///     Hence, this method stores an offset of
+        ///     <paramref name="result" />.Offset + 1.
         /// </remarks>
         /// <param name="result">
         ///     A consume result used to determine
@@ -346,6 +357,9 @@ namespace Confluent.Kafka
         /// </exception>
         /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
         ///     Thrown if result is in error.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        ///     Thrown if the <paramref name="result"/> param is an empty consume result.
         /// </exception>
         void StoreOffset(ConsumeResult<TKey, TValue> result);
 
@@ -410,6 +424,10 @@ namespace Confluent.Kafka
         /// <summary>
         ///     Commits an offset based on the
         ///     topic/partition/offset of a ConsumeResult.
+        ///
+        ///     EOF messages must not be committed as they are control messages and
+        ///     have and an invalid leader epoch, it's throwing an InvalidOperationException
+        ///     in that case.
         /// </summary>
         /// <param name="result">
         ///     The ConsumeResult instance used
@@ -420,6 +438,9 @@ namespace Confluent.Kafka
         /// </exception>
         /// <exception cref="Confluent.Kafka.TopicPartitionOffsetException">
         ///     Thrown if the result is in error.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        ///     Thrown if the <paramref name="result"/> param is an empty consume result.
         /// </exception>
         /// <remarks>
         ///     A consumer at position N has consumed

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
@@ -129,6 +129,15 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer.Close();
             }
 
+            consumerConfig = new ConsumerConfig
+            {
+                GroupId = Guid.NewGuid().ToString(),
+                BootstrapServers = bootstrapServers,
+                EnablePartitionEof = true,
+                EnableAutoOffsetStore = false,
+                EnableAutoCommit = false,
+            };
+
             // eof, generic consumer case.
             using (var consumer =
                 new TestConsumerBuilder<Null, string>(consumerConfig)
@@ -145,12 +154,19 @@ namespace Confluent.Kafka.IntegrationTests
                 var cr1 = consumer.Consume();
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
+
                 var cr2 = consumer.Consume();
                 Assert.NotNull(cr2.Message);
                 Assert.False(cr2.IsPartitionEOF);
+
                 var cr3 = consumer.Consume();
                 Assert.Null(cr3.Message);
                 Assert.True(cr3.IsPartitionEOF);
+                Assert.Throws<InvalidOperationException>(() =>
+                    consumer.StoreOffset(cr3));
+                Assert.Throws<InvalidOperationException>(() =>
+                    consumer.Commit(cr3));
+
                 var cr4 = consumer.Consume(TimeSpan.FromSeconds(1));
                 Assert.Null(cr4);
 


### PR DESCRIPTION
StoreOffset now rejects empty consume results (EOF control messages),
which have an invalid leader epoch and must not be stored or committed.
Update IConsumer docs for StoreOffset and Commit to document the new
InvalidOperationException behaviour.