### PR TITLE
feat(client): expose ClusterId on Producer, Consumer, and AdminClient via rd_kafka_clusterid()

### DIFF
--- a/src/Confluent.Kafka/AdminClient.cs
+++ b/src/Confluent.Kafka/AdminClient.cs
@@ -1643,9 +1643,13 @@ namespace Confluent.Kafka
         public string Name
             => kafkaHandle.Name;
 
+        /// <inheritdoc/>
+        public string ClusterId
+            => kafkaHandle.ClusterId;
+
 
         /// <summary>
-        ///     An opaque reference to the underlying librdkafka 
+        ///     An opaque reference to the underlying librdkafka
         ///     client instance.
         /// </summary>
         public Handle Handle

--- a/src/Confluent.Kafka/Consumer.cs
+++ b/src/Confluent.Kafka/Consumer.cs
@@ -566,6 +566,11 @@ namespace Confluent.Kafka
 
 
         /// <inheritdoc/>
+        public string ClusterId
+            => kafkaHandle.ClusterId;
+
+
+        /// <inheritdoc/>
         public int AddBrokers(string brokers)
             => kafkaHandle.AddBrokers(brokers);
 

--- a/src/Confluent.Kafka/IClient.cs
+++ b/src/Confluent.Kafka/IClient.cs
@@ -51,6 +51,22 @@ namespace Confluent.Kafka
 
 
         /// <summary>
+        ///     Gets the cluster id of the Kafka cluster this client is
+        ///     connected to, or null if it has not yet been retrieved.
+        ///
+        ///     The cluster id is fetched from the broker metadata and cached
+        ///     locally. A null return indicates the cluster id has not yet
+        ///     been retrieved; the application should retry after a short
+        ///     delay.
+        /// </summary>
+        /// <remarks>
+        ///     This attribute corresponds to the OpenTelemetry semantic
+        ///     convention <c>messaging.kafka.cluster.id</c>.
+        /// </remarks>
+        string ClusterId { get; }
+
+
+        /// <summary>
         ///     Adds one or more brokers to the Client's list
         ///     of initial bootstrap brokers. 
         ///

