### PR TITLE
Fix early return in FindMessageByName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Add support for saving Azure key version with DEK (#2641)
 * Pass context when clients make KEK calls to DEK Registry (#2642)
 
+## Fixes
+
+* Fix early return in FindMessageByName (#2644)
+
 
 # 2.15.0
 

--- a/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
+++ b/src/Confluent.SchemaRegistry.Serdes.Protobuf/ProtobufUtils.cs
@@ -193,7 +193,11 @@ namespace Confluent.SchemaRegistry.Serdes
                 {
                     foreach (var messageType in file.MessageTypes)
                     {
-                        return FindMessageByName(messageType, messageFullName);
+                        DescriptorProto found = FindMessageByName(messageType, messageFullName);
+                        if (found != null)
+                        {
+                            return found;
+                        }
                     }
                 }
             }
@@ -207,7 +211,11 @@ namespace Confluent.SchemaRegistry.Serdes
 
                 foreach (DescriptorProto nestedType in messageType.NestedTypes)
                 {
-                    return FindMessageByName(nestedType, messageFullName);
+                    DescriptorProto found = FindMessageByName(nestedType, messageFullName);
+                    if (found != null)
+                    {
+                        return found;
+                    }
                 }
             }
             return null;

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
@@ -102,14 +102,17 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
 
             var method = typeof(ProtobufUtils).GetMethod(
                 "FindMessageByName", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
 
-            dynamic result = method.Invoke(null, new object[]
+            var result = method.Invoke(null, new object[]
             {
                 fds, ".io.confluent.kafka.serializers.protobuf.test.SecondMessage"
             });
 
             Assert.NotNull(result);
-            Assert.Equal("SecondMessage", (string)result.Name);
+            var nameProperty = result.GetType().GetProperty("Name");
+            Assert.NotNull(nameProperty);
+            Assert.Equal("SecondMessage", (string)nameProperty.GetValue(result));
         }
 
         [Fact]

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
@@ -21,6 +21,7 @@ using System;
 using Xunit;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Confluent.Kafka;
 using Confluent.Kafka.Examples.Protobuf;
 using Confluent.SchemaRegistry.Encryption;
@@ -77,6 +78,38 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var rootFile = fds.Files.First(s => s.Name == "__root.proto");
             Assert.Equal(1, rootFile.MessageTypes.Count);
             Assert.Equal("ReferrerMessage", rootFile.MessageTypes.First().Name);
+        }
+
+        [Fact]
+        public void FindMessageByNameFindsNonFirstMessage()
+        {
+            // Regression test: FindMessageByName used to return after checking
+            // only the first candidate at each level (file or nested type),
+            // so a message other than the first one in the schema could never
+            // be found.
+            string schema = @"syntax = ""proto3"";
+            package io.confluent.kafka.serializers.protobuf.test;
+
+            message FirstMessage {
+                string first_field = 1;
+            }
+
+            message SecondMessage {
+                string second_field = 1;
+            }";
+
+            var fds = ProtobufUtils.Parse(schema, new Dictionary<string, string>());
+
+            var method = typeof(ProtobufUtils).GetMethod(
+                "FindMessageByName", BindingFlags.NonPublic | BindingFlags.Static);
+
+            dynamic result = method.Invoke(null, new object[]
+            {
+                fds, ".io.confluent.kafka.serializers.protobuf.test.SecondMessage"
+            });
+
+            Assert.NotNull(result);
+            Assert.Equal("SecondMessage", (string)result.Name);
         }
 
         [Fact]


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
`ProtobufUtils.FindMessageByName` is used to resolve a message's schema-level descriptor (for rule/field-transform targeting) by full name. Both of its search loops — over a `FileDescriptorSet'`s files/top-level messages, and over a `DescriptorProto`'s nested types — returned the result of the first recursive call unconditionally, instead of only returning on an actual match and continuing otherwise. In any schema with more than one top-level message, or any message with more than one nested type, only the first candidate at each level was ever inspected; a lookup for anything else silently returned null, breaking rule-based field targeting for those messages.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
