### PR TITLE
add default value to Headers property of MessageMetadata class

### DIFF
--- a/src/Confluent.Kafka/MessageMetadata.cs
+++ b/src/Confluent.Kafka/MessageMetadata.cs
@@ -34,6 +34,6 @@ namespace Confluent.Kafka
         ///      empty list are equivalent. The order of headers is maintained, and
         ///     duplicate header keys are allowed.
         /// </summary>
-        public Headers Headers { get; set; }
+        public Headers Headers { get; set; } = new Headers();
     }
 }


### PR DESCRIPTION
add default value to Headers of MessageMetadata as pic below:
<img width="684" height="438" alt="Screenshot 2026-06-12 210849" src="https://github.com/user-attachments/assets/4d0beaab-f529-4f8b-b72f-2b553a339c58" />
 to resolve issue  https://github.com/confluentinc/confluent-kafka-dotnet/issues/2623


What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
Fixes https://github.com/confluentinc/confluent-kafka-dotnet/issues/2623