--- a/src/Confluent.Kafka/Impl/LibRdKafka.cs
+++ b/src/Confluent.Kafka/Impl/LibRdKafka.cs
@@ -238,6 +238,7 @@ namespace Confluent.Kafka.Impl
             _new = (Func<RdKafkaType, IntPtr, StringBuilder, UIntPtr, SafeKafkaHandle>)methods.Single(m => m.Name == "rd_kafka_new").CreateDelegate(typeof(Func<RdKafkaType, IntPtr, StringBuilder, UIntPtr, SafeKafkaHandle>));
             _name = (Func<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_name").CreateDelegate(typeof(Func<IntPtr, IntPtr>));
             _memberid = (Func<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_memberid").CreateDelegate(typeof(Func<IntPtr, IntPtr>));
+            _clusterid = (Func<IntPtr, IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_clusterid").CreateDelegate(typeof(Func<IntPtr, IntPtr, IntPtr>));
             _Uuid_new = (Func<long, long, IntPtr>)methods.Single(m => m.Name == "rd_kafka_Uuid_new").CreateDelegate(typeof(Func<long, long, IntPtr>));
             _Uuid_base64str = (Func<IntPtr, IntPtr>)methods.Single(m => m.Name == "rd_kafka_Uuid_base64str").CreateDelegate(typeof(Func<IntPtr, IntPtr>));
             _Uuid_most_significant_bits = (Func<IntPtr, long>)methods.Single(m => m.Name == "rd_kafka_Uuid_most_significant_bits").CreateDelegate(typeof(Func<IntPtr, long>));
@@ -1056,6 +1057,9 @@ namespace Confluent.Kafka.Impl
 
         private static Func<IntPtr, IntPtr> _memberid;
         internal static IntPtr memberid(IntPtr rk) => _memberid(rk);
+
+        private static Func<IntPtr, IntPtr, IntPtr> _clusterid;
+        internal static IntPtr clusterid(IntPtr rk, IntPtr timeout_ms) => _clusterid(rk, timeout_ms);
 
         private static Func<long, long, IntPtr> _Uuid_new;
         internal static IntPtr Uuid_new(long most_significant_bits, long least_significant_bits)

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods.cs
@@ -312,6 +312,9 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern /* char * */ IntPtr rd_kafka_memberid(IntPtr rk);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern /* char * */ IntPtr rd_kafka_clusterid(IntPtr rk, IntPtr timeout_ms);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern /* rd_kafka_Uuid_t * */IntPtr rd_kafka_Uuid_new(
                 long most_significant_bits,
                 long least_significant_bits

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Alpine.cs
@@ -316,6 +316,9 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern /* char * */ IntPtr rd_kafka_memberid(IntPtr rk);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern /* char * */ IntPtr rd_kafka_clusterid(IntPtr rk, IntPtr timeout_ms);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern /* rd_kafka_Uuid_t * */IntPtr rd_kafka_Uuid_new(
                 long most_significant_bits,
                 long least_significant_bits

--- a/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos8.cs
+++ b/src/Confluent.Kafka/Impl/NativeMethods/NativeMethods_Centos8.cs
@@ -316,6 +316,9 @@ namespace Confluent.Kafka.Impl.NativeMethods
         internal static extern /* char * */ IntPtr rd_kafka_memberid(IntPtr rk);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern /* char * */ IntPtr rd_kafka_clusterid(IntPtr rk, IntPtr timeout_ms);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern /* rd_kafka_Uuid_t * */IntPtr rd_kafka_Uuid_new(
                 long most_significant_bits,
                 long least_significant_bits

--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -1179,6 +1179,24 @@ namespace Confluent.Kafka.Impl
             }
         }
 
+        internal string ClusterId
+        {
+            get
+            {
+                ThrowIfHandleClosed();
+
+                IntPtr strPtr = Librdkafka.clusterid(handle, IntPtr.Zero);
+                if (strPtr == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                string clusterId = Util.Marshal.PtrToStringUTF8(strPtr);
+                Librdkafka.mem_free(handle, strPtr);
+                return clusterId;
+            }
+        }
+
         internal static List<TopicPartitionError> GetTopicPartitionErrorList(IntPtr listPtr)
         {
             if (listPtr == IntPtr.Zero)

--- a/src/Confluent.Kafka/Producer.cs
+++ b/src/Confluent.Kafka/Producer.cs
@@ -478,6 +478,11 @@ namespace Confluent.Kafka
 
 
         /// <inheritdoc/>
+        public string ClusterId
+            => KafkaHandle.ClusterId;
+
+
+        /// <inheritdoc/>
         public int AddBrokers(string brokers)
             => KafkaHandle.AddBrokers(brokers);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/ClusterId.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/ClusterId.cs
@@ -1,0 +1,84 @@
+// Copyright 2025 Confluent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Refer to LICENSE for more information.
+
+#pragma warning disable xUnit1026
+
+using System;
+using Xunit;
+using Confluent.Kafka.TestsCommon;
+
+
+namespace Confluent.Kafka.IntegrationTests
+{
+    public partial class Tests
+    {
+        /// <summary>
+        ///     Tests that ClusterId returns a non-null, non-empty string after a
+        ///     broker connection has been established on Producer, Consumer, and
+        ///     AdminClient.
+        ///
+        ///     ClusterId wraps rd_kafka_clusterid() with timeout_ms=0, which
+        ///     returns the cached value. A metadata request is used to ensure the
+        ///     cluster id has been fetched and cached before reading the property.
+        /// </summary>
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public void ClusterId(string bootstrapServers)
+        {
+            LogToFile("start ClusterId");
+
+            var adminClientConfig = new AdminClientConfig { BootstrapServers = bootstrapServers };
+            using (var adminClient = new AdminClientBuilder(adminClientConfig).Build())
+            {
+                // Metadata request populates the cached cluster id.
+                adminClient.GetMetadata(TimeSpan.FromSeconds(10));
+
+                var clusterId = adminClient.ClusterId;
+                Assert.NotNull(clusterId);
+                Assert.NotEmpty(clusterId);
+            }
+
+            var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
+            using (var producer = new TestProducerBuilder<Null, string>(producerConfig).Build())
+            using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
+            {
+                adminClient.GetMetadata(TimeSpan.FromSeconds(10));
+
+                var clusterId = producer.ClusterId;
+                Assert.NotNull(clusterId);
+                Assert.NotEmpty(clusterId);
+            }
+
+            var consumerConfig = new ConsumerConfig
+            {
+                BootstrapServers = bootstrapServers,
+                GroupId = Guid.NewGuid().ToString(),
+                SessionTimeoutMs = 6000
+            };
+            using (var consumer = new TestConsumerBuilder<byte[], byte[]>(consumerConfig).Build())
+            using (var adminClient = new DependentAdminClientBuilder(consumer.Handle).Build())
+            {
+                adminClient.GetMetadata(TimeSpan.FromSeconds(10));
+
+                var clusterId = consumer.ClusterId;
+                Assert.NotNull(clusterId);
+                Assert.NotEmpty(clusterId);
+            }
+
+            Assert.Equal(0, Library.HandleCount);
+            LogToFile("end   ClusterId");
+        }
+    }
+}


### PR DESCRIPTION
What
----
Exposes the Kafka cluster id on all three client types (Producer, Consumer, AdminClient) through a new `ClusterId` property on the `IClient` interface.

The property wraps `rd_kafka_clusterid(rk, timeout_ms=0)` which returns the cached cluster id without blocking. A `null` return means the id has not yet been fetched from the broker; callers should retry after a short delay (e.g. after the first `GetMetadata`, produce, or consume call completes).

This attribute directly maps to the OpenTelemetry semantic convention [`messaging.kafka.cluster.id`](https://opentelemetry.io/docs/specs/semconv/messaging/kafka/), enabling instrumentation libraries to populate that attribute without requiring a separate AdminClient or metadata call.

**Implementation strategy:**

Follows the existing `MemberId` / `rd_kafka_memberid` pattern throughout the codebase:
- `NativeMethods{,_Centos8,_Alpine}.cs` — adds the `rd_kafka_clusterid` `DllImport` declaration
- `LibRdKafka.cs` — adds the delegate field, loader, and wrapper (same dynamic-delegate pattern used for all other librdkafka functions)
- `SafeKafkaHandle.cs` — adds an internal `ClusterId` property that calls `Librdkafka.clusterid(handle, IntPtr.Zero)`, handles `IntPtr.Zero` return (not yet fetched), and frees the returned string via `mem_free` (heap-allocated by librdkafka)
- `IClient.cs` — adds `string ClusterId { get; }` to the interface
- `Producer.cs`, `Consumer.cs`, `AdminClient.cs` — implement the property by forwarding to `kafkaHandle.ClusterId`

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
  - New `ClusterId` property added to `IClient`, `IProducer<TKey,TValue>`, `IConsumer<TKey,TValue>`, and `IAdminClient` (all inherit from `IClient`)
  - Property returns `null` rather than throwing when cluster id is not yet available — avoids breaking callers that run before the first metadata fetch
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Added `test/Confluent.Kafka.IntegrationTests/Tests/ClusterId.cs` which tests all three client types: calls `GetMetadata()` to populate the cache, then asserts `ClusterId` is a non-null, non-empty string

References
----------
OpenTelemetry semantic convention: https://opentelemetry.io/docs/specs/semconv/messaging/kafka/
librdkafka `rd_kafka_clusterid`: https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a0cafc3c8f5cfb9c37deb3f9ee0960ed6

Test & Review
------------
Integration test `ClusterId` in `Confluent.Kafka.IntegrationTests` covers:
1. AdminClient: calls `GetMetadata()` to populate the cache, asserts `ClusterId` is a non-null, non-empty string.
2. Producer: builds a `DependentAdminClient` from the producer handle, calls `GetMetadata()`, then asserts `producer.ClusterId`.
3. Consumer: same approach via `DependentAdminClient` from the consumer handle.

Open questions / Follow-ups
--------------------------
- Should `ClusterId` be exposed on the higher-level `IConsumer<K,V>` and `IProducer<K,V>` interfaces separately (with doc comments), or is inheritance from `IClient` sufficient? Currently inherited, which matches how `Name`, `Handle`, `AddBrokers`, and `SetSaslCredentials` are handled.