### PR TITLE
Fix NJsonSchema security warnings and migrate Kafka tests to xunit.v3

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,10 +65,10 @@ blocks:
             - powershell -ExecutionPolicy ByPass -File dotnet-install.ps1 -Channel 10.0 -Quality GA -InstallDir C:\dotnet
             - $Env:Path += ";C:\dotnet"
             - dotnet restore
-            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
-            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
-            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
-            - dotnet test -f net10.0 -c ${CONFIGURATION} --no-build test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/Confluent.Kafka.OAuthBearer.Aws.UnitTests.csproj
+            - dotnet test --project test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj -f net10.0 -c ${CONFIGURATION} --no-build
+            - dotnet test --project test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj -f net10.0 -c ${CONFIGURATION} --no-build
+            - dotnet test --project test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj -f net10.0 -c ${CONFIGURATION} --no-build
+            - dotnet test --project test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/Confluent.Kafka.OAuthBearer.Aws.UnitTests.csproj -f net10.0 -c ${CONFIGURATION} --no-build
   - name: 'Windows Artifacts on untagged commits'
     run:
       when: "tag !~ '.*'"
@@ -155,7 +155,7 @@ blocks:
             - cd test/docker && docker-compose up -d && sleep 30 && cd ../..
             - export SEMAPHORE_SKIP_FLAKY_TESTS='true'
             - dotnet restore -p:TargetFramework=net10.0
-            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../classic-coverage.xml && cd ../..
+            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 --output Normal' -f xml -o ../../classic-coverage.xml && cd ../..
             - artifact push workflow classic-coverage.xml || true
         - name: 'Build and test with "consumer" protocol'
           commands:
@@ -164,15 +164,15 @@ blocks:
             - export SEMAPHORE_SKIP_FLAKY_TESTS='true'
             - export TEST_CONSUMER_GROUP_PROTOCOL=consumer
             - dotnet restore -p:TargetFramework=net10.0
-            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../consumer-coverage.xml && cd ../..
+            - cd test/Confluent.Kafka.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 --output Normal' -f xml -o ../../consumer-coverage.xml && cd ../..
             - artifact push workflow consumer-coverage.xml || true
         - name: 'Schema registry and serdes integration tests'
           commands:
             - cd test/docker && docker-compose up -d && cd ../..
             - export SEMAPHORE_SKIP_FLAKY_TESTS='true'
             - dotnet restore -p:TargetFramework=net10.0
-            - cd test/Confluent.SchemaRegistry.Serdes.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../sr-target/serdes-coverage.xml && cd ../..
-            - cd test/Confluent.SchemaRegistry.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 -l "console;verbosity=normal"' -f xml -o ../../sr-target/coverage.xml && cd ../..
+            - cd test/Confluent.SchemaRegistry.Serdes.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 --output Normal' -f xml -o ../../sr-target/serdes-coverage.xml && cd ../..
+            - cd test/Confluent.SchemaRegistry.IntegrationTests && $DOTNET_COVERAGE_TOOL collect 'dotnet test -f net10.0 --output Normal' -f xml -o ../../sr-target/coverage.xml && cd ../..
             - artifact push workflow sr-target || true
 
 after_pipeline:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.x.0
+# 2.15.1 (not released)
 
 ## Enhancements
 
@@ -9,6 +9,7 @@
 
 * Fix early return in FindMessageByName (#2644)
 * Preserve HTTP status for retriable SR errors (#2647)
+* Security patch in examples and tests using old NJsonSchema versions, test framework upgrade in `Confluent.Kafka` tests (#)
 
 
 # 2.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 * Fix early return in FindMessageByName (#2644)
 * Preserve HTTP status for retriable SR errors (#2647)
-* Security patch in examples and tests using old NJsonSchema versions, test framework upgrade in `Confluent.Kafka` tests (#)
+* Security patch in examples and tests using old NJsonSchema versions, test framework upgrade in `Confluent.Kafka` tests (#2654)
 
 
 # 2.15.0

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,16 @@ build:
 
 test:
 	@(for d in $(UNIT_TEST_DIRS) ; do \
-		dotnet test test/$$d/$$d.csproj ; \
+		dotnet test --project test/$$d/$$d.csproj ; \
 	done)
 
 test-coverage:
 	@(for d in $(UNIT_TEST_DIRS) ; do \
-		$(DOTNET_COVERAGE_TOOL) collect "dotnet test -f $(DEFAULT_TEST_FRAMEWORK) test/$$d/$$d.csproj" \
+		$(DOTNET_COVERAGE_TOOL) collect "dotnet test --project test/$$d/$$d.csproj -f $(DEFAULT_TEST_FRAMEWORK)" \
 			-f xml -o test/$$d/coverage.xml ; \
 	done)
 
 test-latest:
 	@(for d in $(UNIT_TEST_DIRS) ; do \
-		dotnet test -f $(DEFAULT_TEST_FRAMEWORK) test/$$d/$$d.csproj ; \
+		dotnet test --project test/$$d/$$d.csproj -f $(DEFAULT_TEST_FRAMEWORK) ; \
 	done)

--- a/examples/OAuthConsumer/OAuthConsumer.csproj
+++ b/examples/OAuthConsumer/OAuthConsumer.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.8.0" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
   </ItemGroup>
 
 </Project>

--- a/examples/OAuthOIDC/OAuthOIDC.csproj
+++ b/examples/OAuthOIDC/OAuthOIDC.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.8.0" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
   </ItemGroup>
 
 </Project>

--- a/examples/OAuthProducer/OAuthProducer.csproj
+++ b/examples/OAuthProducer/OAuthProducer.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.8.0" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/ConfigGen/ConfigGen.csproj
+++ b/src/ConfigGen/ConfigGen.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/test/Confluent.Kafka.IntegrationTests/AdminClient_DescribeTopics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/AdminClient_DescribeTopics.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.Admin;
 
@@ -36,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     2. After creating Acls and with IncludeAuthorizedOperations.
         /// </summary>
         [Theory, MemberData(nameof(SaslPlainKafkaParameters))]
-        public async void AdminClient_DescribeTopics(string bootstrapServers,
+        public async Task AdminClient_DescribeTopics(string bootstrapServers,
             string admin, string adminSecret, string user, string userSecret)
         {
             LogToFile("start AdminClient_DescribeTopics");

--- a/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
+++ b/test/Confluent.Kafka.IntegrationTests/Confluent.Kafka.IntegrationTests.csproj
@@ -19,10 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AddBroker.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AddBroker.cs
@@ -44,7 +44,7 @@ namespace Confluent.Kafka.IntegrationTests
                 try
                 {
                     var metadata = adminClient.GetMetadata(TimeSpan.FromSeconds(3));
-                    Assert.True(false, "Broker should not be reached here");
+                    Assert.Fail("Broker should not be reached here");
                 }
                 catch (KafkaException e)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AclOperations.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AclOperations.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.Admin;
 using Confluent.Kafka.TestsCommon;
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient ACL operations.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public async void AdminClient_AclOperations(string bootstrapServers)
+        public async Task AdminClient_AclOperations(string bootstrapServers)
         {
             LogToFile("start AdminClient_AclOperations");
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterConfigs.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
 using Xunit;
@@ -31,15 +32,15 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.AlterConfigs.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_AlterConfigs(string bootstrapServers)
+        public async Task AdminClient_AlterConfigs(string bootstrapServers)
         {
             LogToFile("start AdminClient_AlterConfigs");
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
                 // 1. create a new topic to play with.
                 string topicName = Guid.NewGuid().ToString();
-                adminClient.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                await adminClient.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName, NumPartitions = 1, ReplicationFactor = 1 } });
                 Thread.Sleep(TimeSpan.FromSeconds(1)); // without this, sometimes describe topic throws unknown topic/partition error.
 
                 // 2. do an invalid alter configs call to change it.
@@ -56,38 +57,36 @@ namespace Confluent.Kafka.IntegrationTests
                 };
                 try
                 {
-                    adminClient.AlterConfigsAsync(toUpdate).Wait();
-                    Assert.True(false);
+                    await adminClient.AlterConfigsAsync(toUpdate);
+                    Assert.Fail("expecting exception");
                 }
-                catch (Exception e)
+                catch (AlterConfigsException ace)
                 {
-                    Assert.True(e.InnerException.GetType() == typeof(AlterConfigsException));
-                    var ace = (AlterConfigsException)e.InnerException;
                     Assert.Single(ace.Results);
                     Assert.Contains("Unknown", ace.Results[0].Error.Reason);
                 }
 
-                // 3. test that in the failed alter configs call for the specified config resource, the 
+                // 3. test that in the failed alter configs call for the specified config resource, the
                 // config that was specified correctly wasn't updated.
-                List<DescribeConfigsResult> describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                List<DescribeConfigsResult> describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
                 Assert.NotEqual("10001", describeConfigsResult[0].Entries["flush.ms"].Value);
 
                 // 4. do a valid call, and check that the alteration did correctly happen.
-                toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>> 
-                { 
-                    { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value="10011" } } } 
+                toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>>
+                {
+                    { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value="10011" } } }
                 };
-                adminClient.AlterConfigsAsync(toUpdate);
-                describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                await adminClient.AlterConfigsAsync(toUpdate);
+                describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
                 Assert.Equal("10011", describeConfigsResult[0].Entries["flush.ms"].Value);
 
                 // 4. test ValidateOnly = true does not update config entry.
-                toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>> 
-                { 
-                    { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value="20002" } } } 
+                toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>>
+                {
+                    { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value="20002" } } }
                 };
-                adminClient.AlterConfigsAsync(toUpdate, new AlterConfigsOptions { ValidateOnly = true }).Wait();
-                describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                await adminClient.AlterConfigsAsync(toUpdate, new AlterConfigsOptions { ValidateOnly = true });
+                describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
                 Assert.Equal("10011", describeConfigsResult[0].Entries["flush.ms"].Value);
 
                 // FIXME: altering broker configuration sometimes causes
@@ -113,18 +112,18 @@ namespace Confluent.Kafka.IntegrationTests
                   
                 // 6. test updating more than one resource.
                 string topicName2 = Guid.NewGuid().ToString();
-                adminClient.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                await adminClient.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } });
                 Thread.Sleep(TimeSpan.FromSeconds(1)); // without this, sometimes describe topic throws unknown topic/partition error.
 
                 var configResource2 = new ConfigResource { Name = topicName2, Type = ResourceType.Topic };
-                toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>> 
+                toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>>
                 {
                     { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value="222" } } },
                     { configResource2, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value="333" } } }
                 };
-                adminClient.AlterConfigsAsync(toUpdate).Wait();
-                describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource, configResource2 }).Result;
+                await adminClient.AlterConfigsAsync(toUpdate);
+                describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource, configResource2 });
                 Assert.Equal(2, describeConfigsResult.Count);
                 Assert.Equal("222", describeConfigsResult[0].Entries["flush.ms"].Value);
                 Assert.Equal("333", describeConfigsResult[1].Entries["flush.ms"].Value);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterListConsumerGroupOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_AlterListConsumerGroupOffsets.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Confluent.Kafka.Admin;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
@@ -33,7 +34,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     AdminClient.AlterConsumerGroupOffsets.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_AlterListConsumerGroupOffsets(string bootstrapServers)
+        public async Task AdminClient_AlterListConsumerGroupOffsets(string bootstrapServers)
         {
             LogToFile("start AdminClient_AlterListConsumerGroupOffsets");
             var numMessages = 5;
@@ -104,15 +105,14 @@ namespace Confluent.Kafka.IntegrationTests
                     {
                         var tpoListInvalid = new List<TopicPartitionOffset>();
                         tpoListInvalid.Add(new TopicPartitionOffset(topic.Name, 0, 2));
-                        var _ = adminClient.AlterConsumerGroupOffsetsAsync(
+                        var _ = await adminClient.AlterConsumerGroupOffsetsAsync(
                             new ConsumerGroupTopicPartitionOffsets[] {
                                 new ConsumerGroupTopicPartitionOffsets(groupID, tpoListInvalid),
-                        }).Result;
+                        });
                     }
-                    catch (Exception e)
+                    catch (AlterConsumerGroupOffsetsException)
                     {
                         errorOccured = true;
-                        Assert.IsType<AlterConsumerGroupOffsetsException>(e.InnerException);
                     }
                     Assert.True(errorOccured);
 
@@ -122,12 +122,12 @@ namespace Confluent.Kafka.IntegrationTests
                 // 3. List, Alter and then again List Consumer Group Offsets
                 var tpList = new List<TopicPartition>();
                 tpList.Add(new TopicPartition(topic.Name, 0));
-                var lcgoResults = adminClient.ListConsumerGroupOffsetsAsync(
+                var lcgoResults = await adminClient.ListConsumerGroupOffsetsAsync(
                     new ConsumerGroupTopicPartitions[] {
                         new ConsumerGroupTopicPartitions(groupID, tpList),
                     },
                     new ListConsumerGroupOffsetsOptions() { RequireStableOffsets = false }
-                ).Result;
+                );
 
                 Assert.Single(lcgoResults);
 
@@ -141,10 +141,10 @@ namespace Confluent.Kafka.IntegrationTests
 
                 var tpoList = new List<TopicPartitionOffset>();
                 tpoList.Add(new TopicPartitionOffset(topic.Name, 0, 2));
-                var acgoResults = adminClient.AlterConsumerGroupOffsetsAsync(
+                var acgoResults = await adminClient.AlterConsumerGroupOffsetsAsync(
                     new ConsumerGroupTopicPartitionOffsets[] {
                         new ConsumerGroupTopicPartitionOffsets(groupID, tpoList),
-                }).Result;
+                });
 
                 Assert.Single(acgoResults);
                 var groupResultAlter = acgoResults[0];
@@ -157,12 +157,12 @@ namespace Confluent.Kafka.IntegrationTests
 
                 tpList = new List<TopicPartition>();
                 tpList.Add(new TopicPartition(topic.Name, 0));
-                lcgoResults = adminClient.ListConsumerGroupOffsetsAsync(
+                lcgoResults = await adminClient.ListConsumerGroupOffsetsAsync(
                     new ConsumerGroupTopicPartitions[] {
                         new ConsumerGroupTopicPartitions(groupID, tpList),
                     },
                     new ListConsumerGroupOffsetsOptions() { RequireStableOffsets = false }
-                ).Result;
+                );
 
                 Assert.Single(lcgoResults);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreatePartitions.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreatePartitions.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Confluent.Kafka.Admin;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
@@ -33,7 +34,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.CreatePartitions
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_CreatePartitions(string bootstrapServers)
+        public async Task AdminClient_CreatePartitions(string bootstrapServers)
         {
             LogToFile("start AdminClient_CreatePartitions");
 
@@ -48,21 +49,20 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
-                adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = topicName1, IncreaseTo = 2 } }).Wait();
+                await adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } });
+                await adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = topicName1, IncreaseTo = 2 } });
 
-                var dr1 = producer.ProduceAsync(new TopicPartition(topicName1, 0), new Message<Null, Null>()).Result;
-                var dr2 = producer.ProduceAsync(new TopicPartition(topicName1, 1), new Message<Null, Null>()).Result;
-                
+                var dr1 = await producer.ProduceAsync(new TopicPartition(topicName1, 0), new Message<Null, Null>(), TestContext.Current.CancellationToken);
+                var dr2 = await producer.ProduceAsync(new TopicPartition(topicName1, 1), new Message<Null, Null>(), TestContext.Current.CancellationToken);
+
                 try
                 {
-                    producer.ProduceAsync(new TopicPartition(topicName1, 2), new Message<Null, Null>()).Wait();
-                    Assert.True(false, "expecting exception");
+                    await producer.ProduceAsync(new TopicPartition(topicName1, 2), new Message<Null, Null>(), TestContext.Current.CancellationToken);
+                    Assert.Fail("expecting exception");
                 }
-                catch (AggregateException ex)
+                catch (ProduceException<Null, Null> ex)
                 {
-                    Assert.IsType<ProduceException<Null,Null>>(ex.InnerException);
-                    Assert.True(((ProduceException<Null,Null>)ex.InnerException).Error.IsError);
+                    Assert.True(ex.Error.IsError);
                 }
             }
 
@@ -70,21 +70,20 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
-                adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = topicName2, IncreaseTo = 10 } }, new CreatePartitionsOptions { ValidateOnly = true }).Wait();
+                await adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } });
+                await adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = topicName2, IncreaseTo = 10 } }, new CreatePartitionsOptions { ValidateOnly = true });
 
                 // forces a metadata request.
-                var dr1 = producer.ProduceAsync(new TopicPartition(topicName2, 0), new Message<Null, Null>()).Result;
+                var dr1 = await producer.ProduceAsync(new TopicPartition(topicName2, 0), new Message<Null, Null>(), TestContext.Current.CancellationToken);
                 try
                 {
                     // since we have metadata, this throws immediately (i.e. not wrapped in AggregateException)
-                    var dr2 = producer.ProduceAsync(new TopicPartition(topicName2, 1), new Message<Null, Null>()).Result;
-                    Assert.True(false, "expecting exception");
+                    var dr2 = await producer.ProduceAsync(new TopicPartition(topicName2, 1), new Message<Null, Null>(), TestContext.Current.CancellationToken);
+                    Assert.Fail("expecting exception");
                 }
-                catch (AggregateException ex)
+                catch (ProduceException<Null, Null> ex)
                 {
-                    Assert.IsType<ProduceException<Null,Null>>(ex.InnerException);
-                    Assert.True(((ProduceException<Null,Null>)ex.InnerException).Error.IsError);
+                    Assert.True(ex.Error.IsError);
                 }
             }
 
@@ -92,37 +91,35 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName3, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
-                adminClient.CreatePartitionsAsync(
-                    new List<PartitionsSpecification> 
+                await adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName3, NumPartitions = 1, ReplicationFactor = 1 } });
+                await adminClient.CreatePartitionsAsync(
+                    new List<PartitionsSpecification>
                     {
-                        new PartitionsSpecification { Topic = topicName2, IncreaseTo = 2, ReplicaAssignments = new List<List<int>> { new List<int> { 0 } } } 
-                    }, 
+                        new PartitionsSpecification { Topic = topicName2, IncreaseTo = 2, ReplicaAssignments = new List<List<int>> { new List<int> { 0 } } }
+                    },
                     new CreatePartitionsOptions { ValidateOnly = true }
-                ).Wait();
+                );
             }
 
             // check invalid Assignments property value works.
             using (var producer = new TestProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName4, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                await adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName4, NumPartitions = 1, ReplicationFactor = 1 } });
 
                 try
                 {
-                    adminClient.CreatePartitionsAsync(
-                        new List<PartitionsSpecification> 
+                    await adminClient.CreatePartitionsAsync(
+                        new List<PartitionsSpecification>
                         {
-                            new PartitionsSpecification { Topic = topicName2, IncreaseTo = 2, ReplicaAssignments = new List<List<int>> { new List<int> { 42 } } } 
-                        }, 
+                            new PartitionsSpecification { Topic = topicName2, IncreaseTo = 2, ReplicaAssignments = new List<List<int>> { new List<int> { 42 } } }
+                        },
                         new CreatePartitionsOptions { ValidateOnly = true }
-                    ).Wait();
-                    Assert.True(false, "Expecting exception");
+                    );
+                    Assert.Fail("Expecting exception");
                 }
-                catch (AggregateException ex)
+                catch (CreatePartitionsException cpe)
                 {
-                    Assert.True(ex.InnerException.GetType() == typeof(CreatePartitionsException));
-                    var cpe = (CreatePartitionsException)ex.InnerException;
                     Assert.Single(cpe.Results);
                     Assert.True(cpe.Results.First().Error.IsError);
                 }
@@ -131,22 +128,22 @@ namespace Confluent.Kafka.IntegrationTests
             // more than one.
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                adminClient.CreateTopicsAsync(new TopicSpecification[] 
-                    { 
+                await adminClient.CreateTopicsAsync(new TopicSpecification[]
+                    {
                         new TopicSpecification { Name = topicName5, NumPartitions = 1, ReplicationFactor = 1 },
                         new TopicSpecification { Name = topicName6, NumPartitions = 1, ReplicationFactor = 1 }
                     }
-                ).Wait();
+                );
                 Thread.Sleep(TimeSpan.FromSeconds(1));
 
                 // just a simple check there wasn't an exception.
-                adminClient.CreatePartitionsAsync(
-                    new List<PartitionsSpecification> 
+                await adminClient.CreatePartitionsAsync(
+                    new List<PartitionsSpecification>
                     {
                         new PartitionsSpecification { Topic = topicName5, IncreaseTo = 2 },
                         new PartitionsSpecification { Topic = topicName6, IncreaseTo = 3 }
                     }
-                ).Wait();
+                );
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreateTopics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_CreateTopics.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Confluent.Kafka.Admin;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
@@ -32,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.CreateTopics.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_CreateTopics(string bootstrapServers)
+        public async Task AdminClient_CreateTopics(string bootstrapServers)
         {
             LogToFile("start AdminClient_CreateTopics");
 
@@ -47,13 +48,13 @@ namespace Confluent.Kafka.IntegrationTests
             //  - creation of more than one topic.
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                adminClient.CreateTopicsAsync(
+                await adminClient.CreateTopicsAsync(
                     new TopicSpecification[]
-                    { 
+                    {
                         new TopicSpecification { Name = topicName1, NumPartitions = 2, ReplicationFactor = 1 },
                         new TopicSpecification { Name = topicName2, NumPartitions = 12, ReplicationFactor = 1 }
                     }
-                ).Wait();
+                );
             }
 
             // test 
@@ -63,12 +64,12 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient2 = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient2.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName3, NumPartitions = 24, ReplicationFactor = 1 } }).Wait();
+                await adminClient2.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName3, NumPartitions = 24, ReplicationFactor = 1 } });
 
-                var deliveryReport1 = producer.ProduceAsync(topicName1, new Message<Null, Null>()).Result;
-                var deliveryReport2 = producer.ProduceAsync(topicName2, new Message<Null, Null>()).Result;
-                var deliveryReport3 = producer.ProduceAsync(topicName3, new Message<Null, Null>()).Result;
+                var deliveryReport1 = await producer.ProduceAsync(topicName1, new Message<Null, Null>(), TestContext.Current.CancellationToken);
+                var deliveryReport2 = await producer.ProduceAsync(topicName2, new Message<Null, Null>(), TestContext.Current.CancellationToken);
+                var deliveryReport3 = await producer.ProduceAsync(topicName3, new Message<Null, Null>(), TestContext.Current.CancellationToken);
                 
                 Assert.Equal(topicName1, deliveryReport1.Topic);
                 Assert.Equal(topicName2, deliveryReport2.Topic);
@@ -82,24 +83,19 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 try
                 {
-                    adminClient.CreateTopicsAsync(new List<TopicSpecification> 
-                        { 
+                    await adminClient.CreateTopicsAsync(new List<TopicSpecification>
+                        {
                             new TopicSpecification { Name = topicName3, NumPartitions = 1, ReplicationFactor = 1 },
                             new TopicSpecification { Name = topicName4, NumPartitions = 1, ReplicationFactor = 1 }
                         }
-                    ).Wait();
-                    Assert.True(false, "Expect CreateTopics request to throw an exception.");
+                    );
+                    Assert.Fail("Expect CreateTopics request to throw an exception.");
                 }
-
-                // if awaited, the CreateTopicsException is not wrapped. 
-                // this is an annoyance if used synchronously, but not atypical.
-                catch (AggregateException ex)
+                catch (CreateTopicsException cte)
                 {
-                    Assert.True(ex.InnerException.GetType() == typeof(CreateTopicsException));
-                    var cte = (CreateTopicsException) ex.InnerException;
                     Assert.Equal(2, cte.Results.Count);
-                    Assert.Single(cte.Results.Where(r => r.Error.IsError));
-                    Assert.Single(cte.Results.Where(r => !r.Error.IsError));
+                    Assert.Single(cte.Results, r => r.Error.IsError);
+                    Assert.Single(cte.Results, r => !r.Error.IsError);
                     Assert.Equal(topicName3, cte.Results.Where(r => r.Error.IsError).First().Topic);
                     Assert.Equal(topicName4, cte.Results.Where(r => !r.Error.IsError).First().Topic);
                 }
@@ -109,15 +105,15 @@ namespace Confluent.Kafka.IntegrationTests
             //  - validate only
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                adminClient.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName5, NumPartitions = 1, ReplicationFactor = 1 } }, 
+                await adminClient.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName5, NumPartitions = 1, ReplicationFactor = 1 } },
                     new CreateTopicsOptions { ValidateOnly = true, RequestTimeout = TimeSpan.FromSeconds(30) }
-                ).Wait();
+                );
 
                 // creating for real shouldn't throw exception.
-                adminClient.CreateTopicsAsync(
+                await adminClient.CreateTopicsAsync(
                     new List<TopicSpecification> { new TopicSpecification { Name = topicName5, NumPartitions = 1, ReplicationFactor = 1 } }
-                ).Wait();
+                );
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteConsumerGroup.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteConsumerGroup.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -28,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests 
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_DeleteConsumerGroup(string bootstrapServers)
+        public async Task AdminClient_DeleteConsumerGroup(string bootstrapServers)
         {
             LogToFile("start AdminClient_DeleteConsumerGroup");
 
@@ -43,7 +44,7 @@ namespace Confluent.Kafka.IntegrationTests
                 // test single delete group
                 CreateConsumer(bootstrapServers, groupId, topic.Name);
 
-                admin.DeleteGroupsAsync(new List<string> { groupId }, new DeleteGroupsOptions()).Wait();
+                await admin.DeleteGroupsAsync(new List<string> { groupId }, new DeleteGroupsOptions());
 
                 var groups = admin.ListGroups(TimeSpan.FromSeconds(5));
                 Assert.DoesNotContain(groups, (group) => group.Group == groupId);
@@ -54,15 +55,14 @@ namespace Confluent.Kafka.IntegrationTests
 
                 try
                 {
-                    admin.DeleteGroupsAsync(new List<string> {groupId2, groupId3}, new DeleteGroupsOptions()).Wait();
+                    await admin.DeleteGroupsAsync(new List<string> {groupId2, groupId3}, new DeleteGroupsOptions());
                     Assert.True(false); // expecting exception.
                 }
-                catch (AggregateException ex)
+                catch (DeleteGroupsException dge)
                 {
-                    var dge = (DeleteGroupsException)ex.InnerException;
                     Assert.Equal(2, dge.Results.Count);
-                    Assert.Single(dge.Results.Where(r => r.Error.IsError));
-                    Assert.Single(dge.Results.Where(r => !r.Error.IsError));
+                    Assert.Single(dge.Results, r => r.Error.IsError);
+                    Assert.Single(dge.Results, r => !r.Error.IsError);
                     Assert.Equal(groupId2, dge.Results.Where(r => !r.Error.IsError).First().Group);
                     Assert.Equal(groupId3, dge.Results.Where(r => r.Error.IsError).First().Group);
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteConsumerGroupOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteConsumerGroupOffsets.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 using System.Linq;
+using System.Threading.Tasks;
 using Confluent.Kafka.TestsCommon;
 
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.DeleteConsumerGroupOffsets.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_DeleteConsumerGroupOffsets(string bootstrapServers)
+        public async Task AdminClient_DeleteConsumerGroupOffsets(string bootstrapServers)
         {
             if (!TestConsumerGroupProtocol.IsClassic())
             {
@@ -66,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(offsetToCommit, committedOffsets[0].Offset);
 
                 List<TopicPartition> topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic1.Name, 0) };
-                var res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                var res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                 Assert.Equal(groupId1, res.Group);
                 Assert.Single(res.Partitions);
                 Assert.Equal(0, res.Partitions[0].Partition.Value);
@@ -92,12 +93,11 @@ namespace Confluent.Kafka.IntegrationTests
                 topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic1.Name, 0) };
                 try
                 {
-                    res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                    res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                     Assert.True(false); // expecting exception.
                 }
-                catch (AggregateException ex)
+                catch (DeleteConsumerGroupOffsetsException dcgoe)
                 {
-                    var dcgoe = (DeleteConsumerGroupOffsetsException)ex.InnerException;
                     Assert.Equal(ErrorCode.Local_Partial, dcgoe.Error.Code);
                     Assert.Equal(groupId1, dcgoe.Result.Group);
                     Assert.Single(dcgoe.Result.Partitions);
@@ -118,7 +118,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(Offset.Unset, committedOffsets[0].Offset);
 
                 topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic2.Name, 0) };
-                res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                 Assert.Equal(groupId1, res.Group);
                 Assert.Single(res.Partitions);
                 Assert.Equal(0, res.Partitions[0].Partition.Value);
@@ -138,7 +138,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Reset offset for partition 0
                 topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic3.Name, 0) };
-                res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                 Assert.Equal(groupId1, res.Group);
                 Assert.Single(res.Partitions);
                 Assert.Equal(0, res.Partitions[0].Partition.Value);
@@ -156,7 +156,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     with the cooperative assignor.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_DeleteConsumerGroupOffsets_Cooperative(string bootstrapServers)
+        public async Task AdminClient_DeleteConsumerGroupOffsets_Cooperative(string bootstrapServers)
         {
             LogToFile("start AdminClient_DeleteConsumerGroupOffsets_Cooperative");
             var assignmentDone = false;
@@ -187,7 +187,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.Equal(offsetToCommit, committedOffsets[0].Offset);
 
                 List<TopicPartition> topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic1.Name, 0) };
-                var res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                var res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                 Assert.Equal(groupId1, res.Group);
                 Assert.Single(res.Partitions);
                 Assert.Equal(0, res.Partitions[0].Partition.Value);
@@ -208,7 +208,7 @@ namespace Confluent.Kafka.IntegrationTests
                     Assert.Equal(Offset.Unset, committedOffsets[0].Offset);
 
                     topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic2.Name, 0) };
-                    res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                    res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                     Assert.Equal(groupId1, res.Group);
                     Assert.Single(res.Partitions);
                     Assert.Equal(0, res.Partitions[0].Partition.Value);
@@ -229,7 +229,7 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Reset offset for partition 0
                 topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic3.Name, 0) };
-                res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                 Assert.Equal(groupId1, res.Group);
                 Assert.Single(res.Partitions);
                 Assert.Equal(0, res.Partitions[0].Partition.Value);
@@ -259,12 +259,11 @@ namespace Confluent.Kafka.IntegrationTests
                 topicPartitionToReset = new List<TopicPartition>() { new TopicPartition(topic1.Name, 0) };
                 try
                 {
-                    res = adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset).Result;
+                    res = await adminClient.DeleteConsumerGroupOffsetsAsync(groupId1, topicPartitionToReset);
                     Assert.True(false); // expecting exception.
                 }
-                catch (AggregateException ex)
+                catch (DeleteConsumerGroupOffsetsException dcgoe)
                 {
-                    var dcgoe = (DeleteConsumerGroupOffsetsException)ex.InnerException;
                     Assert.Equal(ErrorCode.Local_Partial, dcgoe.Error.Code);
                     Assert.Equal(groupId1, dcgoe.Result.Group);
                     Assert.Single(dcgoe.Result.Partitions);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteRecords.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteRecords.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.DeleteRecords.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_DeleteRecords(string bootstrapServers)
+        public async Task AdminClient_DeleteRecords(string bootstrapServers)
         {
             LogToFile("start AdminClient_DeleteRecords");
 
@@ -48,11 +49,11 @@ namespace Confluent.Kafka.IntegrationTests
                 }
                 producer.Flush(TimeSpan.FromSeconds(10));
 
-                var r = adminClient.DeleteRecordsAsync(new List<TopicPartitionOffset>
+                var r = await adminClient.DeleteRecordsAsync(new List<TopicPartitionOffset>
                     {
                         new TopicPartitionOffset(topic1.Name, 0, 4),
                         new TopicPartitionOffset(topic2.Name, 0, 0) // no modification.
-                    }).Result;
+                    });
                 var t1r = r.Where(a => a.Topic == topic1.Name).ToList()[0];
                 var t2r = r.Where(a => a.Topic == topic2.Name).ToList()[0];
                 Assert.Equal(4, (int)t1r.Offset);
@@ -63,25 +64,22 @@ namespace Confluent.Kafka.IntegrationTests
                 var wm2 = consumer.QueryWatermarkOffsets(new TopicPartition(topic2.Name, 0), TimeSpan.FromSeconds(10));
                 Assert.Equal(0, (int)wm2.Low);
 
-                r = adminClient.DeleteRecordsAsync(new List<TopicPartitionOffset>
+                r = await adminClient.DeleteRecordsAsync(new List<TopicPartitionOffset>
                     {
                         new TopicPartitionOffset(topic1.Name, 0, 3)
-                    }).Result;
+                    });
                 Assert.Equal(4, (int)r.First().Offset);
 
                 try
                 {
-                    r = adminClient.DeleteRecordsAsync(new List<TopicPartitionOffset>
+                    r = await adminClient.DeleteRecordsAsync(new List<TopicPartitionOffset>
                         {
                             new TopicPartitionOffset(topic1.Name, 0, 12)
-                        }).Result;
+                        });
                     Assert.True(false); // expecting exception.
                 }
-                catch (Exception e)
+                catch (Admin.DeleteRecordsException dre)
                 {
-                    var ie = e.InnerException;
-                    Assert.IsType<Admin.DeleteRecordsException>(ie);
-                    var dre = (Admin.DeleteRecordsException)ie;
                     Assert.Single(dre.Results);
                     Assert.Equal(ErrorCode.OffsetOutOfRange, dre.Results[0].Error.Code);
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteTopics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DeleteTopics.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
 using Xunit;
@@ -32,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.CreateTopics.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_DeleteTopics(string bootstrapServers)
+        public async Task AdminClient_DeleteTopics(string bootstrapServers)
         {
             LogToFile("start AdminClient_DeleteTopics");
 
@@ -43,12 +44,12 @@ namespace Confluent.Kafka.IntegrationTests
             // test single delete topic.
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                adminClient.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                await adminClient.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } });
                 Thread.Sleep(TimeSpan.FromSeconds(1));
 
                 Thread.Sleep(TimeSpan.FromSeconds(2)); // git the topic some time to be created.
-                adminClient.DeleteTopicsAsync(new List<string> { topicName1 }).Wait();
+                await adminClient.DeleteTopicsAsync(new List<string> { topicName1 });
             }
 
             // test
@@ -56,24 +57,23 @@ namespace Confluent.Kafka.IntegrationTests
             //  - check that explicitly giving options doesn't obviously not work.
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                adminClient.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                await adminClient.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 } });
                 Thread.Sleep(TimeSpan.FromSeconds(1));
 
                 Thread.Sleep(TimeSpan.FromSeconds(2));
                 try
                 {
-                    adminClient.DeleteTopicsAsync(
+                    await adminClient.DeleteTopicsAsync(
                         new List<string> { topicName2, topicName3 },
                         new DeleteTopicsOptions { RequestTimeout = TimeSpan.FromSeconds(30) }
-                    ).Wait();
+                    );
                 }
-                catch (AggregateException ex)
+                catch (DeleteTopicsException dte)
                 {
-                    var dte = (DeleteTopicsException) ex.InnerException;
                     Assert.Equal(2, dte.Results.Count);
-                    Assert.Single(dte.Results.Where(r => r.Error.IsError));
-                    Assert.Single(dte.Results.Where(r => !r.Error.IsError));
+                    Assert.Single(dte.Results, r => r.Error.IsError);
+                    Assert.Single(dte.Results, r => !r.Error.IsError);
                     Assert.Equal(topicName2, dte.Results.Where(r => !r.Error.IsError).First().Topic);
                     Assert.Equal(topicName3, dte.Results.Where(r => r.Error.IsError).First().Topic);
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DescribeCluster.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DescribeCluster.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.Admin;
 
@@ -36,7 +37,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     3. After creating ACLs with the user matched by the ACL.
         /// </summary>
         [Theory, MemberData(nameof(SaslPlainKafkaParameters))]
-        public async void AdminClient_DescribeCluster(string bootstrapServers,
+        public async Task AdminClient_DescribeCluster(string bootstrapServers,
             string admin, string adminSecret, string user, string userSecret)
         {
             LogToFile("start AdminClient_DescribeCluster");

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DescribeConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_DescribeConfigs.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Confluent.Kafka.Admin;
 using Xunit;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.DescribeConfigs.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_DescribeConfigs(string bootstrapServers)
+        public async Task AdminClient_DescribeConfigs(string bootstrapServers)
         {
             LogToFile("start AdminClient_DescribeConfigs");
 
@@ -40,33 +41,33 @@ namespace Confluent.Kafka.IntegrationTests
                 // broker configs
                 // ---
                 var configResource = new ConfigResource { Name = "0", Type = ResourceType.Broker };
-                var results = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                var results = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
 
                 Assert.Single(results);
                 Assert.True(results[0].Entries.Count > 50);
                 // note: unlike other parts of the api, Entries is kept as a dictionary since it's convenient for
                 // the most typical use case.
-                Assert.Single(results[0].Entries.Where(e => e.Key == "advertised.listeners"));
-                Assert.Single(results[0].Entries.Where(e => e.Key == "num.network.threads"));
+                Assert.Single(results[0].Entries, e => e.Key == "advertised.listeners");
+                Assert.Single(results[0].Entries, e => e.Key == "num.network.threads");
 
                 var a = results.Select(aa => aa.Entries.Where(b => b.Value.Synonyms.Count > 0).ToList()).ToList();
 
                 // topic configs, more than one.
                 // ---
-                results = adminClient.DescribeConfigsAsync(new List<ConfigResource> { 
+                results = await adminClient.DescribeConfigsAsync(new List<ConfigResource> {
                     new ConfigResource { Name = singlePartitionTopic, Type = ResourceType.Topic },
                     new ConfigResource { Name = partitionedTopic, Type = ResourceType.Topic }
-                }).Result;
+                });
 
                 Assert.Equal(2, results.Count);
                 Assert.True(results[0].Entries.Count > 20);
                 Assert.True(results[1].Entries.Count > 20);
-                Assert.Single(results[0].Entries.Where(e => e.Key == "compression.type"));
-                Assert.Single(results[0].Entries.Where(e => e.Key == "flush.ms"));
+                Assert.Single(results[0].Entries, e => e.Key == "compression.type");
+                Assert.Single(results[0].Entries, e => e.Key == "flush.ms");
 
                 // options are specified.
                 // ---
-                results = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }, new DescribeConfigsOptions { RequestTimeout = TimeSpan.FromSeconds(10) }).Result;
+                results = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }, new DescribeConfigsOptions { RequestTimeout = TimeSpan.FromSeconds(10) });
                 Assert.Single(results);
                 Assert.True(results[0].Entries.Count > 20);
 
@@ -74,7 +75,7 @@ namespace Confluent.Kafka.IntegrationTests
                 // --- 
                 try
                 {
-                    results = adminClient.DescribeConfigsAsync(new List<ConfigResource> { new ConfigResource() }).Result;
+                    results = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { new ConfigResource() });
                     Assert.True(false);
                 }
                 catch (ArgumentException)
@@ -86,18 +87,16 @@ namespace Confluent.Kafka.IntegrationTests
                 // ---
                 try
                 {
-                    results = adminClient.DescribeConfigsAsync(
-                        new List<ConfigResource> 
+                    results = await adminClient.DescribeConfigsAsync(
+                        new List<ConfigResource>
                         {
                             new ConfigResource { Name="invalid.name.for.resource", Type = ResourceType.Broker }
                         }
-                    ).Result;
+                    );
                     Assert.True(false);
                 }
-                catch (AggregateException ex)
+                catch (KafkaException ace)
                 {
-                    Assert.True(ex.InnerException.GetType() == typeof(KafkaException));
-                    var ace = (KafkaException)ex.InnerException;
                     Assert.Contains("Expected an int32", ace.Message);
                 }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_IncrementalAlterConfigs.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_IncrementalAlterConfigs.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
 using Xunit;
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.IncrementalAlterConfigs.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_IncrementalAlterConfigs(string bootstrapServers)
+        public async Task AdminClient_IncrementalAlterConfigs(string bootstrapServers)
         {
             LogToFile("start AdminClient_IncrementalAlterConfigs");
 
@@ -38,8 +39,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 // 1. create new topics to play with.
                 string topicName = Guid.NewGuid().ToString(), topicName2 = Guid.NewGuid().ToString();
-                adminClient.CreateTopicsAsync(
-                    new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 }, new TopicSpecification { Name = topicName, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
+                await adminClient.CreateTopicsAsync(
+                    new List<TopicSpecification> { new TopicSpecification { Name = topicName2, NumPartitions = 1, ReplicationFactor = 1 }, new TopicSpecification { Name = topicName, NumPartitions = 1, ReplicationFactor = 1 } });
                 Thread.Sleep(TimeSpan.FromSeconds(1)); // without this, sometimes describe topic throws unknown topic/partition error.
 
                 // 2. do an invalid alter configs call to change it.
@@ -57,21 +58,19 @@ namespace Confluent.Kafka.IntegrationTests
                 };
                 try
                 {
-                    adminClient.IncrementalAlterConfigsAsync(toUpdate).Wait();
-                    Assert.True(false);
+                    await adminClient.IncrementalAlterConfigsAsync(toUpdate);
+                    Assert.Fail("expecting exception");
                 }
-                catch (Exception e)
+                catch (IncrementalAlterConfigsException ace)
                 {
-                    Assert.True(e.InnerException.GetType() == typeof(IncrementalAlterConfigsException));
-                    var ace = (IncrementalAlterConfigsException)e.InnerException;
                     Assert.Single(ace.Results);
                     Assert.True(ace.Results[0].Error.Reason.Contains("not allowed") ||
                         ace.Results[0].Error.Reason.Contains("Can't APPEND"));
                 }
 
-                // 3. test that in the failed alter configs call for the specified config resource, the 
+                // 3. test that in the failed alter configs call for the specified config resource, the
                 // config that was specified correctly isn't updated.
-                List<DescribeConfigsResult> describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                List<DescribeConfigsResult> describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
                 Assert.NotEqual("delete,compact", describeConfigsResult[0].Entries["cleanup.policy"].Value);
 
                 // 4. do a valid call, and check that the alteration did correctly happen.
@@ -85,9 +84,9 @@ namespace Confluent.Kafka.IntegrationTests
                         } 
                     } 
                 };
-                adminClient.IncrementalAlterConfigsAsync(toUpdate);
+                await adminClient.IncrementalAlterConfigsAsync(toUpdate);
                 Thread.Sleep(TimeSpan.FromMilliseconds(200));
-                describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
                 Assert.Equal("10001", describeConfigsResult[0].Entries["flush.ms"].Value);
                 Assert.Equal("delete,compact", describeConfigsResult[0].Entries["cleanup.policy"].Value);
 
@@ -96,9 +95,9 @@ namespace Confluent.Kafka.IntegrationTests
                 { 
                     { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value = "20002" , IncrementalOperation = AlterConfigOpType.Set } } } 
                 };
-                adminClient.IncrementalAlterConfigsAsync(toUpdate, new IncrementalAlterConfigsOptions { ValidateOnly = true }).Wait();
+                await adminClient.IncrementalAlterConfigsAsync(toUpdate, new IncrementalAlterConfigsOptions { ValidateOnly = true });
                 Thread.Sleep(TimeSpan.FromMilliseconds(200));
-                describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource }).Result;
+                describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource });
                 Assert.Equal("10001", describeConfigsResult[0].Entries["flush.ms"].Value);
 
                 // 6. test updating broker resource. 
@@ -109,8 +108,8 @@ namespace Confluent.Kafka.IntegrationTests
                         new List<ConfigEntry> { new ConfigEntry { Name = "num.network.threads", Value = "6" , IncrementalOperation = AlterConfigOpType.Set } }
                     }
                 };
-                adminClient.IncrementalAlterConfigsAsync(toUpdate).Wait();
-                
+                await adminClient.IncrementalAlterConfigsAsync(toUpdate);
+
                 // 7. test updating more than one resource.
                 var configResource2 = new ConfigResource { Name = topicName2, Type = ResourceType.Topic };
                 toUpdate = new Dictionary<ConfigResource, List<ConfigEntry>> 
@@ -118,9 +117,9 @@ namespace Confluent.Kafka.IntegrationTests
                     { configResource, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value = "222" , IncrementalOperation = AlterConfigOpType.Set } } },
                     { configResource2, new List<ConfigEntry> { new ConfigEntry { Name = "flush.ms", Value = "333" , IncrementalOperation = AlterConfigOpType.Set } } }
                 };
-                adminClient.IncrementalAlterConfigsAsync(toUpdate).Wait();
+                await adminClient.IncrementalAlterConfigsAsync(toUpdate);
                 Thread.Sleep(TimeSpan.FromMilliseconds(200));
-                describeConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource, configResource2 }).Result;
+                describeConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { configResource, configResource2 });
                 Assert.Equal(2, describeConfigsResult.Count);
                 Assert.Equal("222", describeConfigsResult[0].Entries["flush.ms"].Value);
                 Assert.Equal("333", describeConfigsResult[1].Entries["flush.ms"].Value);
@@ -141,9 +140,9 @@ namespace Confluent.Kafka.IntegrationTests
                             }
                         }
                     };
-                    adminClient.IncrementalAlterConfigsAsync(groupToUpdate).Wait();
+                    await adminClient.IncrementalAlterConfigsAsync(groupToUpdate);
                     Thread.Sleep(TimeSpan.FromMilliseconds(200));
-                    var describeGroupConfigsResult = adminClient.DescribeConfigsAsync(new List<ConfigResource> { groupConfigResource }).Result;
+                    var describeGroupConfigsResult = await adminClient.DescribeConfigsAsync(new List<ConfigResource> { groupConfigResource });
                     Assert.Single(describeGroupConfigsResult);
                     Assert.Equal("50000", describeGroupConfigsResult[0].Entries["consumer.session.timeout.ms"].Value);
                     LogToFile($"Successfully updated consumer.group {groupName} config");

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListConsumerGroups.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListConsumerGroups.cs
@@ -21,6 +21,7 @@ using Xunit;
 using Confluent.Kafka.Admin;
 using Confluent.Kafka.TestsCommon;
 using System.Threading;
+using System.Threading.Tasks;
 
 
 namespace Confluent.Kafka.IntegrationTests
@@ -37,7 +38,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///         all returned groups should be of type opposite of T and G must not be included.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_ListConsumerGroups(string bootstrapServers)
+        public async Task AdminClient_ListConsumerGroups(string bootstrapServers)
         {
             var usedType = ConsumerGroupType.Consumer;
             var oppositeType = ConsumerGroupType.Classic;
@@ -89,18 +90,18 @@ namespace Confluent.Kafka.IntegrationTests
                     Thread.Sleep(2000);
 
                     // Our consumer group should be present with same group type option
-                    var groups = adminClient.ListConsumerGroupsAsync(listOptionsWithUsed).Result;
-                    Assert.Empty(groups.Valid.Where(group => group.Type != usedType));
-                    Assert.Single(groups.Valid.Where(group => group.GroupId == groupId));
+                    var groups = await adminClient.ListConsumerGroupsAsync(listOptionsWithUsed);
+                    Assert.DoesNotContain(groups.Valid, group => group.Type != usedType);
+                    Assert.Single(groups.Valid, group => group.GroupId == groupId);
                     
                     var group = groups.Valid.Find(group => group.GroupId == groupId);
                     Assert.Equal(ConsumerGroupState.Stable, group.State);
                     Assert.False(group.IsSimpleConsumerGroup);
 
                     // Our consumer group should not be present with opposite group type option
-                    groups = adminClient.ListConsumerGroupsAsync(listOptionsWithOpposite).Result;
-                    Assert.Empty(groups.Valid.Where(group => group.Type != oppositeType));
-                    Assert.Empty(groups.Valid.Where(group => group.GroupId == groupId));
+                    groups = await adminClient.ListConsumerGroupsAsync(listOptionsWithOpposite);
+                    Assert.DoesNotContain(groups.Valid, group => group.Type != oppositeType);
+                    Assert.DoesNotContain(groups.Valid, group => group.GroupId == groupId);
                 }
                 finally
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListDescribeConsumerGroups.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListDescribeConsumerGroups.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.Admin;
 using Confluent.Kafka.TestsCommon;
@@ -61,7 +62,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     3. Empty consumer group.
         /// </summary>
         [Theory(Skip="FIXME: Review and fix this test"), MemberData(nameof(KafkaParameters))]
-        public void AdminClient_ListDescribeConsumerGroups(string bootstrapServers)
+        public async Task AdminClient_ListDescribeConsumerGroups(string bootstrapServers)
         {
             LogToFile("start AdminClient_ListDescribeConsumerGroups");
             var groupID = Guid.NewGuid().ToString();
@@ -81,9 +82,9 @@ namespace Confluent.Kafka.IntegrationTests
                 };
 
                 // We should not have any group initially.
-                var groups = adminClient.ListConsumerGroupsAsync().Result;
-                Assert.Empty(groups.Valid.Where(group => group.GroupId == groupID));
-                Assert.Empty(groups.Valid.Where(group => group.GroupId == nonExistentGroupID));
+                var groups = await adminClient.ListConsumerGroupsAsync();
+                Assert.DoesNotContain(groups.Valid, group => group.GroupId == groupID);
+                Assert.DoesNotContain(groups.Valid, group => group.GroupId == nonExistentGroupID);
 
                 // Ensure that the partitioned topic we are using has exactly two partitions.
                 Assert.Equal(2, partitionedTopicNumPartitions);
@@ -103,10 +104,10 @@ namespace Confluent.Kafka.IntegrationTests
                 // Wait for rebalance.
                 consumer1.Consume(TimeSpan.FromSeconds(10));
 
-                var descResult = adminClient.DescribeConsumerGroupsAsync(
+                var descResult = await adminClient.DescribeConsumerGroupsAsync(
                     new List<String>() { groupID },
-                    describeOptionsWithTimeout).Result;
-                Assert.Single(descResult.ConsumerGroupDescriptions.Where(group => group.GroupId == groupID));
+                    describeOptionsWithTimeout);
+                Assert.Single(descResult.ConsumerGroupDescriptions, group => group.GroupId == groupID);
                 var groupDesc = descResult.ConsumerGroupDescriptions.Find(group => group.GroupId == groupID);
 
                 while (consumer1.Assignment.Count != 2 ||
@@ -114,23 +115,23 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer1.Consume(TimeSpan.FromSeconds(1));
 
-                    descResult = adminClient.DescribeConsumerGroupsAsync(
+                    descResult = await adminClient.DescribeConsumerGroupsAsync(
                         new List<String>() { groupID },
-                        describeOptionsWithTimeout).Result;
-                    Assert.Single(descResult.ConsumerGroupDescriptions.Where(group => group.GroupId == groupID));
+                        describeOptionsWithTimeout);
+                    Assert.Single(descResult.ConsumerGroupDescriptions, group => group.GroupId == groupID);
                     groupDesc = descResult.ConsumerGroupDescriptions.Find(group => group.GroupId == groupID);
                 }
 
-                groups = adminClient.ListConsumerGroupsAsync(listOptionsWithTimeout).Result;
-                Assert.Single(groups.Valid.Where(group => group.GroupId == groupID));
-                Assert.Empty(groups.Valid.Where(group => group.GroupId == nonExistentGroupID));
+                groups = await adminClient.ListConsumerGroupsAsync(listOptionsWithTimeout);
+                Assert.Single(groups.Valid, group => group.GroupId == groupID);
+                Assert.DoesNotContain(groups.Valid, group => group.GroupId == nonExistentGroupID);
                 var group = groups.Valid.Find(group => group.GroupId == groupID);
                 Assert.Equal(ConsumerGroupState.Stable, group.State);
                 Assert.False(group.IsSimpleConsumerGroup);
 
-                descResult = adminClient.DescribeConsumerGroupsAsync(
+                descResult = await adminClient.DescribeConsumerGroupsAsync(
                     new List<String>() { groupID },
-                    describeOptionsWithTimeout).Result;
+                    describeOptionsWithTimeout);
                 groupDesc = descResult.ConsumerGroupDescriptions.Find(group => group.GroupId == groupID);
                 var clientIdToToppars = new Dictionary<string, List<TopicPartition>>();
                 clientIdToToppars[clientID1] = new List<TopicPartition>()
@@ -154,10 +155,10 @@ namespace Confluent.Kafka.IntegrationTests
                     consumer1.Consume(TimeSpan.FromSeconds(1));
                     consumer2.Consume(TimeSpan.FromSeconds(1));
 
-                    descResult = adminClient.DescribeConsumerGroupsAsync(
+                    descResult = await adminClient.DescribeConsumerGroupsAsync(
                         new List<String>() { groupID },
-                        describeOptionsWithTimeout).Result;
-                    Assert.Single(descResult.ConsumerGroupDescriptions.Where(group => group.GroupId == groupID));
+                        describeOptionsWithTimeout);
+                    Assert.Single(descResult.ConsumerGroupDescriptions, group => group.GroupId == groupID);
                     groupDesc = descResult.ConsumerGroupDescriptions.Find(group => group.GroupId == groupID);
                 }
 
@@ -179,15 +180,15 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Check the 'States' option by listing Stable consumer groups, which shouldn't
                 // include `groupID`.
-                groups = adminClient.ListConsumerGroupsAsync(new Admin.ListConsumerGroupsOptions()
+                groups = await adminClient.ListConsumerGroupsAsync(new Admin.ListConsumerGroupsOptions()
                 { MatchStates = new List<ConsumerGroupState>() { ConsumerGroupState.Stable },
-                  RequestTimeout = TimeSpan.FromSeconds(30) }).Result;
-                Assert.Empty(groups.Valid.Where(group => group.GroupId == groupID));
+                  RequestTimeout = TimeSpan.FromSeconds(30) });
+                Assert.DoesNotContain(groups.Valid, group => group.GroupId == groupID);
 
-                descResult = adminClient.DescribeConsumerGroupsAsync(
+                descResult = await adminClient.DescribeConsumerGroupsAsync(
                     new List<String>() { groupID },
-                    describeOptionsWithTimeout).Result;
-                Assert.Single(descResult.ConsumerGroupDescriptions.Where(group => group.GroupId == groupID));
+                    describeOptionsWithTimeout);
+                Assert.Single(descResult.ConsumerGroupDescriptions, group => group.GroupId == groupID);
                 groupDesc = descResult.ConsumerGroupDescriptions.Find(group => group.GroupId == groupID);
                 clientIdToToppars = new Dictionary<string, List<TopicPartition>>();
                 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_ListOffsets.cs
@@ -27,7 +27,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public async void AdminClient_ListOffsets(string bootstrapServers)
+        public async Task AdminClient_ListOffsets(string bootstrapServers)
         {
             LogToFile("start AdminClient_ListOffsets");
             
@@ -36,9 +36,9 @@ namespace Confluent.Kafka.IntegrationTests
             using var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
             
             long basetimestamp = 10000000;
-            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 100, TimestampType.CreateTime)});
-            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 400, TimestampType.CreateTime)});
-            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 250, TimestampType.CreateTime)});
+            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 100, TimestampType.CreateTime)}, TestContext.Current.CancellationToken);
+            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 400, TimestampType.CreateTime)}, TestContext.Current.CancellationToken);
+            await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "Producer Message", Timestamp = new Timestamp(basetimestamp + 250, TimestampType.CreateTime)}, TestContext.Current.CancellationToken);
             producer.Flush(new TimeSpan(0, 0, 10));
             
             var timeout = TimeSpan.FromSeconds(30);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Confluent.Kafka.Admin;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
@@ -33,7 +34,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Tests the validation of input parameter to guard against uncaught segfaults.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AdminClient_NullReferenceChecks(string bootstrapServers)
+        public async Task AdminClient_NullReferenceChecks(string bootstrapServers)
         {
             LogToFile("start AdminClient_NullReferenceChecks");
             var topicName1 = Guid.NewGuid().ToString();
@@ -47,8 +48,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 try
                 {
-                    adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = nullTopic, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
-                    Assert.True(false, "Expected exception.");
+                    await adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = nullTopic, NumPartitions = 1, ReplicationFactor = 1 } });
+                    Assert.Fail("Expected exception.");
                 }
                 catch (ArgumentException ex)
                 {
@@ -63,9 +64,9 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 try
                 {
-                    adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
-                    adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = nullTopic, IncreaseTo = 2 } }).Wait();
-                    Assert.True(false, "Expected exception.");
+                    await adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = topicName1, NumPartitions = 1, ReplicationFactor = 1 } });
+                    await adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = nullTopic, IncreaseTo = 2 } });
+                    Assert.Fail("Expected exception.");
                 }
                 catch (ArgumentException ex)
                 {
@@ -84,7 +85,7 @@ namespace Confluent.Kafka.IntegrationTests
                 try
                 {
                     adminClient.AddBrokers(null);
-                    Assert.True(false, "Expected exception.");
+                    Assert.Fail("Expected exception.");
                 }
                 catch (ArgumentNullException ex)
                 {
@@ -99,7 +100,7 @@ namespace Confluent.Kafka.IntegrationTests
                 try
                 {
                     adminClient.GetMetadata(null, TimeSpan.FromSeconds(10));
-                    Assert.True(false, "Expected exception.");
+                    Assert.Fail("Expected exception.");
                 }
                 catch (ArgumentNullException ex)
                 {
@@ -113,8 +114,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 try
                 {
-                    adminClient.DeleteTopicsAsync(new List<string> { topicName1, nullTopic });
-                    Assert.True(false, "Expected exception.");
+                    await adminClient.DeleteTopicsAsync(new List<string> { topicName1, nullTopic });
+                    Assert.Fail("Expected exception.");
                 }
                 catch(ArgumentException ex)
                 {
@@ -129,7 +130,7 @@ namespace Confluent.Kafka.IntegrationTests
                 try
                 {
                     adminClient.ListGroup(null, TimeSpan.FromSeconds(10));
-                    Assert.True(false, "Expected exception.");
+                    Assert.Fail("Expected exception.");
                 }
                 catch (ArgumentNullException ex)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_UserScram.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_UserScram.cs
@@ -20,6 +20,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test functionality of AdminClient.DescribeUserScramCredentials and AdminClient.AlterUserScramCredentials.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public async void AdminClient_UserScramCredentials(string bootstrapServers)
+        public async Task AdminClient_UserScramCredentials(string bootstrapServers)
         {
             LogToFile("start AdminClient_UserScramCredentials");
             var timeout = TimeSpan.FromSeconds(10);
@@ -50,7 +51,7 @@ namespace Confluent.Kafka.IntegrationTests
                 try
                 {
                     await adminClient.DescribeUserScramCredentialsAsync(users, describeOptions);
-                    Assert.True(false, "Describe request shouldn't succeed");
+                    Assert.Fail("Describe request shouldn't succeed");
                 }
                 catch (DescribeUserScramCredentialsException e)
                 {
@@ -100,7 +101,7 @@ namespace Confluent.Kafka.IntegrationTests
                 try
                 {
                     await adminClient.DescribeUserScramCredentialsAsync(users, describeOptions);
-                    Assert.True(false, "Describe request shouldn't succeed");
+                    Assert.Fail("Describe request shouldn't succeed");
                 }
                 catch (DescribeUserScramCredentialsException e)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignOverloads.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Simple test of all Consumer.Assign overloads.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AssignOverloads(string bootstrapServers)
+        public async Task AssignOverloads(string bootstrapServers)
         {
             LogToFile("start AssignOverloads");
 
@@ -51,10 +52,10 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<Null, string> dr, dr3;
             using (var producer = new TestProducerBuilder<Null, string>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString }).Result;
-                producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString2 }).Wait();
-                dr3 = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString3 }).Result;
-                producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString4 }).Wait();
+                dr = await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString2 }, TestContext.Current.CancellationToken);
+                dr3 = await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString3 }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = testString4 }, TestContext.Current.CancellationToken);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AssignPastEnd.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     higher than the offset of the last message on a partition.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void AssignPastEnd(string bootstrapServers)
+        public async Task AssignPastEnd(string bootstrapServers)
         {
             LogToFile("start AssignPastEnd");
 
@@ -48,7 +49,7 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<Null, byte[]> dr;
             using (var producer = new TestProducerBuilder<Null, byte[]>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }).Result;
+                dr = await producer.ProduceAsync(singlePartitionTopic, new Message<Null, byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                 Assert.True(dr.Offset >= 0);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Builder_CustomDefaults.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -101,7 +102,7 @@ namespace Confluent.Kafka.IntegrationTests
         }
 
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void ProducerBuilder(string bootstrapServers)
+        public async Task ProducerBuilder(string bootstrapServers)
         {
             LogToFile("start Builder_CustomDefaults");
 
@@ -110,7 +111,7 @@ namespace Confluent.Kafka.IntegrationTests
             var dr = new DeliveryResult<string, string>();
             using (var p = new MyProducerBuilder<string, string>(producerConfig).Build())
             {
-                dr = p.ProduceAsync(singlePartitionTopic, new Message<string, string> { Key = "abc", Value = "123" }).Result;
+                dr = await p.ProduceAsync(singlePartitionTopic, new Message<string, string> { Key = "abc", Value = "123" }, TestContext.Current.CancellationToken);
             }
             
             var consumerConfig = new ConsumerConfig

--- a/test/Confluent.Kafka.IntegrationTests/Tests/CancellationDelayMax.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/CancellationDelayMax.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.Admin;
 using Confluent.Kafka.TestsCommon;
@@ -31,8 +32,8 @@ namespace Confluent.Kafka.IntegrationTests
         /// <summary>
         ///     Test internal poll time is effective.
         /// </summary>
-        [SkippableTheory, MemberData(nameof(KafkaParameters))]
-        public void CancellationDelayMax(string bootstrapServers)
+        [Theory, MemberData(nameof(KafkaParameters))]
+        public async Task CancellationDelayMax(string bootstrapServers)
         {
             LogToFile("start CancellationDelayMax");
 
@@ -71,7 +72,11 @@ namespace Confluent.Kafka.IntegrationTests
                     var sw = Stopwatch.StartNew();
                     try
                     {
+                        // Intentionally using a short-lived, purpose-built token here (not
+                        // TestContext.Current.CancellationToken) - this is what's under test.
+#pragma warning disable xUnit1051
                         var record = consumer.Consume(cts.Token);
+#pragma warning restore xUnit1051
                     }
                     catch (OperationCanceledException)
                     {
@@ -83,17 +88,17 @@ namespace Confluent.Kafka.IntegrationTests
                     // should 4 almost all of the time. A higher value is apparently required on
                     // Windows (but still less than 50).
                     var elapsed = sw.ElapsedMilliseconds;
-                    Skip.If(elapsed > 20);
+                    Assert.SkipWhen(elapsed > 20, "elapsed time exceeded expected CancellationDelayMaxMs bound");
                 }
 
                 consumer.Close();
 
                 // for the producer, make do with just a simple check that this does not throw or hang.
-                var dr = producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 42 }, Value = new byte[] { 255 } }).Result;
-                
+                var dr = await producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 42 }, Value = new byte[] { 255 } }, TestContext.Current.CancellationToken);
+
                 // for the admin client, make do with just simple check that this does not throw or hang.
                 var cr = new Confluent.Kafka.Admin.ConfigResource { Type = ResourceType.Topic, Name = topic.Name };
-                var configs = adminClient.DescribeConfigsAsync(new ConfigResource[] { cr }).Result;
+                var configs = await adminClient.DescribeConfigsAsync(new ConfigResource[] { cr });
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_Committed_Position.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Commit_Committed_Position.cs
@@ -30,10 +30,10 @@ namespace Confluent.Kafka.IntegrationTests
         /// <summary>
         ///    Some simple tests for all variants of Commit (and also Committed and Position)
         /// </summary>
-        [SkippableTheory, MemberData(nameof(KafkaParameters))]
+        [Theory, MemberData(nameof(KafkaParameters))]
         public void Consumer_Commit_Committed_Position(string bootstrapServers)
         {
-            Skip.If(!TestConsumerGroupProtocol.IsClassic(),
+            Assert.SkipWhen(!TestConsumerGroupProtocol.IsClassic(),
                     "FIXME: Why isn't this test working with KIP-848?");
 
             LogToFile("start Consumer_Commit_Committed_Position");

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableHeaders.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -29,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test of disabling marshaling of message headers.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Consumer_DisableHeaders(string bootstrapServers)
+        public async Task Consumer_DisableHeaders(string bootstrapServers)
         {
             LogToFile("start Consumer_DisableHeaders");
 
@@ -45,19 +46,20 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<byte[], byte[]> dr;
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(
+                dr = await producer.ProduceAsync(
                     singlePartitionTopic,
                     new Message<byte[], byte[]>
                     {
                         Value = Serializers.Utf8.Serialize("my-value", SerializationContext.Empty),
                         Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
-                    }
-                ).Result;
+                    },
+                    TestContext.Current.CancellationToken
+                );
             }
 
             using (var consumer =
                 new TestConsumerBuilder<byte[], byte[]>(consumerConfig)
-                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .SetErrorHandler((_, e) => Assert.Fail(e.Reason))
                     .Build())
             {                    
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_DisableTimestamps.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -29,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test of disabling marshaling of message headers.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Consumer_DisableTimestamps(string bootstrapServers)
+        public async Task Consumer_DisableTimestamps(string bootstrapServers)
         {
             LogToFile("start Consumer_DisableTimestamps");
 
@@ -45,19 +46,20 @@ namespace Confluent.Kafka.IntegrationTests
             DeliveryResult<byte[], byte[]> dr;
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                dr = producer.ProduceAsync(
+                dr = await producer.ProduceAsync(
                     singlePartitionTopic,
                     new Message<byte[], byte[]>
                     {
                         Value = Serializers.Utf8.Serialize("my-value", SerializationContext.Empty),
                         Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
-                    }
-                ).Result;
+                    },
+                    TestContext.Current.CancellationToken
+                );
             }
 
             using (var consumer =
                 new TestConsumerBuilder<byte[], byte[]>(consumerConfig)
-                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .SetErrorHandler((_, e) => Assert.Fail(e.Reason))
                     .Build())
             {                    
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_MissingCommits.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_MissingCommits.cs
@@ -53,7 +53,7 @@ namespace Confluent.Kafka.IntegrationTests
                             producer.Produce(new TopicPartition(topic.Name, i), new Message<Null, string> { Value = "test" });
                         }
                     }
-                    producer.Flush();
+                    producer.Flush(TestContext.Current.CancellationToken);
 
                     for (int i=0; i<numPartitionsWithCommittedOffsets; ++i)
                     {
@@ -78,7 +78,7 @@ namespace Confluent.Kafka.IntegrationTests
                     {
                         if (DateTime.UtcNow - startTime > TimeSpan.FromSeconds(30))
                         {
-                            Assert.False(true, "Timed out waiting for consumption of messages to complete");
+                            Assert.Fail("Timed out waiting for consumption of messages to complete");
                             complete = true;
                         }
 
@@ -124,7 +124,7 @@ namespace Confluent.Kafka.IntegrationTests
                         }
                         catch
                         {
-                            Assert.False(true, "Failed to close consumer instance " + i);
+                            Assert.Fail("Failed to close consumer instance " + i);
                         }
                     }
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_PartitionEOF.cs
@@ -57,10 +57,10 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = consumer.Consume();
+                var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = consumer.Consume();
+                var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr2.Message);
                 Assert.False(cr2.IsPartitionEOF);
                 var cr3 = consumer.Consume(TimeSpan.FromSeconds(1));
@@ -82,10 +82,10 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = consumer.Consume();
+                var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = consumer.Consume();
+                var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr2.Message);
                 Assert.False(cr2.IsPartitionEOF);
                 var cr3 = consumer.Consume(TimeSpan.FromSeconds(1));
@@ -114,13 +114,13 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = consumer.Consume();
+                var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
-                var cr2 = consumer.Consume();
+                var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr2.Message);
                 Assert.False(cr2.IsPartitionEOF);
-                var cr3 = consumer.Consume();
+                var cr3 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.Null(cr3.Message);
                 Assert.True(cr3.IsPartitionEOF);
                 var cr4 = consumer.Consume(TimeSpan.FromSeconds(1));
@@ -151,15 +151,15 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 consumer.Subscribe(singlePartitionTopic);
 
-                var cr1 = consumer.Consume();
+                var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr1.Message);
                 Assert.False(cr1.IsPartitionEOF);
 
-                var cr2 = consumer.Consume();
+                var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr2.Message);
                 Assert.False(cr2.IsPartitionEOF);
 
-                var cr3 = consumer.Consume();
+                var cr3 = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.Null(cr3.Message);
                 Assert.True(cr3.IsPartitionEOF);
                 Assert.Throws<InvalidOperationException>(() =>

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Pause_Resume.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Simple Consumer Pause / Resume test.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Consumer_Pause_Resume(string bootstrapServers)
+        public async Task Consumer_Pause_Resume(string bootstrapServers)
         {
             LogToFile("start Consumer_Pause_Resume");
 
@@ -62,13 +63,13 @@ namespace Confluent.Kafka.IntegrationTests
                 ConsumeResult<byte[], byte[]> record = consumer.Consume(TimeSpan.FromSeconds(2));
                 Assert.Null(record);
 
-                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record?.Message);
                 Assert.Equal(0, record?.Offset);
 
                 consumer.Pause(assignment);
-                producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value 2", SerializationContext.Empty) }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value 2", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                 record = consumer.Consume(TimeSpan.FromSeconds(2));
                 Assert.Null(record);
                 consumer.Resume(assignment);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_DeserializationError.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Poll_DeserializationError.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -32,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     and values.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Consumer_Poll_DeserializationError(string bootstrapServers)
+        public async Task Consumer_Poll_DeserializationError(string bootstrapServers)
         {
             LogToFile("start Consumer_Poll_DeserializationError");
 
@@ -42,9 +43,9 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 var keyData = Encoding.UTF8.GetBytes("key");
-                firstProduced = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Key = keyData }).Result.TopicPartitionOffset;
+                firstProduced = (await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Key = keyData }, TestContext.Current.CancellationToken)).TopicPartitionOffset;
                 var valData = Encoding.UTF8.GetBytes("val");
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = valData });
+                await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = valData }, TestContext.Current.CancellationToken);
                 Assert.True(producer.Flush(TimeSpan.FromSeconds(10)) == 0);
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_Seek.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Basic test of Consumer.Seek.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Consumer_Seek(string bootstrapServers)
+        public async Task Consumer_Seek(string bootstrapServers)
         {
             LogToFile("start Consumer_Seek");
 
@@ -46,13 +47,13 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             using (var consumer =
                 new TestConsumerBuilder<Null, string>(consumerConfig)
-                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .SetErrorHandler((_, e) => Assert.Fail(e.Reason))
                     .Build())
             {
                 const string checkValue = "check value";
-                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(checkValue, SerializationContext.Empty) }).Result;
-                var dr2 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("second value", SerializationContext.Empty) }).Result;
-                var dr3 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("third value", SerializationContext.Empty) }).Result;
+                var dr = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(checkValue, SerializationContext.Empty) }, TestContext.Current.CancellationToken);
+                var dr2 = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("second value", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
+                var dr3 = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("third value", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
 
                 consumer.Assign(new TopicPartitionOffset[] { new TopicPartitionOffset(singlePartitionTopic, 0, dr.Offset) });
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Simple Consumer StoreOffsets test.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Consumer_StoreOffset(string bootstrapServers)
+        public async Task Consumer_StoreOffset(string bootstrapServers)
         {
             LogToFile("start Consumer_StoreOffset");
 
@@ -66,7 +67,7 @@ namespace Confluent.Kafka.IntegrationTests
                 ConsumeResult<Null, string> record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.Null(record);
 
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test store offset value", SerializationContext.Empty) }).Wait();
+                await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test store offset value", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                 record = consumer.Consume(TimeSpan.FromSeconds(10));
                 Assert.NotNull(record?.Message);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset_ErrState.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Consumer_StoreOffset_ErrState.cs
@@ -51,7 +51,7 @@ namespace Confluent.Kafka.IntegrationTests
                 consumer1.Subscribe(topic.Name);
 
                 // wait until consumer is assigned to both partitions.
-                ConsumeResult<Null, string> cr = consumer1.Consume();
+                ConsumeResult<Null, string> cr = consumer1.Consume(TestContext.Current.CancellationToken);
                 Assert.Equal(2, consumer1.Assignment.Count);
 
                 // store offsets on both partitions should not throw.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/DuplicateConsumerAssign.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -34,7 +35,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     You should never do this, but the brokers don't actually prevent it.
         /// </remarks>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void DuplicateConsumerAssign(string bootstrapServers)
+        public async Task DuplicateConsumerAssign(string bootstrapServers)
         {
             LogToFile("start DuplicateConsumerAssign");
 
@@ -53,7 +54,7 @@ namespace Confluent.Kafka.IntegrationTests
                 DeliveryResult<byte[], byte[]> dr;
                 using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
                 {
-                    dr = producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }).Result;
+                    dr = await producer.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize(testString, SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                     Assert.NotNull(dr);
                     producer.Flush(TimeSpan.FromSeconds(10));
                 }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/GarbageCollect.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -32,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Segfault?
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void GarbageCollect(string bootstrapServers)
+        public async Task GarbageCollect(string bootstrapServers)
         {
             LogToFile("start GarbageCollect");
 
@@ -41,7 +42,7 @@ namespace Confluent.Kafka.IntegrationTests
 
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }).Wait();
+                await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
             }
 
             using (var consumer = new TestConsumerBuilder<byte[], byte[]>(consumerConfig).Build())

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test various message header produce / consume scenarios.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void MessageHeaderProduceConsume(string bootstrapServers)
+        public async Task MessageHeaderProduceConsume(string bootstrapServers)
         {
             LogToFile("start MessageHeaderProduceConsume");
 
@@ -55,33 +56,37 @@ namespace Confluent.Kafka.IntegrationTests
                 // single header value.
                 var headers = new Headers();
                 headers.Add("test-header", new byte[] { 142 } );
-                dr_single = producer.ProduceAsync(
+                dr_single = await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value", Headers = headers }).Result;
+                    new Message<Null, string> { Value = "the value", Headers = headers },
+                    TestContext.Current.CancellationToken);
                 Assert.Single(dr_single.Message.Headers);
                 Assert.Equal("test-header", dr_single.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 142 }, dr_single.Message.Headers[0].GetValueBytes());
 
                 // empty header values
                 var headers0 = new Headers();
-                dr_empty = producer.ProduceAsync(
+                dr_empty = await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value", Headers = headers0 }).Result;
+                    new Message<Null, string> { Value = "the value", Headers = headers0 },
+                    TestContext.Current.CancellationToken);
                 Assert.Empty(dr_empty.Message.Headers);
 
                 // null header value
-                dr_null = producer.ProduceAsync(
+                dr_null = await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value" }).Result;
+                    new Message<Null, string> { Value = "the value" },
+                    TestContext.Current.CancellationToken);
                 Assert.Empty(dr_null.Message.Headers);
 
                 // multiple header values (also Headers no Dictionary, since order is tested).
                 var headers2 = new Headers();
                 headers2.Add("test-header-a", new byte[] { 111 } );
                 headers2.Add("test-header-b", new byte[] { 112 } );
-                dr_multiple = producer.ProduceAsync(
+                dr_multiple = await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<Null, string> { Value = "the value", Headers = headers2 }).Result;
+                    new Message<Null, string> { Value = "the value", Headers = headers2 },
+                    TestContext.Current.CancellationToken);
                 Assert.Equal(2, dr_multiple.Message.Headers.Count);
                 Assert.Equal("test-header-a", dr_multiple.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 111 }, dr_multiple.Message.Headers[0].GetValueBytes());
@@ -95,7 +100,7 @@ namespace Confluent.Kafka.IntegrationTests
                 headers3.Add(new Header("test-header-a", new byte[] { 113 } ));
                 headers3.Add(new Header("test-header-b", new byte[] { 114 } ));
                 headers3.Add(new Header("test-header-c", new byte[] { 115 } ));
-                dr_duplicate = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "the value", Headers = headers3 }).Result;
+                dr_duplicate = await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "the value", Headers = headers3 }, TestContext.Current.CancellationToken);
                 Assert.Equal(5, dr_duplicate.Message.Headers.Count);
                 Assert.Equal("test-header-a", dr_duplicate.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 111 }, dr_duplicate.Message.Headers[0].GetValueBytes());
@@ -104,12 +109,13 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Test headers work as expected with all serializing ProduceAsync variants.
 
-                dr_ol1 = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "the value" }).Result;
+                dr_ol1 = await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "the value" }, TestContext.Current.CancellationToken);
                 Assert.Empty(dr_ol1.Message.Headers);
-                dr_ol3 = producer.ProduceAsync(
+                dr_ol3 = await producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> { Value = "the value", Headers = headers }
-                ).Result;
+                    new Message<Null, string> { Value = "the value", Headers = headers },
+                    TestContext.Current.CancellationToken
+                );
                 Assert.Single(dr_ol3.Message.Headers);
                 Assert.Equal("test-header", dr_ol3.Message.Headers[0].Key);
                 Assert.Equal(new byte[] { 142 }, dr_ol3.Message.Headers[0].GetValueBytes());
@@ -139,13 +145,13 @@ namespace Confluent.Kafka.IntegrationTests
 
                 // Test headers work as expected with all non-serializing ProduceAsync variants. 
 
-                dr_ol4 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = null }).Result;
+                dr_ol4 = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = null }, TestContext.Current.CancellationToken);
                 Assert.Empty(dr_ol4.Message.Headers);
-                dr_ol5 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = null }).Result;
+                dr_ol5 = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = null }, TestContext.Current.CancellationToken);
                 Assert.Empty(dr_ol5.Message.Headers);
-                dr_ol6 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = headers }).Result;
+                dr_ol6 = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = headers }, TestContext.Current.CancellationToken);
                 Assert.Single(dr_ol6.Message.Headers);
-                dr_ol7 = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = headers }).Result;
+                dr_ol7 = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Headers = headers }, TestContext.Current.CancellationToken);
                 Assert.Single(dr_ol7.Message.Headers);
 
                 // Test headers work as expected with all non-serializing Produce variants.
@@ -310,7 +316,7 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var headers = new Headers();
                 headers.Add("my-header", null);
-                nulldr = producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "test-value", Headers = headers }).Result;
+                nulldr = await producer.ProduceAsync(singlePartitionTopic, new Message<Null, string> { Value = "test-value", Headers = headers }, TestContext.Current.CancellationToken);
                 Assert.Single(nulldr.Headers);
                 Assert.Null(nulldr.Headers[0].GetValueBytes());
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Headers_SerializationContext.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Headers_SerializationContext.cs
@@ -79,9 +79,9 @@ namespace Confluent.Kafka.IntegrationTests
                 .SetValueDeserializer(new TestDeserializer())
                 .Build())
             {
-                producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "aaa" });
+                producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = "aaa" }, TestContext.Current.CancellationToken);
                 consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
-                var cr = consumer.Consume();
+                var cr = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr.Message);
                 Assert.Single(cr.Message.Headers);
                 cr.Message.Headers.TryGetLastBytes("test_header", out byte[] testHeader);
@@ -100,9 +100,9 @@ namespace Confluent.Kafka.IntegrationTests
                 .SetValueDeserializer(new TestDeserializer())
                 .Build())
             {
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Value = "aaa", Headers = new Headers { new Header("original", new byte[] { 32 }) } });
+                producer.ProduceAsync(topic.Name, new Message<string, string> { Value = "aaa", Headers = new Headers { new Header("original", new byte[] { 32 }) } }, TestContext.Current.CancellationToken);
                 consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
-                var cr = consumer.Consume();
+                var cr = consumer.Consume(TestContext.Current.CancellationToken);
                 Assert.NotNull(cr.Message);
                 Assert.Equal(3, cr.Message.Headers.Count);
                 cr.Message.Headers.TryGetLastBytes("test_header", out byte[] testHeader);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Ignore.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Test that the ignore deserializer behaves as expected.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void IgnoreTest(string bootstrapServers)
+        public async Task IgnoreTest(string bootstrapServers)
         {
             LogToFile("start IgnoreTest");
 
@@ -41,10 +42,10 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 // Assume that all these produce calls succeed.
-                dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }).Result;
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = new byte[1] { 1 } }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[1] { 0 }, Value = null }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[1] { 42 }, Value = new byte[2] { 42, 240 } }).Wait();
+                dr = await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = new byte[1] { 1 } }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[1] { 0 }, Value = null }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[1] { 42 }, Value = new byte[2] { 42, 240 } }, TestContext.Current.CancellationToken);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/LogDelegate.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -28,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Tests that log messages are received by OnLog on all Producer and Consumer variants.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void LogDelegate(string bootstrapServers)
+        public async Task LogDelegate(string bootstrapServers)
         {
             LogToFile("start LogDelegate");
 
@@ -60,7 +61,7 @@ namespace Confluent.Kafka.IntegrationTests
                     .SetLogHandler((_, m) => logCount += 1)
                     .Build())
             {
-                dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }).Result;
+                dr = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test value", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
             Assert.True(logCount > 0);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/NullVsEmpty.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     as expected.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void NullVsEmpty(string bootstrapServers)
+        public async Task NullVsEmpty(string bootstrapServers)
         {
             LogToFile("start NullVsEmpty");
 
@@ -47,10 +48,10 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
                 // Assume that all these produce calls succeed.
-                dr = producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }).Result;
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = new byte[0] {} }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[0] {}, Value = null }).Wait();
-                producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[0] {}, Value = new byte[0] {} }).Wait();
+                dr = await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = null }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = null, Value = new byte[0] {} }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[0] {}, Value = null }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(new TopicPartition(singlePartitionTopic, 0), new Message<byte[], byte[]> { Key = new byte[0] {}, Value = new byte[0] {} }, TestContext.Current.CancellationToken);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OauthBearerToken_Delegate.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OauthBearerToken_Delegate.cs
@@ -56,7 +56,7 @@ namespace Confluent.Kafka.IntegrationTests
                     producerCallsCount++;
                 })
                 .Build();
-            producer.Flush();
+            producer.Flush(TestContext.Current.CancellationToken);
             Assert.True(producerCallsCount > 0);
 
             LogToFileEndTest();

--- a/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/OnPartitionsAssignedNotSet.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void OnPartitionsAssignedNotSet(string bootstrapServers)
+        public async Task OnPartitionsAssignedNotSet(string bootstrapServers)
         {
             LogToFile("start OnPartitionsAssignedNotSet");
 
@@ -47,7 +48,7 @@ namespace Confluent.Kafka.IntegrationTests
             // Producing onto the topic to make sure it exists.
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                var dr = producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }).Result;
+                var dr = await producer.ProduceAsync(singlePartitionTopic, new Message<byte[], byte[]> { Value = Serializers.Utf8.Serialize("test string", SerializationContext.Empty) }, TestContext.Current.CancellationToken);
                 Assert.NotEqual(Offset.Unset, dr.Offset);
                 producer.Flush(TimeSpan.FromSeconds(10));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_DisableDeliveryReports.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_DisableDeliveryReports.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Producer_DisableDeliveryReports(string bootstrapServers)
+        public async Task Producer_DisableDeliveryReports(string bootstrapServers)
         {
             LogToFile("start Producer_DisableDeliveryReports");
 
@@ -76,23 +77,27 @@ namespace Confluent.Kafka.IntegrationTests
 
                 var drTask = producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue },
+                    TestContext.Current.CancellationToken);
                 Assert.True(drTask.IsCompleted); // should complete immediately.
-                Assert.Equal(Offset.Unset, drTask.Result.Offset);
-                Assert.Equal(Partition.Any, drTask.Result.Partition);
-                Assert.Equal(singlePartitionTopic, drTask.Result.Topic);
-                Assert.Equal(TestKey, drTask.Result.Message.Key);
-                Assert.Equal(TestValue, drTask.Result.Message.Value);
+                var dr = await drTask;
+                Assert.Equal(Offset.Unset, dr.Offset);
+                Assert.Equal(Partition.Any, dr.Partition);
+                Assert.Equal(singlePartitionTopic, dr.Topic);
+                Assert.Equal(TestKey, dr.Message.Key);
+                Assert.Equal(TestValue, dr.Message.Value);
 
                 drTask = producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue });
+                    new Message<byte[], byte[]> { Key = TestKey, Value = TestValue },
+                    TestContext.Current.CancellationToken);
                 Assert.True(drTask.IsCompleted); // should complete immediately.
-                Assert.Equal(Offset.Unset, drTask.Result.Offset);
-                Assert.Equal(0, (int)drTask.Result.Partition);
-                Assert.Equal(singlePartitionTopic, drTask.Result.Topic);
-                Assert.Equal(TestKey, drTask.Result.Message.Key);
-                Assert.Equal(TestValue, drTask.Result.Message.Value);
+                dr = await drTask;
+                Assert.Equal(Offset.Unset, dr.Offset);
+                Assert.Equal(0, (int)dr.Partition);
+                Assert.Equal(singlePartitionTopic, dr.Topic);
+                Assert.Equal(TestKey, dr.Message.Key);
+                Assert.Equal(TestValue, dr.Message.Value);
 
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Handles.cs
@@ -17,6 +17,7 @@
 #pragma warning disable xUnit1026
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Producer_Handles(string bootstrapServers)
+        public async Task Producer_Handles(string bootstrapServers)
         {
             LogToFile("start Producer_Handles");
 
@@ -47,32 +48,32 @@ namespace Confluent.Kafka.IntegrationTests
                 using (var producer7 = new TestProducerBuilder<double, double>(producerConfig).Build())
                 using (var adminClient = new DependentAdminClientBuilder(producer7.Handle).Build())
                 {
-                    var r1 = producer1.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 42 }, Value = new byte[] { 33 } }).Result;
+                    var r1 = await producer1.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 42 }, Value = new byte[] { 33 } }, TestContext.Current.CancellationToken);
                     Assert.Equal(new byte[] { 42 }, r1.Key);
                     Assert.Equal(new byte[] { 33 }, r1.Value);
                     Assert.Equal(0, r1.Offset);
 
-                    var r2 = producer2.ProduceAsync(topic.Name, new Message<string, string> { Key = "hello", Value = "world" }).Result;
+                    var r2 = await producer2.ProduceAsync(topic.Name, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
                     Assert.Equal("hello", r2.Key);
                     Assert.Equal("world", r2.Value);
 
-                    var r3 = producer3.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 40 }, Value = new byte[] { 31 } }).Result;
+                    var r3 = await producer3.ProduceAsync(topic.Name, new Message<byte[], byte[]> { Key = new byte[] { 40 }, Value = new byte[] { 31 } }, TestContext.Current.CancellationToken);
                     Assert.Equal(new byte[] { 40 }, r3.Key);
                     Assert.Equal(new byte[] { 31 }, r3.Value);
 
-                    var r4 = producer4.ProduceAsync(topic.Name, new Message<int, string> { Key = 42, Value = "mellow world" }).Result;
+                    var r4 = await producer4.ProduceAsync(topic.Name, new Message<int, string> { Key = 42, Value = "mellow world" }, TestContext.Current.CancellationToken);
                     Assert.Equal(42, r4.Key);
                     Assert.Equal("mellow world", r4.Value);
 
-                    var r5 = producer5.ProduceAsync(topic.Name, new Message<int, int> { Key = int.MaxValue, Value = int.MinValue }).Result;
+                    var r5 = await producer5.ProduceAsync(topic.Name, new Message<int, int> { Key = int.MaxValue, Value = int.MinValue }, TestContext.Current.CancellationToken);
                     Assert.Equal(int.MaxValue, r5.Key);
                     Assert.Equal(int.MinValue, r5.Value);
 
-                    var r6 = producer6.ProduceAsync(topic.Name, new Message<string, byte[]> { Key = "yellow mould", Value = new byte[] { 69 } }).Result;
+                    var r6 = await producer6.ProduceAsync(topic.Name, new Message<string, byte[]> { Key = "yellow mould", Value = new byte[] { 69 } }, TestContext.Current.CancellationToken);
                     Assert.Equal("yellow mould", r6.Key);
                     Assert.Equal(new byte[] { 69 }, r6.Value);
 
-                    var r7 = producer7.ProduceAsync(topic.Name, new Message<double, double> { Key = 44.0, Value = 234.4 }).Result;
+                    var r7 = await producer7.ProduceAsync(topic.Name, new Message<double, double> { Key = 44.0, Value = 234.4 }, TestContext.Current.CancellationToken);
                     Assert.Equal(44.0, r7.Key);
                     Assert.Equal(234.4, r7.Value);
 

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_OptimizeDeliveryReports.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_OptimizeDeliveryReports.cs
@@ -16,6 +16,7 @@
 
 #pragma warning disable xUnit1026
 
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -28,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public async void Producer_OptimizeDeliveryReports(string bootstrapServers)
+        public async Task Producer_OptimizeDeliveryReports(string bootstrapServers)
         {
             LogToFile("start Producer_OptimizeDeliveryReports");
 
@@ -52,8 +53,9 @@ namespace Confluent.Kafka.IntegrationTests
                     { 
                         Key = TestKey, 
                         Value = TestValue, 
-                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) } 
-                    }
+                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
+                    },
+                    TestContext.Current.CancellationToken
                 );
                 Assert.Equal(TimestampType.NotAvailable, dr.Timestamp.Type);
                 Assert.Equal(0, dr.Timestamp.UnixTimestampMs);
@@ -73,8 +75,9 @@ namespace Confluent.Kafka.IntegrationTests
                     { 
                         Key = TestKey, 
                         Value = TestValue, 
-                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) } 
-                    }
+                        Headers = new Headers() { new Header("my-header", new byte[] { 42 }) }
+                    },
+                    TestContext.Current.CancellationToken
                 );
                 Assert.Equal(TimestampType.NotAvailable, dr.Timestamp.Type);
                 Assert.Equal(0, dr.Timestamp.UnixTimestampMs);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll.cs
@@ -31,14 +31,14 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Producer_Poll(string bootstrapServers)
+        public async Task Producer_Poll(string bootstrapServers)
         {
             LogToFile("start Producer_Poll");
 
             using (var tempTopic = new TemporaryTopic(bootstrapServers, 1))
             using (var producer = new TestProducerBuilder<Null, string>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             {
-                var r = producer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "a message" }).Result;
+                var r = await producer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "a message" }, TestContext.Current.CancellationToken);
                 Assert.True(r.Status == PersistenceStatus.Persisted);
 
                 // should be no events to serve and this should block for 500ms.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll_Backoff.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Poll_Backoff.cs
@@ -73,7 +73,7 @@ namespace Confluent.Kafka.IntegrationTests
                 }
                 Assert.Equal(1, exceptionCount);
 
-                producer.Flush();
+                producer.Flush(TestContext.Current.CancellationToken);
             }
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Await.cs
@@ -42,14 +42,19 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     var dr = await producer.ProduceAsync(
                         singlePartitionTopic,
-                        new Message<Null, string> { Value = "test string" });
+                        new Message<Null, string> { Value = "test string" },
+                        TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                     Assert.NotEqual(Offset.Unset, dr.Offset);
                 }
             };
 
+            // deliberately blocks the calling thread via Task.Wait (rather than await) to test that
+            // awaiting ProduceAsync and then blocking synchronously does not deadlock.
+#pragma warning disable xUnit1031, xUnit1051
             mthd().Wait();
-            
+#pragma warning restore xUnit1031, xUnit1051
+
             Assert.Equal(0, Library.HandleCount);
             LogToFile("end   Producer_ProduceAsync_Await_Serializing");
         }
@@ -67,7 +72,8 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 var dr = await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") });
+                    new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") },
+                    TestContext.Current.CancellationToken);
                 Assert.NotEqual(Offset.Unset, dr.Offset);
             }
 
@@ -92,7 +98,8 @@ namespace Confluent.Kafka.IntegrationTests
                     {
                         await producer.ProduceAsync(
                             new TopicPartition(singlePartitionTopic, 42),
-                            new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") });
+                            new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") },
+                            TestContext.Current.CancellationToken);
                         throw new Exception("unexpected exception");
                     });
             }
@@ -105,12 +112,16 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     var dr = await producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 1001),
-                        new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") });
+                        new Message<byte[], byte[]> { Value = Encoding.UTF8.GetBytes("test string") },
+                        TestContext.Current.CancellationToken);
                     throw new Exception("unexpected exception.");
                 }
             };
 
+            // deliberately tests that blocking Wait() on a faulted task throws AggregateException.
+#pragma warning disable xUnit1031, xUnit1051
             Assert.Throws<AggregateException>(() => { mthd().Wait(); });
+#pragma warning restore xUnit1031, xUnit1051
 
             Assert.Equal(0, Library.HandleCount);
             LogToFile("end   Producer_ProduceAsync_Await_Throws");

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Error.cs
@@ -30,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Producer_ProduceAsync_Error(string bootstrapServers)
+        public async Task Producer_ProduceAsync_Error(string bootstrapServers)
         {
             LogToFile("start Producer_ProduceAsync_Error");
 
@@ -44,23 +44,25 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drt = producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 42),
-                    new Message<string, string> { Key = "test key 0", Value = "test val 0" });
+                    new Message<string, string> { Key = "test key 0", Value = "test val 0" },
+                    TestContext.Current.CancellationToken);
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
+            // deliberately tests that blocking Wait() on a faulted task throws AggregateException.
+#pragma warning disable xUnit1031, xUnit1051
             Assert.Throws<AggregateException>(() => { drt.Wait(); });
+#pragma warning restore xUnit1031, xUnit1051
 
             try
             {
-                var dr = drt.Result;
+                var dr = await drt;
             }
-            catch (AggregateException e)
+            catch (ProduceException<string, string> inner)
             {
-                var inner = e.InnerException;
-                Assert.IsType<ProduceException<string, string>>(inner);
-                var dr = ((ProduceException<string, string>)inner).DeliveryResult;
-                var err = ((ProduceException<string, string>)inner).Error;
-                
+                var dr = inner.DeliveryResult;
+                var err = inner.Error;
+
                 Assert.True(err.IsError);
                 Assert.Equal(PersistenceStatus.NotPersisted, dr.Status);
                 Assert.False(err.IsFatal);
@@ -79,23 +81,26 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drt2 = producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 42),
-                    new Message<byte[], byte[]> { Key = new byte[] { 100 }, Value = new byte[] { 101 } });
+                    new Message<byte[], byte[]> { Key = new byte[] { 100 }, Value = new byte[] { 101 } },
+                    TestContext.Current.CancellationToken);
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
+            // deliberately tests that blocking Wait() on a faulted task throws AggregateException.
+            // (note: this pre-existing check re-checks 'drt', not 'drt2' -- kept as-is, out of scope for this warning fix)
+#pragma warning disable xUnit1031, xUnit1051
             Assert.Throws<AggregateException>(() => { drt.Wait(); });
+#pragma warning restore xUnit1031, xUnit1051
 
             try
             {
-                var dr = drt2.Result;
+                var dr = await drt2;
             }
-            catch (AggregateException e)
+            catch (ProduceException<byte[], byte[]> inner)
             {
-                var inner = e.InnerException;
-                Assert.IsType<ProduceException<byte[], byte[]>>(inner);
-                var dr = ((ProduceException<byte[], byte[]>)inner).DeliveryResult;
-                var err = ((ProduceException<byte[], byte[]>)inner).Error;
-                
+                var dr = inner.DeliveryResult;
+                var err = inner.Error;
+
                 Assert.True(err.IsError);
                 Assert.False(err.IsFatal);
                 Assert.Equal(partitionedTopic, dr.Topic);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_HighConcurrency.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_HighConcurrency.cs
@@ -59,17 +59,23 @@ namespace Confluent.Kafka.IntegrationTests
                 int N = workerThreads+2;
                 for (int i=0; i<N; ++i)
                 {
-                    tasks.Add(producer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "test" }));
+                    tasks.Add(producer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "test" }, TestContext.Current.CancellationToken));
                 }
 
+                // deliberately blocks the calling thread via Task.WaitAll (rather than await) to test that
+                // producing via more concurrent tasks than there are thread pool worker threads does not deadlock.
+#pragma warning disable xUnit1031, xUnit1051
                 Task.WaitAll(tasks.ToArray());
+#pragma warning restore xUnit1031, xUnit1051
 
                 for (int i=0; i<N; ++i)
                 {
-                    tasks.Add(dProducer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "test" }));
+                    tasks.Add(dProducer.ProduceAsync(tempTopic.Name, new Message<Null, string> { Value = "test" }, TestContext.Current.CancellationToken));
                 }
 
+#pragma warning disable xUnit1031, xUnit1051
                 Task.WaitAll(tasks.ToArray());
+#pragma warning restore xUnit1031, xUnit1051
             }
 
             ThreadPool.SetMaxThreads(originalWorkerThreads, originalCompletionPortThreads);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Null_Task.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Producer_ProduceAsync_Null_Task(string bootstrapServers)
+        public async Task Producer_ProduceAsync_Null_Task(string bootstrapServers)
         {
             LogToFile("start Producer_ProduceAsync_Null_Task");
 
@@ -46,14 +46,14 @@ namespace Confluent.Kafka.IntegrationTests
             using (var producer = new TestProducerBuilder<Null, Null>(producerConfig).Build())
             {
                 drs.Add(producer.ProduceAsync(
-                    new TopicPartition(partitionedTopic, 0), new Message<Null, Null> {}));
-                drs.Add(producer.ProduceAsync(partitionedTopic, new Message<Null, Null> {}));
+                    new TopicPartition(partitionedTopic, 0), new Message<Null, Null> {}, TestContext.Current.CancellationToken));
+                drs.Add(producer.ProduceAsync(partitionedTopic, new Message<Null, Null> {}, TestContext.Current.CancellationToken));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
             for (int i=0; i<2; ++i)
             {
-                var dr = drs[i].Result;
+                var dr = await drs[i];
                 Assert.True(dr.Partition == 0 || dr.Partition == 1);
                 Assert.Equal(partitionedTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
@@ -63,7 +63,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
 
-            Assert.Equal((Partition)0, drs[0].Result.Partition);
+            Assert.Equal((Partition)0, (await drs[0]).Partition);
             
 
             // byte[] case
@@ -71,14 +71,14 @@ namespace Confluent.Kafka.IntegrationTests
             var drs2 = new List<Task<DeliveryResult<byte[], byte[]>>>();
             using (var producer = new TestProducerBuilder<byte[], byte[]>(producerConfig).Build())
             {
-                drs2.Add(producer.ProduceAsync(new TopicPartition(partitionedTopic, 1), new Message<byte[], byte[]> {}));
-                drs2.Add(producer.ProduceAsync(partitionedTopic, new Message<byte[], byte[]> {}));
+                drs2.Add(producer.ProduceAsync(new TopicPartition(partitionedTopic, 1), new Message<byte[], byte[]> {}, TestContext.Current.CancellationToken));
+                drs2.Add(producer.ProduceAsync(partitionedTopic, new Message<byte[], byte[]> {}, TestContext.Current.CancellationToken));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
             for (int i=0; i<2; ++i)
             {
-                var dr = drs2[i].Result;
+                var dr = await drs2[i];
                 Assert.True(dr.Partition == 0 || dr.Partition == 1);
                 Assert.Equal(partitionedTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
@@ -88,7 +88,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
             
-            Assert.Equal((Partition)1, drs2[0].Result.Partition);
+            Assert.Equal((Partition)1, (await drs2[0]).Partition);
             
 
             Assert.Equal(0, Library.HandleCount);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_ProduceAsync_Task.cs
@@ -33,7 +33,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Producer_ProduceAsync_Task(string bootstrapServers)
+        public async Task Producer_ProduceAsync_Task(string bootstrapServers)
         {
             LogToFile("start Producer_ProduceAsync_Task");
 
@@ -47,16 +47,18 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drs.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 1),
-                    new Message<string, string> { Key = "test key 0", Value = "test val 0" }));
+                    new Message<string, string> { Key = "test key 0", Value = "test val 0" },
+                    TestContext.Current.CancellationToken));
                 drs.Add(producer.ProduceAsync(
                     partitionedTopic,
-                    new Message<string, string> { Key = "test key 1", Value = "test val 1" }));
+                    new Message<string, string> { Key = "test key 1", Value = "test val 1" },
+                    TestContext.Current.CancellationToken));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
             for (int i=0; i<2; ++i)
             {
-                var dr = drs[i].Result;
+                var dr = await drs[i];
                 Assert.Equal(PersistenceStatus.Persisted, dr.Status);
                 Assert.Equal(partitionedTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
@@ -67,7 +69,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
 
-            Assert.Equal((Partition)1, drs[0].Result.Partition);
+            Assert.Equal((Partition)1, (await drs[0]).Partition);
 
 
             // byte[] case
@@ -77,16 +79,18 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 drs2.Add(producer.ProduceAsync(
                     new TopicPartition(partitionedTopic, 1),
-                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 2"), Value = Encoding.UTF8.GetBytes("test val 2") }));
+                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 2"), Value = Encoding.UTF8.GetBytes("test val 2") },
+                    TestContext.Current.CancellationToken));
                 drs2.Add(producer.ProduceAsync(
                     partitionedTopic,
-                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 3"), Value = Encoding.UTF8.GetBytes("test val 3") }));
+                    new Message<byte[], byte[]> { Key = Encoding.UTF8.GetBytes("test key 3"), Value = Encoding.UTF8.GetBytes("test val 3") },
+                    TestContext.Current.CancellationToken));
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
 
             for (int i=0; i<2; ++i)
             {
-                var dr = drs2[i].Result;
+                var dr = await drs2[i];
                 Assert.Equal(partitionedTopic, dr.Topic);
                 Assert.True(dr.Offset >= 0);
                 Assert.True(dr.Partition == 0 || dr.Partition == 1);
@@ -96,7 +100,7 @@ namespace Confluent.Kafka.IntegrationTests
                 Assert.True(Math.Abs((DateTime.UtcNow - dr.Message.Timestamp.UtcDateTime).TotalMinutes) < 1.0);
             }
 
-            Assert.Equal((Partition)1, drs2[0].Result.Partition);
+            Assert.Equal((Partition)1, (await drs2[0]).Partition);
 
             Assert.Equal(0, Library.HandleCount);
             LogToFile("end   Producer_ProduceAsync_Task");

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_SyncOverAsync.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Producer_Produce_SyncOverAsync.cs
@@ -59,6 +59,10 @@ namespace Confluent.Kafka.IntegrationTests
                 // will deadlock if N >= workerThreads. Set to max number that 
                 // should not deadlock.
                 int N = workerThreads-1;
+                // deliberately blocks worker threads via Task.Run + Monitor.Wait (rather than an
+                // async-friendly approach) to test that sync-over-async does not deadlock when
+                // blocked threads are one less than available workers.
+#pragma warning disable xUnit1031, xUnit1051
                 for (int i=0; i<N; ++i)
                 {
                     Func<int, Action> actionCreator = (taskNumber) =>
@@ -90,6 +94,7 @@ namespace Confluent.Kafka.IntegrationTests
                 }
 
                 Task.WaitAll(tasks.ToArray());
+#pragma warning restore xUnit1031, xUnit1051
             }
 
             ThreadPool.SetMaxThreads(originalWorkerThreads, originalCompletionPortThreads);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Timestamps.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -30,7 +31,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Integration tests for Producing / consuming timestamps.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Timestamps(string bootstrapServers)
+        public async Task Timestamps(string bootstrapServers)
         {
             LogToFile("start Timestamps");
 
@@ -52,43 +53,47 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 // --- ProduceAsync, serializer case.
 
-                drs_task.Add(producer.ProduceAsync(
-                    singlePartitionTopic, 
-                    new Message<Null, string> { Value = "testvalue" }).Result);
-                
+                drs_task.Add(await producer.ProduceAsync(
+                    singlePartitionTopic,
+                    new Message<Null, string> { Value = "testvalue" }, TestContext.Current.CancellationToken));
+
                 // TimestampType: CreateTime
-                drs_task.Add(producer.ProduceAsync(
+                drs_task.Add(await producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> 
-                    { 
-                        Value = "test-value", 
+                    new Message<Null, string>
+                    {
+                        Value = "test-value",
                         Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc))
-                    }).Result);
+                    }, TestContext.Current.CancellationToken));
 
                 // TimestampType: CreateTime (default)
-                drs_task.Add(producer.ProduceAsync(
+                drs_task.Add(await producer.ProduceAsync(
                     new TopicPartition(singlePartitionTopic, 0),
-                    new Message<Null, string> { Value = "test-value" }).Result);
+                    new Message<Null, string> { Value = "test-value" }, TestContext.Current.CancellationToken));
 
                 // TimestampType: LogAppendTime
+                // Deliberately uses .Result (not await) so the thrown ArgumentException is
+                // observed wrapped in an AggregateException, as asserted below.
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 0),
                         new Message<Null, string>
                         {
-                            Value = "test-value", 
-                            Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) 
-                        }).Result);
+                            Value = "test-value",
+                            Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime)
+                        }, TestContext.Current.CancellationToken).Result);
 
                 // TimestampType: NotAvailable
+                // Deliberately uses .Result (not await) so the thrown ArgumentException is
+                // observed wrapped in an AggregateException, as asserted below.
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         new TopicPartition(singlePartitionTopic, 0),
-                        new Message<Null, string> 
-                        { 
+                        new Message<Null, string>
+                        {
                             Value = "test-value",
                             Timestamp = new Timestamp(10, TimestampType.NotAvailable)
-                        }).Result);
+                        }, TestContext.Current.CancellationToken).Result);
 
                 Action<DeliveryReport<Null, string>> dh 
                     = (DeliveryReport<Null, string> dr) => drs_produce.Add(dr);
@@ -145,31 +150,35 @@ namespace Confluent.Kafka.IntegrationTests
             {
                 // --- ProduceAsync, byte[] case.
 
-                drs2_task.Add(producer.ProduceAsync(
+                drs2_task.Add(await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Timestamp = Timestamp.Default }).Result);
+                    new Message<byte[], byte[]> { Timestamp = Timestamp.Default }, TestContext.Current.CancellationToken));
 
                 // TimestampType: CreateTime
-                drs2_task.Add(producer.ProduceAsync(
+                drs2_task.Add(await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)) }).Result);
+                    new Message<byte[], byte[]> { Timestamp = new Timestamp(new DateTime(2008, 11, 12, 0, 0, 0, DateTimeKind.Utc)) }, TestContext.Current.CancellationToken));
 
                 // TimestampType: CreateTime (default)
-                drs2_task.Add(producer.ProduceAsync(
+                drs2_task.Add(await producer.ProduceAsync(
                     singlePartitionTopic,
-                    new Message<byte[], byte[]> { Timestamp = Timestamp.Default }).Result);
+                    new Message<byte[], byte[]> { Timestamp = Timestamp.Default }, TestContext.Current.CancellationToken));
 
                 // TimestampType: LogAppendTime
+                // Deliberately uses .Result (not await) so the thrown ArgumentException is
+                // observed wrapped in an AggregateException, as asserted below.
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         singlePartitionTopic,
-                        new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) }).Result);
+                        new Message<byte[], byte[]> { Timestamp = new Timestamp(DateTime.Now, TimestampType.LogAppendTime) }, TestContext.Current.CancellationToken).Result);
 
                 // TimestampType: NotAvailable
+                // Deliberately uses .Result (not await) so the thrown ArgumentException is
+                // observed wrapped in an AggregateException, as asserted below.
                 Assert.Throws<AggregateException>(() =>
                     producer.ProduceAsync(
                         singlePartitionTopic,
-                        new Message<byte[], byte[]> { Timestamp = new Timestamp(10, TimestampType.NotAvailable) }).Result);
+                        new Message<byte[], byte[]> { Timestamp = new Timestamp(10, TimestampType.NotAvailable) }, TestContext.Current.CancellationToken).Result);
 
 
                 // --- begin produce, byte[] case.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Abort.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Abort.cs
@@ -57,7 +57,7 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
 
-                    var cr1 = consumer.Consume();
+                    var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                     var cr2 = consumer.Consume(TimeSpan.FromMilliseconds(100)); // force the consumer to read over the final control message internally.
                     Assert.Equal("test val 1", cr1.Message.Value);
                     Assert.Equal(2, cr1.Offset); // there should be skipped offsets due to the aborted txn and commit marker in the log.
@@ -68,8 +68,8 @@ namespace Confluent.Kafka.IntegrationTests
                 {
                     consumer.Assign(new TopicPartitionOffset(topic.Name, 0, 0));
 
-                    var cr1 = consumer.Consume();
-                    var cr2 = consumer.Consume();
+                    var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
+                    var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                     var cr3 = consumer.Consume(TimeSpan.FromMilliseconds(100)); // force the consumer to read over the final control message internally.
                     Assert.Equal("test val 0", cr1.Message.Value);
                     Assert.Equal(0, cr1.Offset); // the aborted message should not be skipped.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Commit.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Commit.cs
@@ -54,8 +54,8 @@ namespace Confluent.Kafka.IntegrationTests
                     producer.Produce(topic.Name, new Message<string, string> { Key = "test key 1", Value = "test val 1" });
                     producer.CommitTransaction(defaultTimeout);
 
-                    var cr1 = consumer.Consume();
-                    var cr2 = consumer.Consume();
+                    var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
+                    var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                     var cr3 = consumer.Consume(TimeSpan.FromMilliseconds(100)); // force the consumer to read over the final control message internally.
                     Assert.Equal(wm.High, cr1.Offset);
                     Assert.Equal(wm.High+2, cr2.Offset); // there should be a skipped offset due to a commit marker in the log.

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Statistics.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_Statistics.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
@@ -29,7 +30,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Transactions_Statistics(string bootstrapServers)
+        public async Task Transactions_Statistics(string bootstrapServers)
         {
             LogToFile("start Transactions_Statistics");
 
@@ -65,17 +66,17 @@ namespace Confluent.Kafka.IntegrationTests
 
                 producer.InitTransactions(TimeSpan.FromSeconds(30));
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message_a" }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message_a" }, TestContext.Current.CancellationToken);
                 producer.CommitTransaction(TimeSpan.FromSeconds(30));
 
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message_b" }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message_b" }, TestContext.Current.CancellationToken);
                 producer.CommitTransaction(TimeSpan.FromSeconds(30));
 
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message1" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message2" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message3" }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message1" }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message2" }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message3" }, TestContext.Current.CancellationToken);
 
                 for (int i=0; i<10; ++i)
                 {

--- a/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/Transactions_WatermarkOffsets.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -28,7 +29,7 @@ namespace Confluent.Kafka.IntegrationTests
     public partial class Tests
     {
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void Transactions_WatermarkOffsets(string bootstrapServers)
+        public async Task Transactions_WatermarkOffsets(string bootstrapServers)
         {
             LogToFile("start Transactions_WatermarkOffsets");
 
@@ -45,9 +46,9 @@ namespace Confluent.Kafka.IntegrationTests
 
                 producer.InitTransactions(TimeSpan.FromSeconds(30));
                 producer.BeginTransaction();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message1" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message2" }).Wait();
-                producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message3" }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message1" }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message2" }, TestContext.Current.CancellationToken);
+                await producer.ProduceAsync(topic.Name, new Message<string, string> { Key = "test", Value = "message3" }, TestContext.Current.CancellationToken);
 
                 WatermarkOffsets wo2 = new WatermarkOffsets(Offset.Unset, Offset.Unset);
                 for (int i=0; i<10; ++i)

--- a/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/WatermarkOffsets.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka.TestsCommon;
 
@@ -31,7 +32,7 @@ namespace Confluent.Kafka.IntegrationTests
         ///     Tests for GetWatermarkOffsets and QueryWatermarkOffsets.
         /// </summary>
         [Theory, MemberData(nameof(KafkaParameters))]
-        public void WatermarkOffsets(string bootstrapServers)
+        public async Task WatermarkOffsets(string bootstrapServers)
         {
             LogToFile("start WatermarkOffsets");
 
@@ -51,7 +52,7 @@ namespace Confluent.Kafka.IntegrationTests
                 DeliveryResult<Null, string> dr;
                 using (var producer = new TestProducerBuilder<Null, string>(producerConfig).Build())
                 {
-                    dr = producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = testString }).Result;
+                    dr = await producer.ProduceAsync(topic.Name, new Message<Null, string> { Value = testString }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10))); // this isn't necessary.
                 }
 

--- a/test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/AwsRealStsIntegrationTests.cs
+++ b/test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/AwsRealStsIntegrationTests.cs
@@ -37,10 +37,10 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
     /// </remarks>
     public class AwsRealStsIntegrationTests
     {
-        [SkippableFact]
+        [Fact]
         public void RoundTrip_ProducesValidJwtWithExpectedClaims()
         {
-            Skip.IfNot(
+            Assert.SkipUnless(
                 Environment.GetEnvironmentVariable("RUN_AWS_STS_REAL") == "1",
                 "Set RUN_AWS_STS_REAL=1 to enable. Requires EC2/Lambda with the right IAM role.");
 

--- a/test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/AwsStsTokenProviderTests.cs
+++ b/test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/AwsStsTokenProviderTests.cs
@@ -118,7 +118,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var fake = new FakeStsClient((req, ct) => Task.FromResult(OkResponse()));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://my.audience");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.Single(fake.LastRequest.Audience);
             Assert.Equal("https://my.audience", fake.LastRequest.Audience[0]);
         }
@@ -130,7 +130,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var cfg = AwsOAuthBearerConfig.Parse(
                 "region=us-east-1,audience=https://a,signing_algorithm=RS256");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.Equal("RS256", fake.LastRequest.SigningAlgorithm);
         }
 
@@ -141,7 +141,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var cfg = AwsOAuthBearerConfig.Parse(
                 "region=us-east-1,audience=https://a,duration_seconds=900");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.Equal(900, fake.LastRequest.DurationSeconds);
         }
 
@@ -151,7 +151,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var fake = new FakeStsClient((req, ct) => Task.FromResult(OkResponse()));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.Equal(300, fake.LastRequest.DurationSeconds);
         }
 
@@ -161,7 +161,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var fake = new FakeStsClient((req, ct) => Task.FromResult(OkResponse()));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.Equal("ES384", fake.LastRequest.SigningAlgorithm);
         }
 
@@ -172,7 +172,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var cfg = AwsOAuthBearerConfig.Parse(
                 "region=us-east-1,audience=https://a,tag_team=platform,tag_environment=prod");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(2, fake.LastRequest.Tags.Count);
             Assert.Contains(fake.LastRequest.Tags, t => t.Key == "team" && t.Value == "platform");
@@ -185,7 +185,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var fake = new FakeStsClient((req, ct) => Task.FromResult(OkResponse()));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await provider.GetTokenAsync();
+            await provider.GetTokenAsync(TestContext.Current.CancellationToken);
 
             // AWS SDK pre-initializes Tags to an empty AlwaysSendList<Tag>; verify we didn't add any entries.
             Assert.Empty(fake.LastRequest.Tags);
@@ -199,7 +199,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var fake = new FakeStsClient((req, ct) => Task.FromResult(OkResponse()));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            var tok = await provider.GetTokenAsync();
+            var tok = await provider.GetTokenAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(CannedJwt, tok.TokenValue);
             Assert.Equal(RoleArn, tok.PrincipalName);
@@ -221,7 +221,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
                 }));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            var tok = await provider.GetTokenAsync();
+            var tok = await provider.GetTokenAsync(TestContext.Current.CancellationToken);
 
             var utcKind = DateTime.SpecifyKind(localKindTimestamp, DateTimeKind.Utc);
             var expected = new DateTimeOffset(utcKind).ToUnixTimeMilliseconds();
@@ -243,7 +243,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var provider = new AwsStsTokenProvider(cfg, fake);
 
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => provider.GetTokenAsync());
+                () => provider.GetTokenAsync(TestContext.Current.CancellationToken));
             Assert.Contains("Expiration", ex.Message);
         }
         
@@ -260,7 +260,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
                 "region=us-east-1,audience=https://a",
                 saslExtensions);
             var provider = new AwsStsTokenProvider(cfg, fake);
-            var tok = await provider.GetTokenAsync();
+            var tok = await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.NotNull(tok.Extensions);
             Assert.Equal(2, tok.Extensions.Count);
             Assert.Equal("lkc-123", tok.Extensions["logicalCluster"]);
@@ -273,7 +273,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var fake = new FakeStsClient((req, ct) => Task.FromResult(OkResponse()));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            var tok = await provider.GetTokenAsync();
+            var tok = await provider.GetTokenAsync(TestContext.Current.CancellationToken);
             Assert.Null(tok.Extensions);
         }
 
@@ -290,7 +290,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
                 }));
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
-            await Assert.ThrowsAsync<FormatException>(() => provider.GetTokenAsync());
+            await Assert.ThrowsAsync<FormatException>(() => provider.GetTokenAsync(TestContext.Current.CancellationToken));
         }
 
         [Fact]
@@ -303,7 +303,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
             var ex = await Assert.ThrowsAsync<AmazonSecurityTokenServiceException>(
-                () => provider.GetTokenAsync());
+                () => provider.GetTokenAsync(TestContext.Current.CancellationToken));
             Assert.Equal("AccessDenied", ex.ErrorCode);
         }
 
@@ -316,7 +316,7 @@ namespace Confluent.Kafka.OAuthBearer.Aws.UnitTests
             var cfg = AwsOAuthBearerConfig.Parse("region=us-east-1,audience=https://a");
             var provider = new AwsStsTokenProvider(cfg, fake);
             await Assert.ThrowsAsync<OutboundWebIdentityFederationDisabledException>(
-                () => provider.GetTokenAsync());
+                () => provider.GetTokenAsync(TestContext.Current.CancellationToken));
         }
 
         [Fact]

--- a/test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/Confluent.Kafka.OAuthBearer.Aws.UnitTests.csproj
+++ b/test/Confluent.Kafka.OAuthBearer.Aws.UnitTests/Confluent.Kafka.OAuthBearer.Aws.UnitTests.csproj
@@ -11,10 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Confluent.Kafka.UnitTests/Admin/AlterUserScramCredentialsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/AlterUserScramCredentialsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -134,7 +135,7 @@ namespace Confluent.Kafka.UnitTests
         };
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -151,7 +152,7 @@ namespace Confluent.Kafka.UnitTests
         }
         
         [Fact]
-        public async void NullAlterations()
+        public async Task NullAlterations()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -168,7 +169,7 @@ namespace Confluent.Kafka.UnitTests
         }
         
         [Fact]
-        public async void InvalidSubclass()
+        public async Task InvalidSubclass()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {

--- a/test/Confluent.Kafka.UnitTests/Admin/CreateAclsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/CreateAclsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
@@ -58,7 +59,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullAclBindings()
+        public async Task NullAclBindings()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -69,7 +70,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void EmptyAclBindings()
+        public async Task EmptyAclBindings()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -80,7 +81,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullResourcePattern()
+        public async Task NullResourcePattern()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -97,7 +98,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullAccessControlEntry()
+        public async Task NullAccessControlEntry()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -114,7 +115,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -127,7 +128,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void InvalidAclBindings()
+        public async Task InvalidAclBindings()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {

--- a/test/Confluent.Kafka.UnitTests/Admin/CreateTopicsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/CreateTopicsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
@@ -24,7 +25,7 @@ namespace Confluent.Kafka.UnitTests
     public class CreateTopicsErrorTests
     {
         [Fact]
-        public async void NullTopic()
+        public async Task NullTopic()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:666" }).Build())
             {
@@ -36,7 +37,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:666" }).Build())
             {

--- a/test/Confluent.Kafka.UnitTests/Admin/DeleteAclsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/DeleteAclsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
@@ -68,7 +69,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullAclBindingFilters()
+        public async Task NullAclBindingFilters()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -79,7 +80,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void EmptyAclBindingFilters()
+        public async Task EmptyAclBindingFilters()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -90,7 +91,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullResourcePattern()
+        public async Task NullResourcePattern()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -107,7 +108,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullAccessControlEntry()
+        public async Task NullAccessControlEntry()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -124,7 +125,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -137,7 +138,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void InvalidAclBindingFilters()
+        public async Task InvalidAclBindingFilters()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {

--- a/test/Confluent.Kafka.UnitTests/Admin/DescribeAclsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/DescribeAclsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
@@ -61,7 +62,7 @@ namespace Confluent.Kafka.UnitTests
         };
 
         [Fact]
-        public async void NullAclBindingFilter()
+        public async Task NullAclBindingFilter()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -72,7 +73,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullResourcePattern()
+        public async Task NullResourcePattern()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -88,7 +89,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void NullAccessControlEntry()
+        public async Task NullAccessControlEntry()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -104,7 +105,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -121,7 +122,7 @@ namespace Confluent.Kafka.UnitTests
         }
         
         [Fact]
-        public async void InvalidAclBindingFilters()
+        public async Task InvalidAclBindingFilters()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {

--- a/test/Confluent.Kafka.UnitTests/Admin/DescribeTopicsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/DescribeTopicsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using Confluent.Kafka.Admin;
 using System.Collections.Generic;
@@ -33,7 +34,7 @@ namespace Confluent.Kafka.UnitTests
         };
 
         [Fact]
-        public async void NullTopicCollection()
+        public async Task NullTopicCollection()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -47,7 +48,7 @@ namespace Confluent.Kafka.UnitTests
         }
         
         [Fact]
-        public async void EmptyTopicCollection()
+        public async Task EmptyTopicCollection()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -63,7 +64,7 @@ namespace Confluent.Kafka.UnitTests
 
         
         [Fact]
-        public async void WrongTopicNames()
+        public async Task WrongTopicNames()
         {
             var wrongTopicCollections = new List<TopicCollection>
             {
@@ -85,7 +86,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void WrongRequestTimeoutValue()
+        public async Task WrongRequestTimeoutValue()
         {
             var topicCollections =  TopicCollection.OfTopicNames(new List<string> {});
             var wrongRequestTimeoutValue = new DescribeTopicsOptions
@@ -101,7 +102,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig
             { 

--- a/test/Confluent.Kafka.UnitTests/Admin/DescribeUserScramCredentialsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/DescribeUserScramCredentialsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using Confluent.Kafka.Admin;
@@ -51,7 +52,7 @@ namespace Confluent.Kafka.UnitTests
         };
 
         [Fact]
-        public async void LocalTimeout()
+        public async Task LocalTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -68,7 +69,7 @@ namespace Confluent.Kafka.UnitTests
         }
         
         [Fact]
-        public async void EmptyUsers()
+        public async Task EmptyUsers()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {

--- a/test/Confluent.Kafka.UnitTests/Admin/ListOffsetsError.cs
+++ b/test/Confluent.Kafka.UnitTests/Admin/ListOffsetsError.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using System;
 using Confluent.Kafka.Admin;
 using System.Collections.Generic;
@@ -33,7 +34,7 @@ namespace Confluent.Kafka.UnitTests
         };
 
         [Fact]
-        public async void InvalidRequestTimeout()
+        public async Task InvalidRequestTimeout()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig
             { 
@@ -54,7 +55,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void InvalidPartitions()
+        public async Task InvalidPartitions()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig
             { 
@@ -100,7 +101,7 @@ namespace Confluent.Kafka.UnitTests
         }
         
         [Fact]
-        public async void EmptyPartitions()
+        public async Task EmptyPartitions()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = "localhost:90922" }).Build())
             {
@@ -116,7 +117,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void SamePartitionDifferentOffsets()
+        public async Task SamePartitionDifferentOffsets()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig
             { 
@@ -151,7 +152,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void TwoDifferentPartitions()
+        public async Task TwoDifferentPartitions()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig
             { 
@@ -186,7 +187,7 @@ namespace Confluent.Kafka.UnitTests
         }
 
         [Fact]
-        public async void SinglePartition()
+        public async Task SinglePartition()
         {
             using (var adminClient = new AdminClientBuilder(new AdminClientConfig
             { 

--- a/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+++ b/test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <!-- Needed for testing net462 on Linux -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
 </Project>

--- a/test/Confluent.Kafka.UnitTests/Offset.cs
+++ b/test/Confluent.Kafka.UnitTests/Offset.cs
@@ -24,10 +24,10 @@ namespace Confluent.Kafka.UnitTests
         [Fact]
         public void SpecialValues()
         {
-            Assert.Equal(Offset.Beginning.Value, -2);
-            Assert.Equal(Offset.End.Value, -1);
-            Assert.Equal(Offset.Unset.Value, -1001);
-            Assert.Equal(Offset.Stored.Value, -1000);
+            Assert.Equal(-2, Offset.Beginning.Value);
+            Assert.Equal(-1, Offset.End.Value);
+            Assert.Equal(-1001, Offset.Unset.Value);
+            Assert.Equal(-1000, Offset.Stored.Value);
         }
 
         [Fact]

--- a/test/Confluent.Kafka.UnitTests/Partition.cs
+++ b/test/Confluent.Kafka.UnitTests/Partition.cs
@@ -24,7 +24,7 @@ namespace Confluent.Kafka.UnitTests
         [Fact]
         public void SpecialValues()
         {
-            Assert.Equal(Partition.Any.Value, -1);
+            Assert.Equal(-1, Partition.Any.Value);
         }
 
         [Fact]

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Confluent.SchemaRegistry.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Confluent.SchemaRegistry.IntegrationTests.csproj
@@ -20,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.21.0" />
-    <PackageReference Include="NJsonSchema" Version="10.6.3" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/BasicAuth.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/BasicAuth.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka;
 
@@ -26,7 +27,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void BasicAuth(Config config)
+        public static async Task BasicAuth(Config config)
         {
             var testSchema1 = 
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
@@ -52,8 +53,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ToDelegate()(new SerializationContext(MessageComponentType.Value, topicName), null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                var schema = sr.GetLatestSchemaAsync(subject).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema1);
+                var schema = await sr.GetLatestSchemaAsync(subject);
                 Assert.Equal(schema.Id, id);
             }
 
@@ -67,8 +68,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                var schema = sr.GetLatestSchemaAsync(subject).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema1);
+                var schema = await sr.GetLatestSchemaAsync(subject);
                 Assert.Equal(schema.Id, id);
             }
 
@@ -84,8 +85,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                var schema = sr.GetLatestSchemaAsync(subject).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema1);
+                var schema = await sr.GetLatestSchemaAsync(subject);
                 Assert.Equal(schema.Id, id);
             }
 
@@ -98,8 +99,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                var schema = sr.GetLatestSchemaAsync(subject).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema1);
+                var schema = await sr.GetLatestSchemaAsync(subject);
                 Assert.Equal(schema.Id, id);
             }
 
@@ -139,19 +140,12 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             // SR <= 5.3.4 returns Unauthorized with empty Content (HttpRequestException)
             // 5.3.4 < SR <= 5.3.8 returns Unauthorized with message but without error_code (SchemaRegistryException)
             // SR >= 5.40 returns Unauthorized with message and error_code (SchemaRegistryException)
-            var schemaRegistryException = Assert.Throws<SchemaRegistryException>(() => 
-            { 
+            var schemaRegistryException = await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
+            {
                 var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.ServerWithAuth });
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-                try
-                {
-                    var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                }
-                catch (Exception e)
-                {
-                    throw e.InnerException;
-                }
+                await sr.RegisterSchemaAsync(subject, testSchema1);
             });
             Assert.Equal(401, schemaRegistryException.ErrorCode);
             Assert.Equal("Unauthorized; error code: 401", schemaRegistryException.Message);

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Failover.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Failover.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -25,7 +26,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void Failover(Config config)
+        public static async Task Failover(Config config)
         {
             var testSchema =
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
@@ -36,8 +37,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema, false).Result;
-                var id2 = sr.GetSchemaIdAsync(subject, testSchema, false).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema, false);
+                var id2 = await sr.GetSchemaIdAsync(subject, testSchema, false);
                 Assert.Equal(id, id2);
             }
 
@@ -45,8 +46,8 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema, false).Result;
-                var id2 = sr.GetSchemaIdAsync(subject, testSchema, false).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema, false);
+                var id2 = await sr.GetSchemaIdAsync(subject, testSchema, false);
                 Assert.Equal(id, id2);
             }
 
@@ -55,16 +56,9 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
                 
-                Assert.Throws<HttpRequestException>(() => 
+                await Assert.ThrowsAsync<HttpRequestException>(async () =>
                 {
-                    try
-                    {
-                        sr.RegisterSchemaAsync(subject, testSchema).Wait();
-                    }
-                    catch (AggregateException e)
-                    {
-                        throw e.InnerException;
-                    }
+                    await sr.RegisterSchemaAsync(subject, testSchema);
                 });
             }
 

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/FillTheCache.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/FillTheCache.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void FillTheCache(Config config)
+        public static async Task FillTheCache(Config config)
         {
             const int capacity = 16;
 
@@ -54,7 +55,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
                 var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
                 subjects.Add(subject);
 
-                var id = sr.RegisterSchemaAsync(subject, testSchema).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema);
                 ids.Add(id);
             }
         }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetAllSubjects.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetAllSubjects.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void GetAllSubjects(Config config)
+        public static async Task GetAllSubjects(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -35,22 +36,22 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
-            var subjectsBefore = sr.GetAllSubjectsAsync().Result;
+            var subjectsBefore = await sr.GetAllSubjectsAsync();
 
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
-            var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
+            var id = await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            var subjectsAfter = sr.GetAllSubjectsAsync().Result;
+            var subjectsAfter = await sr.GetAllSubjectsAsync();
 
             Assert.Equal(1, subjectsAfter.Count - subjectsBefore.Count);
 
-            sr.RegisterSchemaAsync(subject, testSchema1).Wait();
+            await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            var subjectsAfter2 = sr.GetAllSubjectsAsync().Result;
+            var subjectsAfter2 = await sr.GetAllSubjectsAsync();
 
             Assert.Equal(subjectsAfter.Count, subjectsAfter2.Count);
 
-            Assert.True(subjectsAfter2.Contains(subject));
+            Assert.Contains(subject, subjectsAfter2);
         }
     }
 }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetId.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetId.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -23,7 +24,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void GetId(Config config)
+        public static async Task GetId(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -35,21 +36,14 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
-            var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-            var id2 = sr.GetSchemaIdAsync(subject, testSchema1).Result;
+            var id = await sr.RegisterSchemaAsync(subject, testSchema1);
+            var id2 = await sr.GetSchemaIdAsync(subject, testSchema1);
 
             Assert.Equal(id, id2);
 
-            Assert.Throws<SchemaRegistryException>(() => 
+            await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
             {
-                try
-                {
-                    sr.GetSchemaIdAsync(subject, "{\"type\": \"string\"}").Wait();
-                }
-                catch (AggregateException e)
-                {
-                    throw e.InnerException;
-                }
+                await sr.GetSchemaIdAsync(subject, "{\"type\": \"string\"}");
             });
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetLatestSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetLatestSchema.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void GetLatestSchema(Config config)
+        public static async Task GetLatestSchema(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -36,13 +37,13 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
-            var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
+            var id = await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            var schema = sr.GetLatestSchemaAsync(subject).Result;
+            var schema = await sr.GetLatestSchemaAsync(subject);
 
             Assert.Equal(schema.Id, id);
             Assert.Equal(schema.Subject, subject);
-            Assert.Equal(schema.Version, 1);
+            Assert.Equal(1, schema.Version);
             Assert.Equal(schema.SchemaString, testSchema1);
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaById.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaById.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -23,7 +24,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void GetSchemaById(Config config)
+        public static async Task GetSchemaById(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -35,12 +36,12 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
-            var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
+            var id = await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            var schema = sr.GetSchemaAsync(id).Result;
+            var schema = await sr.GetSchemaAsync(id);
             Assert.Equal(schema.SchemaString, testSchema1);
             Assert.Empty(schema.References);
-            Assert.Equal(schema.SchemaType, SchemaType.Avro);
+            Assert.Equal(SchemaType.Avro, schema.SchemaType);
         }
     }
 }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaBySubjectAndVersion.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSchemaBySubjectAndVersion.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -23,7 +24,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void GetSchemaBySubjectAndVersion(Config config)
+        public static async Task GetSchemaBySubjectAndVersion(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -35,13 +36,13 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-            var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
+            var id = await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            var latestSchema = sr.GetLatestSchemaAsync(subject).Result;
-            var schema = sr.GetRegisteredSchemaAsync(subject, latestSchema.Version).Result;
+            var latestSchema = await sr.GetLatestSchemaAsync(subject);
+            var schema = await sr.GetRegisteredSchemaAsync(subject, latestSchema.Version);
 
             Assert.Equal(schema.SchemaString, testSchema1);
-            Assert.Equal(schema.SchemaType, SchemaType.Avro);
+            Assert.Equal(SchemaType.Avro, schema.SchemaType);
             Assert.Empty(schema.References);
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSubjectVersions.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/GetSubjectVersions.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void GetSubjectVersions(Config config)
+        public static async Task GetSubjectVersions(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -42,12 +43,12 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-            var id1 = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-            var id2 = sr.RegisterSchemaAsync(subject, testSchema2).Result;
+            var id1 = await sr.RegisterSchemaAsync(subject, testSchema1);
+            var id2 = await sr.RegisterSchemaAsync(subject, testSchema2);
 
-            var versions = sr.GetSubjectVersionsAsync(subject).Result;
+            var versions = await sr.GetSubjectVersionsAsync(subject);
 
-            Assert.Equal(versions.Count, 2);
+            Assert.Equal(2, versions.Count);
         }
     }
 }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/IsCompatible.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -23,7 +24,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void IsCompatible_Topic(Config config)
+        public static async Task IsCompatible_Topic(Config config)
         {
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
@@ -42,20 +43,20 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var topicName = Guid.NewGuid().ToString();
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
 
-            sr.RegisterSchemaAsync(subject, testSchema1).Wait();
+            await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            Assert.False(sr.IsCompatibleAsync(subject, testSchema2).Result);
-            Assert.True(sr.IsCompatibleAsync(subject, testSchema1).Result);
+            Assert.False(await sr.IsCompatibleAsync(subject, testSchema2));
+            Assert.True(await sr.IsCompatibleAsync(subject, testSchema1));
 
 
             // case 2: record not specified.
             topicName = Guid.NewGuid().ToString();
             subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, null);
 
-            sr.RegisterSchemaAsync(subject, testSchema1).Wait();
+            await sr.RegisterSchemaAsync(subject, testSchema1);
 
-            Assert.False(sr.IsCompatibleAsync(subject, testSchema2).Result);
-            Assert.True(sr.IsCompatibleAsync(subject, testSchema1).Result);
+            Assert.False(await sr.IsCompatibleAsync(subject, testSchema2));
+            Assert.True(await sr.IsCompatibleAsync(subject, testSchema1));
 
 
             // Note: backwards / forwards compatibility scenarios are not tested here. This is really just testing the API call.

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Json.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Json.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -59,7 +60,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 }";
 
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void Json(Config config)
+        public static async Task Json(Config config)
         {
             var srInitial = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
@@ -67,32 +68,32 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var subjectInitial = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
             var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName+"2", null);
 
-            var id1 = srInitial.RegisterSchemaAsync(subjectInitial, new Schema(TestJsonSchema, SchemaType.Json)).Result;
-            var schema1 = sr.GetSchemaAsync(id1).Result; // use a different sr instance to ensure a cached value is not read.
+            var id1 = await srInitial.RegisterSchemaAsync(subjectInitial, new Schema(TestJsonSchema, SchemaType.Json));
+            var schema1 = await sr.GetSchemaAsync(id1); // use a different sr instance to ensure a cached value is not read.
             Assert.Equal(SchemaType.Json, schema1.SchemaType);
             Assert.NotNull(schema1.SchemaString); // SR munges the schema (whitespace), so in general this won't equal the registered schema.
 
             // check that the id of the schema just registered can be retrieved.
-            var id = sr.GetSchemaIdAsync(subjectInitial, new Schema(schema1.SchemaString, SchemaType.Json)).Result;
+            var id = await sr.GetSchemaIdAsync(subjectInitial, new Schema(schema1.SchemaString, SchemaType.Json));
             Assert.Equal(id1, id);
 
             // re-register the munged schema (to a different subject) and check that it is not re-munged.
-            var id2 = sr.RegisterSchemaAsync(subject, schema1).Result;
-            var schema2 = sr.GetSchemaAsync(id2).Result;
+            var id2 = await sr.RegisterSchemaAsync(subject, schema1);
+            var schema2 = await sr.GetSchemaAsync(id2);
             Assert.Equal(schema1.SchemaString, schema2.SchemaString);
             Assert.Equal(schema1.SchemaType, schema2.SchemaType);
 
             // compatibility
-            var compat = sr.IsCompatibleAsync(subject, schema2).Result;
+            var compat = await sr.IsCompatibleAsync(subject, schema2);
             Assert.True(compat);
             var avroSchema = 
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
 
-            var compat2 = sr.IsCompatibleAsync(subject, avroSchema).Result;
+            var compat2 = await sr.IsCompatibleAsync(subject, avroSchema);
             Assert.False(compat2);
-            var compat3 = sr.IsCompatibleAsync(subject, new Schema(avroSchema, SchemaType.Avro)).Result;
+            var compat3 = await sr.IsCompatibleAsync(subject, new Schema(avroSchema, SchemaType.Avro));
             Assert.False(compat3);
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/JsonWithReferences.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/JsonWithReferences.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -101,7 +102,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
 
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void JsonWithReferences(Config config)
+        public static async Task JsonWithReferences(Config config)
         {
             var srInitial = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
@@ -111,14 +112,14 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var subject2 = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName + "2", null);
 
             // Test there are no errors (exceptions) registering a schema that references another.
-            var id1 = srInitial.RegisterSchemaAsync(subject1, new Schema(S1, SchemaType.Json)).Result;
-            var s1 = srInitial.GetLatestSchemaAsync(subject1).Result;
+            var id1 = await srInitial.RegisterSchemaAsync(subject1, new Schema(S1, SchemaType.Json));
+            var s1 = await srInitial.GetLatestSchemaAsync(subject1);
             var refs = new List<SchemaReference> { new SchemaReference("https://example.com/geographical-location.schema.json", subject1, s1.Version) };
-            var id2 = srInitial.RegisterSchemaAsync(subject2, new Schema(S2, refs, SchemaType.Json)).Result;
+            var id2 = await srInitial.RegisterSchemaAsync(subject2, new Schema(S2, refs, SchemaType.Json));
 
             // In fact, it seems references are not checked server side.
 
-            var latestSchema = sr.GetLatestSchemaAsync(subject2).Result;
+            var latestSchema = await sr.GetLatestSchemaAsync(subject2);
         }
     }
 }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Protobuf.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/Protobuf.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -23,7 +24,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void Protobuf(Config config)
+        public static async Task Protobuf(Config config)
         {
             var srInitial = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
@@ -33,29 +34,29 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName+"2", null);
 
             // check that registering a base64 protobuf schema works.
-            var id1 = srInitial.RegisterSchemaAsync(subjectInitial, new Schema(testSchemaBase64, SchemaType.Protobuf)).Result;
-            var schema1 = sr.GetSchemaAsync(id1, "serialized").Result; // use a different sr instance to ensure a cached value is not read.
+            var id1 = await srInitial.RegisterSchemaAsync(subjectInitial, new Schema(testSchemaBase64, SchemaType.Protobuf));
+            var schema1 = await sr.GetSchemaAsync(id1, "serialized"); // use a different sr instance to ensure a cached value is not read.
             Assert.Equal(SchemaType.Protobuf, schema1.SchemaType);
             Assert.NotNull(schema1.SchemaString); // SR slightly munges the schema as a result of moving to a text representation and back so can't check for equality.
 
             // check that the id of the schema just registered can be retrieved.
-            var id = sr.GetSchemaIdAsync(subjectInitial, new Schema(schema1.SchemaString, SchemaType.Protobuf)).Result;
+            var id = await sr.GetSchemaIdAsync(subjectInitial, new Schema(schema1.SchemaString, SchemaType.Protobuf));
             Assert.Equal(id1, id);
 
             // re-register the munged schema (to a different subject) and check that it is not re-munged.
-            var id2 = sr.RegisterSchemaAsync(subject, schema1).Result;
-            var schema2 = sr.GetSchemaAsync(id2, "serialized").Result;
+            var id2 = await sr.RegisterSchemaAsync(subject, schema1);
+            var schema2 = await sr.GetSchemaAsync(id2, "serialized");
             Assert.Equal(schema1.SchemaString, schema2.SchemaString);
             Assert.Equal(schema1.SchemaType, schema2.SchemaType);
 
             // This sequence of operations is designed to test caching behavior (and two alternat schema getting methods).
-            var schemaAsText = sr.GetSchemaAsync(id2).Result;
-            var schemaAsSerialized = sr.GetSchemaAsync(id2, "serialized").Result;
-            var schemaAsText2 = sr.GetSchemaAsync(id2).Result;
-            var schemaAsSerialized2 = sr.GetSchemaAsync(id2, "serialized").Result;
-            var latestSchema = sr.GetLatestSchemaAsync(subject).Result; // should come back as text.
-            var schemaAsSerialized3 = sr.GetSchemaAsync(id2, "serialized").Result;
-            var latestSchema2 = sr.GetRegisteredSchemaAsync(subject, latestSchema.Version).Result; // should come back as text.
+            var schemaAsText = await sr.GetSchemaAsync(id2);
+            var schemaAsSerialized = await sr.GetSchemaAsync(id2, "serialized");
+            var schemaAsText2 = await sr.GetSchemaAsync(id2);
+            var schemaAsSerialized2 = await sr.GetSchemaAsync(id2, "serialized");
+            var latestSchema = await sr.GetLatestSchemaAsync(subject); // should come back as text.
+            var schemaAsSerialized3 = await sr.GetSchemaAsync(id2, "serialized");
+            var latestSchema2 = await sr.GetRegisteredSchemaAsync(subject, latestSchema.Version); // should come back as text.
             Assert.Equal(schema1.SchemaString, schemaAsSerialized.SchemaString);
             Assert.Equal(SchemaType.Protobuf, schemaAsSerialized.SchemaType);
             Assert.Empty(schemaAsSerialized.References);
@@ -69,20 +70,20 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             Assert.Empty(schemaAsText2.References);
 
             // compatibility
-            var compat = sr.IsCompatibleAsync(subject, schema2).Result;
+            var compat = await sr.IsCompatibleAsync(subject, schema2);
             Assert.True(compat);
             var avroSchema = 
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_color\",\"type\":[\"string\",\"null\"]}]}";
-            var compat2 = sr.IsCompatibleAsync(subject, avroSchema).Result;
+            var compat2 = await sr.IsCompatibleAsync(subject, avroSchema);
             Assert.False(compat2);
-            var compat3 = sr.IsCompatibleAsync(subject, new Schema(avroSchema, SchemaType.Avro)).Result;
+            var compat3 = await sr.IsCompatibleAsync(subject, new Schema(avroSchema, SchemaType.Avro));
             Assert.False(compat3);
 
             // invalid type
-            Assert.ThrowsAny<Exception>(() => {
-                sr.RegisterSchemaAsync(SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName+"3", null), new Schema(avroSchema, SchemaType.Protobuf)).Wait();
+            await Assert.ThrowsAnyAsync<Exception>(async () => {
+                await sr.RegisterSchemaAsync(SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName+"3", null), new Schema(avroSchema, SchemaType.Protobuf));
             });
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/ProtobufWithReferences.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/ProtobufWithReferences.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void ProtobufWithReferences(Config config)
+        public static async Task ProtobufWithReferences(Config config)
         {
             var srInitial = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
@@ -36,19 +37,19 @@ namespace Confluent.SchemaRegistry.IntegrationTests
 
             // check that registering a base64 protobuf schema works, first with the referenced schema
             var PersonName = "confluent.kafka.examples.protobuf.PersonName";
-            var id1 = srInitial.RegisterSchemaAsync(PersonName, new Schema(testSchemaBase64PersonName, SchemaType.Protobuf)).Result;
-            var sc1 = srInitial.GetSchemaAsync(id1).Result;
+            var id1 = await srInitial.RegisterSchemaAsync(PersonName, new Schema(testSchemaBase64PersonName, SchemaType.Protobuf));
+            var sc1 = await srInitial.GetSchemaAsync(id1);
             Assert.NotNull(sc1);
             
             // then with the schema that references it
             var refs = new List<SchemaReference> { new SchemaReference(PersonName, PersonName, 1) };
-            var id2 = sr.RegisterSchemaAsync(subjectInitial, new Schema(testSchemaBase64Person, refs, SchemaType.Protobuf)).Result;
-            var sc2 = sr.GetSchemaAsync(id2).Result;
+            var id2 = await sr.RegisterSchemaAsync(subjectInitial, new Schema(testSchemaBase64Person, refs, SchemaType.Protobuf));
+            var sc2 = await sr.GetSchemaAsync(id2);
             Assert.NotNull(sc2);
 
             // then with the schema that references it and a different subject
-            var id3 = sr.RegisterSchemaAsync(subject, new Schema(testSchemaBase64Person, refs, SchemaType.Protobuf)).Result;
-            var sc3 = sr.GetSchemaAsync(id3).Result;
+            var id3 = await sr.RegisterSchemaAsync(subject, new Schema(testSchemaBase64Person, refs, SchemaType.Protobuf));
+            var sc3 = await sr.GetSchemaAsync(id3);
             Assert.NotNull(sc3);
         }
     }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterIncompatibleSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterIncompatibleSchema.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void RegisterIncompatibleSchema(Config config)
+        public static async Task RegisterIncompatibleSchema(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -36,18 +37,18 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.Server });
 
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
-            var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
+            var id = await sr.RegisterSchemaAsync(subject, testSchema1);
 
             var testSchema2 = // incompatible with testSchema1
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                 "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\",\"type\":[\"i" +
                 "nt\",\"null\"]},{\"name\":\"favorite_shape\",\"type\":[\"string\",\"null\"]}]}";
 
-            Assert.False(sr.IsCompatibleAsync(subject, testSchema2).Result);
+            Assert.False(await sr.IsCompatibleAsync(subject, testSchema2));
 
-            Assert.Throws<AggregateException>(() => sr.RegisterSchemaAsync(subject, testSchema2).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => sr.RegisterSchemaAsync(subject, testSchema2));
 
-            Assert.True(sr.GetAllSubjectsAsync().Result.Contains(subject));
+            Assert.Contains(subject, await sr.GetAllSubjectsAsync());
         }
     }
 }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterNormalizedSchema.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterNormalizedSchema.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void RegisterNormalizedSchema(Config config)
+        public static async Task RegisterNormalizedSchema(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -42,9 +43,9 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             Assert.Equal(topicName + "-key", subject);
 
-            var id1 = sr.RegisterSchemaAsync(subject, testSchema1, true).Result;
-            var id2 = sr.GetSchemaIdAsync(subject, testSchema1, true).Result;
-            var schema = sr.GetSchemaAsync(id2).Result;
+            var id1 = await sr.RegisterSchemaAsync(subject, testSchema1, true);
+            var id2 = await sr.GetSchemaIdAsync(subject, testSchema1, true);
+            var schema = await sr.GetSchemaAsync(id2);
             Assert.Equal(id1, id2);
             Assert.Equal(normalized, schema);
         }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterSameSchemaTwice.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/RegisterSameSchemaTwice.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -24,7 +25,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void RegisterSameSchemaTwice(Config config)
+        public static async Task RegisterSameSchemaTwice(Config config)
         {
             var topicName = Guid.NewGuid().ToString();
 
@@ -38,12 +39,12 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             var subject = SubjectNameStrategy.Topic.ConstructKeySubjectName(topicName, "Confluent.Kafka.Examples.AvroSpecific.User");
             Assert.Equal(topicName + "-key", subject);
 
-            var id1 = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-            var id2 = sr.RegisterSchemaAsync(subject, testSchema1).Result;
+            var id1 = await sr.RegisterSchemaAsync(subject, testSchema1);
+            var id2 = await sr.RegisterSchemaAsync(subject, testSchema1);
 
             Assert.Equal(id1, id2);
             
-            Assert.True(sr.GetAllSubjectsAsync().Result.Contains(subject));
+            Assert.Contains(subject, await sr.GetAllSubjectsAsync());
         }
     }
 }

--- a/test/Confluent.SchemaRegistry.IntegrationTests/Tests/SslAuth.cs
+++ b/test/Confluent.SchemaRegistry.IntegrationTests/Tests/SslAuth.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 using Confluent.Kafka;
 
@@ -26,7 +27,7 @@ namespace Confluent.SchemaRegistry.IntegrationTests
     public static partial class Tests
     {
         [Theory, MemberData(nameof(SchemaRegistryParameters))]
-        public static void SslAuth(Config config)
+        public static async Task SslAuth(Config config)
         {
             var testSchema1 =
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
@@ -52,25 +53,18 @@ namespace Confluent.SchemaRegistry.IntegrationTests
             {
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ToDelegate()(new SerializationContext(MessageComponentType.Value, topicName), null);
-                var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                var schema = sr.GetLatestSchemaAsync(subject).Result;
+                var id = await sr.RegisterSchemaAsync(subject, testSchema1);
+                var schema = await sr.GetLatestSchemaAsync(subject);
                 Assert.Equal(schema.Id, id);
             }
 
             // try to connect with invalid SSL config. shouldn't work.
-            Assert.Throws<HttpRequestException>(() =>
+            await Assert.ThrowsAsync<HttpRequestException>(async () =>
             {
                 var sr = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = config.ServerWithSsl });
                 var topicName = Guid.NewGuid().ToString();
                 var subject = SubjectNameStrategy.Topic.ConstructValueSubjectName(topicName, null);
-                try
-                {
-                    var id = sr.RegisterSchemaAsync(subject, testSchema1).Result;
-                }
-                catch (Exception e)
-                {
-                    throw e.InnerException;
-                }
+                await sr.RegisterSchemaAsync(subject, testSchema1);
             });
 
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Confluent.SchemaRegistry.Serdes.IntegrationTests.csproj
@@ -27,9 +27,9 @@
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.12.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AutoRegisterSchemaDisabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AutoRegisterSchemaDisabled.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Xunit;
 
@@ -27,7 +28,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test behavior when avro.serializer.auto.register.schemas == false.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void AutoRegisterSchemaDisabled(string bootstrapServers, string schemaRegistryServers)
+        public static async Task AutoRegisterSchemaDisabled(string bootstrapServers, string schemaRegistryServers)
         {
             using (var topic = new TemporaryTopic(bootstrapServers, 1))
             {
@@ -58,15 +59,13 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry, new AvroSerializerConfig { AutoRegisterSchemas = false }))
                         .Build())
                 {
-                    Assert.Throws<SchemaRegistryException>(() =>
+                    await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
                     {
                         string guidTopic = Guid.NewGuid().ToString();
                         try
                         {
-                            producer
-                                .ProduceAsync(guidTopic, new Message<string, int> { Key = "test", Value = 112 })
-                                .GetAwaiter()
-                                .GetResult();
+                            await producer
+                                .ProduceAsync(guidTopic, new Message<string, int> { Key = "test", Value = 112 }, TestContext.Current.CancellationToken);
                         }
                         catch (Exception e)
                         {
@@ -98,13 +97,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    Assert.Throws<SchemaRegistryException>(() =>
+                    await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
                     {
                         try
                         {
-                            producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 })
-                                .GetAwaiter()
-                                .GetResult();
+                            await producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }, TestContext.Current.CancellationToken);
                         }
                         catch (Exception e)
                         {
@@ -122,7 +119,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }, TestContext.Current.CancellationToken);
                 }
 
                 // config with avro.serializer.auto.register.schemas == false should work now.
@@ -133,7 +130,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }, TestContext.Current.CancellationToken);
                 }
 
                 // config with avro.serializer.use.latest.version == true should also work now.
@@ -144,7 +141,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, int> { Key = "test", Value = 112 }, TestContext.Current.CancellationToken);
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AvroAndRegular.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/AvroAndRegular.cs
@@ -17,6 +17,7 @@
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -28,7 +29,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test producing/consuming using both regular and Avro serializers.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void AvoAndRegular(string bootstrapServers, string schemaRegistryServers)
+        public static async Task AvoAndRegular(string bootstrapServers, string schemaRegistryServers)
         {
             using (var topic1 = new TemporaryTopic(bootstrapServers, 1))
             using (var topic2 = new TemporaryTopic(bootstrapServers, 1))
@@ -59,21 +60,14 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     // implicit check that this does not fail.
-                    producer.ProduceAsync(topic1.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();
+                    await producer.ProduceAsync(topic1.Name, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
 
                     // check that the value type was registered with SR, and the key was not.
-                    Assert.Throws<SchemaRegistryException>(() =>
+                    await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
                         {
-                            try
-                            {
-                                schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructKeySubjectName(topic1.Name, null)).Wait();
-                            }
-                            catch (AggregateException e)
-                            {
-                                throw e.InnerException;
-                            }
+                            await schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructKeySubjectName(topic1.Name, null));
                         });
-                    var s2 = schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic1.Name, null)).Result;
+                    var s2 = await schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic1.Name, null));
                 }
 
                 using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))
@@ -84,21 +78,14 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     // implicit check that this does not fail.
-                    producer.ProduceAsync(topic2.Name, new Message<string, string> { Key = "hello", Value = "world" }).Wait();
+                    await producer.ProduceAsync(topic2.Name, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
 
                     // check that the key type was registered with SR, and the value was not.
-                    Assert.Throws<SchemaRegistryException>(() =>
+                    await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
                         {
-                            try
-                            {
-                                schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic2.Name, null)).Wait();
-                            }
-                            catch (AggregateException e)
-                            {
-                                throw e.InnerException;
-                            }
+                            await schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic2.Name, null));
                         });
-                    var s2 = schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructKeySubjectName(topic2.Name, null)).Result;
+                    var s2 = await schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructKeySubjectName(topic2.Name, null));
                 }
 
                 // check the above can be consumed (using regular / Avro serializers as appropriate)
@@ -111,7 +98,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             .Build())
                     {
                         consumer.Assign(new TopicPartitionOffset(topic1.Name, 0, 0));
-                        var cr = consumer.Consume();
+                        var cr = consumer.Consume(TestContext.Current.CancellationToken);
                         Assert.Equal("hello", cr.Message.Key);
                         Assert.Equal("world", cr.Message.Value);
                     }
@@ -122,7 +109,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             .SetValueDeserializer(Deserializers.Utf8).Build())
                     {
                         consumer.Assign(new TopicPartitionOffset(topic2.Name, 0, 0));
-                        var cr = consumer.Consume();
+                        var cr = consumer.Consume(TestContext.Current.CancellationToken);
                         Assert.Equal("hello", cr.Message.Key);
                         Assert.Equal("world", cr.Message.Value);
                     }
@@ -138,7 +125,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             {
                                 try
                                 {
-                                    consumer.Consume();
+                                    consumer.Consume(TestContext.Current.CancellationToken);
                                 }
                                 catch (AggregateException e)
                                 {
@@ -158,7 +145,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             {
                                 try
                                 {
-                                    consumer.Consume();
+                                    consumer.Consume(TestContext.Current.CancellationToken);
                                 }
                                 catch (AggregateException e)
                                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumeIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumeIncompatibleTypes.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Confluent.Kafka.Examples.AvroSpecific;
@@ -32,7 +33,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     consume error event.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ConsumeIncompatibleTypes(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ConsumeIncompatibleTypes(string bootstrapServers, string schemaRegistryServers)
         {
             string topic = Guid.NewGuid().ToString();
 
@@ -68,9 +69,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     favorite_color = "orange"
                 };
 
-                producer
-                    .ProduceAsync(topic, new Message<string, User> { Key = user.name, Value = user })
-                    .Wait();
+                await producer
+                    .ProduceAsync(topic, new Message<string, User> { Key = user.name, Value = user }, TestContext.Current.CancellationToken);
             }
 
             using (var schemaRegistry = new CachedSchemaRegistryClient(schemaRegistryConfig))

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumePartitionEOF.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ConsumePartitionEOF.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Confluent.Kafka.Examples.AvroSpecific;
@@ -31,7 +32,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     (which has different code path within Consumer).
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ConsumePartitionEOF(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ConsumePartitionEOF(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig
             {
@@ -51,7 +52,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .SetValueSerializer(new AvroSerializer<User>(schemaRegistry))
                     .Build())
             {
-                producer.ProduceAsync(topic.Name, new Message<Null, User> { Value = new User { name = "test" } }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<Null, User> { Value = new User { name = "test" } }, TestContext.Current.CancellationToken);
 
                 var consumerConfig = new ConsumerConfig
                 {
@@ -72,11 +73,11 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     consumer.Subscribe(topic.Name);
 
-                    var cr1 = consumer.Consume();
+                    var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.NotNull(cr1);
                     Assert.NotNull(cr1.Message);
                     Assert.False(cr1.IsPartitionEOF);
-                    var cr2 = consumer.Consume();
+                    var cr2 = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.NotNull(cr2);
                     Assert.Null(cr2.Message);
                     Assert.True(cr2.IsPartitionEOF);
@@ -101,7 +102,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     consumer.Subscribe(topic.Name);
 
-                    var cr1 = consumer.Consume();
+                    var cr1 = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.NotNull(cr1);
                     Assert.NotNull(cr1.Message);
                     Assert.False(cr1.IsPartitionEOF);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/PrimitiveTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/PrimitiveTypes.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Xunit;
@@ -30,7 +31,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     primitive types.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void PrimitiveTypes(string bootstrapServers, string schemaRegistryServers)
+        public static async Task PrimitiveTypes(string bootstrapServers, string schemaRegistryServers)
         {
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
 
@@ -61,9 +62,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(stringTopic, new Message<string, string> { Key = "hello", Value = "world" })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(stringTopic, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -73,9 +73,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<byte[]>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(bytesTopic, new Message<byte[], byte[]> { Key = new byte[] { 1, 4, 11 }, Value = new byte[] {} })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(bytesTopic, new Message<byte[], byte[]> { Key = new byte[] { 1, 4, 11 }, Value = new byte[] {} }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -85,9 +84,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(intTopic, new Message<int, int> { Key = 42, Value = 43 })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(intTopic, new Message<int, int> { Key = 42, Value = 43 }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -97,9 +95,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<long>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(longTopic, new Message<long, long> { Key = -32, Value = -33 })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(longTopic, new Message<long, long> { Key = -32, Value = -33 }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -109,9 +106,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<bool>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(boolTopic, new Message<bool, bool> { Key = true, Value = false })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(boolTopic, new Message<bool, bool> { Key = true, Value = false }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -121,9 +117,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<float>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(floatTopic, new Message<float, float> { Key = 44.0f, Value = 45.0f })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(floatTopic, new Message<float, float> { Key = 44.0f, Value = 45.0f }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -133,9 +128,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<double>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(doubleTopic, new Message<double, double> { Key = 46.0, Value = 47.0 })
-                        .Wait();
+                    await producer
+                        .ProduceAsync(doubleTopic, new Message<double, double> { Key = 46.0, Value = 47.0 }, TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 
@@ -145,9 +139,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .SetValueSerializer(new AvroSerializer<Null>(schemaRegistry))
                         .Build())
                 {
-                    producer
-                        .ProduceAsync(nullTopic, new Message<Null,Null>())
-                        .Wait();
+                    await producer
+                        .ProduceAsync(nullTopic, new Message<Null,Null>(), TestContext.Current.CancellationToken);
                     Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
                 }
 

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsume.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsume.cs
@@ -96,7 +96,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 new ConsumerBuilder<string, ProduceConsumeUser>(consumerConfig)
                     .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry).AsSyncOverAsync())
                     .SetValueDeserializer(new AvroDeserializer<ProduceConsumeUser>(schemaRegistry).AsSyncOverAsync())
-                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .SetErrorHandler((_, e) => Assert.Fail(e.Reason))
                     .Build())
             {
                 consumer.Subscribe(topic);
@@ -128,22 +128,22 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 if (nameStrategy == SubjectNameStrategy.TopicRecord)
                 {
                     Assert.Equal(2, (int)subjects.Where(s => s.Contains(topic)).Count());
-                    Assert.Single(subjects.Where(s => s == $"{topic}-key"));
-                    Assert.Single(subjects.Where(s => s == $"{topic}-{((Avro.RecordSchema)ProduceConsumeUser._SCHEMA).Fullname}"));
+                    Assert.Single(subjects, s => s == $"{topic}-key");
+                    Assert.Single(subjects, s => s == $"{topic}-{((Avro.RecordSchema)ProduceConsumeUser._SCHEMA).Fullname}");
                 }
 
                 if (nameStrategy == SubjectNameStrategy.Topic)
                 {
                     Assert.Equal(2, (int)subjects.Where(s => s.Contains(topic)).Count());
-                    Assert.Single(subjects.Where(s => s == $"{topic}-key"));
-                    Assert.Single(subjects.Where(s => s == $"{topic}-value"));
+                    Assert.Single(subjects, s => s == $"{topic}-key");
+                    Assert.Single(subjects, s => s == $"{topic}-value");
                 }
 
                 if (nameStrategy == SubjectNameStrategy.Record)
                 {
-                    Assert.Single(subjects.Where(s => s.Contains(topic))); // the string key.
-                    Assert.Single(subjects.Where(s => s == $"{topic}-key"));
-                    Assert.Single(subjects.Where(s => s == $"{((Avro.RecordSchema)ProduceConsumeUser._SCHEMA).Fullname}"));
+                    Assert.Single(subjects, s => s.Contains(topic)); // the string key.
+                    Assert.Single(subjects, s => s == $"{topic}-key");
+                    Assert.Single(subjects, s => s == $"{((Avro.RecordSchema)ProduceConsumeUser._SCHEMA).Fullname}");
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeGeneric.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeGeneric.cs
@@ -165,20 +165,20 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
                 if (nameStrategy == SubjectNameStrategy.TopicRecord)
                 {
-                    Assert.Single(subjects.Where(s => s.Contains(topic)));
-                    Assert.Single(subjects.Where(s => s == $"{topic}-{((Avro.RecordSchema)ProduceConsumeUser2._SCHEMA).Fullname}"));
+                    Assert.Single(subjects, s => s.Contains(topic));
+                    Assert.Single(subjects, s => s == $"{topic}-{((Avro.RecordSchema)ProduceConsumeUser2._SCHEMA).Fullname}");
                 }
 
                 if (nameStrategy == SubjectNameStrategy.Topic)
                 {
-                    Assert.Single(subjects.Where(s => s.Contains(topic)));
-                    Assert.Single(subjects.Where(s => s == $"{topic}-key"));
+                    Assert.Single(subjects, s => s.Contains(topic));
+                    Assert.Single(subjects, s => s == $"{topic}-key");
                 }
 
                 if (nameStrategy == SubjectNameStrategy.Record)
                 {
-                    Assert.Single(subjects.Where(s => s.Contains(topic))); // the string key.
-                    Assert.Single(subjects.Where(s => s == $"{((Avro.RecordSchema)ProduceConsumeUser2._SCHEMA).Fullname}"));
+                    Assert.Single(subjects, s => s.Contains(topic)); // the string key.
+                    Assert.Single(subjects, s => s == $"{((Avro.RecordSchema)ProduceConsumeUser2._SCHEMA).Fullname}");
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeNull.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceConsumeNull.cs
@@ -89,7 +89,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 new ConsumerBuilder<string, ProduceConsumeUser>(consumerConfig)
                     .SetKeyDeserializer(new AvroDeserializer<string>(schemaRegistry).AsSyncOverAsync())
                     .SetValueDeserializer(new AvroDeserializer<ProduceConsumeUser>(schemaRegistry).AsSyncOverAsync())
-                    .SetErrorHandler((_, e) => Assert.True(false, e.Reason))
+                    .SetErrorHandler((_, e) => Assert.Fail(e.Reason))
                     .Build())
             {
                 consumer.Subscribe(topic);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceGenericMultipleTopics.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceGenericMultipleTopics.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Avro;
 using Avro.Generic;
@@ -13,7 +14,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Avro deserializer.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceGenericMultipleTopics(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceGenericMultipleTopics(string bootstrapServers, string schemaRegistryServers)
         {
             var s = (RecordSchema)RecordSchema.Parse(
                 @"{
@@ -48,8 +49,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 record.Add("name", "my name 2");
                 record.Add("favorite_number", 44);
                 record.Add("favorite_color", null);
-                dr = p.ProduceAsync(topic, new Message<Null, GenericRecord> { Key = null, Value = record }).Result;
-                dr2 = p.ProduceAsync(topic2, new Message<Null, GenericRecord> { Key = null, Value = record }).Result;
+                dr = await p.ProduceAsync(topic, new Message<Null, GenericRecord> { Key = null, Value = record }, TestContext.Current.CancellationToken);
+                dr2 = await p.ProduceAsync(topic2, new Message<Null, GenericRecord> { Key = null, Value = record }, TestContext.Current.CancellationToken);
             }
 
             Assert.Null(dr.Key);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceIncompatibleTypes.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceIncompatibleTypes.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Xunit;
 
@@ -28,7 +29,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     throws a SerializationException.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceIncompatibleTypes(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceIncompatibleTypes(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
@@ -53,9 +54,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
                     .Build())
             {
-                producer
-                    .ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" })
-                    .Wait();
+                await producer
+                    .ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
 
                 Assert.Equal(0, producer.Flush(TimeSpan.FromSeconds(10)));
             }
@@ -67,14 +67,12 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .SetValueSerializer(new AvroSerializer<string>(schemaRegistry))
                     .Build())
             {
-                Assert.Throws<SchemaRegistryException>(() =>
+                await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
                 {
                     try
                     {
-                        producer
-                            .ProduceAsync(topic, new Message<int, string> { Key = 42, Value = "world" })
-                            .GetAwaiter()
-                            .GetResult();
+                        await producer
+                            .ProduceAsync(topic, new Message<int, string> { Key = 42, Value = "world" }, TestContext.Current.CancellationToken);
                     }
                     catch (Exception e)
                     {
@@ -91,14 +89,12 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .SetValueSerializer(new AvroSerializer<int>(schemaRegistry))
                     .Build())
             {                
-                Assert.Throws<SchemaRegistryException>(() =>
+                await Assert.ThrowsAsync<SchemaRegistryException>(async () =>
                 {
                     try
                     {
-                        producer
-                            .ProduceAsync(topic, new Message<string, int> { Key = "world", Value = 42 })
-                            .GetAwaiter()
-                            .GetResult();
+                        await producer
+                            .ProduceAsync(topic, new Message<string, int> { Key = "world", Value = 42 }, TestContext.Current.CancellationToken);
                     }
                     catch (Exception e)
                     {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceInvalid.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/ProduceInvalid.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Xunit;
 
@@ -27,7 +28,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test producing non-record type using TopicRecord strategy fails (value)
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        private static void ProduceInvalid_NotRecord1(string bootstrapServers, string schemaRegistryServers)
+        private static async Task ProduceInvalid_NotRecord1(string bootstrapServers, string schemaRegistryServers)
         {
             string topic = Guid.NewGuid().ToString();
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
@@ -51,7 +52,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    await producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -68,7 +69,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test producing non-record type using Record strategy fails (value)
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        private static void ProduceInvalid_NotRecord2(string bootstrapServers, string schemaRegistryServers)
+        private static async Task ProduceInvalid_NotRecord2(string bootstrapServers, string schemaRegistryServers)
         {
             string topic = Guid.NewGuid().ToString();
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
@@ -92,7 +93,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    await producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -109,7 +110,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test producing non-record type using TopicRecord strategy fails (key)
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        private static void ProduceInvalid_NotRecord3(string bootstrapServers, string schemaRegistryServers)
+        private static async Task ProduceInvalid_NotRecord3(string bootstrapServers, string schemaRegistryServers)
         {
             string topic = Guid.NewGuid().ToString();
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
@@ -133,7 +134,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    await producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -150,7 +151,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test producing non-record type using Record strategy fails (key)
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        private static void ProduceInvalid_NotRecord4(string bootstrapServers, string schemaRegistryServers)
+        private static async Task ProduceInvalid_NotRecord4(string bootstrapServers, string schemaRegistryServers)
         {
             string topic = Guid.NewGuid().ToString();
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
@@ -174,7 +175,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 Exception caught = null;
                 try
                 {
-                    producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }).GetAwaiter().GetResult();
+                    await producer.ProduceAsync(topic, new Message<string, string> { Key = "hello", Value = "world" }, TestContext.Current.CancellationToken);
                 }
                 catch (Exception e)
                 {

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/SyncOverAsync.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Avro/SyncOverAsync.cs
@@ -91,10 +91,14 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         };
                     };
 
+                    // deliberately blocks via Task.WaitAll to test sync-over-async does not deadlock
+                    // under thread-pool exhaustion — do not convert to async.
+#pragma warning disable xUnit1031, xUnit1051
                     tasks.Add(Task.Run(actionCreator(i)));
                 }
 
                 Task.WaitAll(tasks.ToArray());
+#pragma warning restore xUnit1031, xUnit1051
             }
 
             ThreadPool.SetMaxThreads(originalWorkerThreads, originalCompletionPortThreads);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/ProduceConsumeMixedJson.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/ProduceConsumeMixedJson.cs
@@ -18,6 +18,7 @@ using Xunit;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Newtonsoft.Json;
@@ -73,7 +74,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test various things
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceConsumeMixedJson(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceConsumeMixedJson(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -93,16 +94,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         LastName = "User",
                         NumberWithRange = 7 // range should be between 2 and 5.
                     };
-                    Assert.Throws<ProduceException<string, PersonPoco>>(() => {
-                        try
-                        {
-                            producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }).Wait();
-                        }
-                        catch (AggregateException ax)
-                        {
-                            // what would be thrown if the call was awaited.
-                            throw ax.InnerException;
-                        }
+                    await Assert.ThrowsAsync<ProduceException<string, PersonPoco>>(async () => {
+                        await producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }, TestContext.Current.CancellationToken);
                     });
                 }
 
@@ -114,8 +107,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         // Omit LastName
                         NumberWithRange = 3
                     };
-                    Assert.Throws<AggregateException>(() => {
-                        producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }).Wait();
+                    await Assert.ThrowsAnyAsync<Exception>(async () => {
+                        await producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }, TestContext.Current.CancellationToken);
                     });
                 }
 
@@ -145,9 +138,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             }
                         }
                     };
-                    producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, PersonPoco> { Key = "test1", Value = p }, TestContext.Current.CancellationToken);
 
-                    var schema = schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic.Name, null)).Result.SchemaString;
+                    var schema = (await schemaRegistry.GetLatestSchemaAsync(SubjectNameStrategy.Topic.ConstructValueSubjectName(topic.Name, null))).SchemaString;
 
                     var consumerConfig = new ConsumerConfig
                     {
@@ -162,7 +155,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             .Build())
                     {
                         consumer.Subscribe(topic.Name);
-                        var cr = consumer.Consume();
+                        var cr = consumer.Consume(TestContext.Current.CancellationToken);
                         Assert.Equal(p.FirstName, cr.Message.Value.FirstName);
                         Assert.Equal(p.MiddleName, cr.Message.Value.MiddleName);
                         Assert.Equal(p.LastName, cr.Message.Value.LastName);

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/SubjectNameStrategies.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/SubjectNameStrategies.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 
 
@@ -32,7 +33,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     strategies works for JSON serializers.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void SubjectNameStrategiesJson(string bootstrapServers, string schemaRegistryServers)
+        public static async Task SubjectNameStrategiesJson(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -49,9 +50,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new SubjectNameStrategyTestPoco();
                     u.Value = testString;
-                    producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
-                    var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                    var subjects = await schemaRegistry.GetAllSubjectsAsync();
                     Assert.Contains(topic.Name + "-SubjectNameStrategyTestPoco", subjects);
                     Assert.DoesNotContain(topic.Name + "-value", subjects);
                     // May contain the record name subject from a previous test.
@@ -64,9 +65,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new SubjectNameStrategyTestPoco();
                     u.Value = testString;
-                    producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
-                    var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                    var subjects = await schemaRegistry.GetAllSubjectsAsync();
                     // Note: If this value is in SR by any means (even if not via this test),
                     // it implies what is being tested here is functional.
                     Assert.Contains("SubjectNameStrategyTestPoco", subjects);
@@ -80,9 +81,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new SubjectNameStrategyTestPoco();
                     u.Value = testString;
-                    producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, SubjectNameStrategyTestPoco> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
-                    var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                    var subjects = await schemaRegistry.GetAllSubjectsAsync();
                     Assert.Contains(topic.Name + "-value", subjects);
                 }
             }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseLatestVersionEnabled.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseLatestVersionEnabled.cs
@@ -16,6 +16,7 @@
 
 using Xunit;
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 
 namespace Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1
@@ -43,7 +44,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test Use Latest Version on when AutoRegister enabled and disabled. 
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void UseLatestVersionCheck(string bootstrapServers, string schemaRegistryServers) 
+        public static async Task UseLatestVersionCheck(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -57,7 +58,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     var c = new Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1.TestPoco { IntField = 1 };
-                    producer.ProduceAsync(topic.Name, new Message<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1.TestPoco> { Key = "test1", Value = c }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses1.TestPoco> { Key = "test1", Value = c }, TestContext.Current.CancellationToken);
                 }
 
                 using (var producer = 
@@ -67,8 +68,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     var c = new Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco { StringField = "Test" };
-                    Assert.Throws<AggregateException>(
-                        () => producer.ProduceAsync(topic.Name, new Message<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco> { Key = "test1", Value = c }).Wait());
+                    await Assert.ThrowsAnyAsync<Exception>(
+                        () => producer.ProduceAsync(topic.Name, new Message<string, Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco> { Key = "test1", Value = c }, TestContext.Current.CancellationToken));
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Json/UseReferences.cs
@@ -17,6 +17,7 @@
 using Xunit;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Newtonsoft.Json;
@@ -141,7 +142,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Test Use References. 
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void UseReferences(string bootstrapServers, string schemaRegistryServers)
+        public static async Task UseReferences(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
 
@@ -167,19 +168,19 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
 
             // Register the reference schemas
             var subject3 = "Customer";
-            var id3 = sr.RegisterSchemaAsync(subject3, new(Schema3, Confluent.SchemaRegistry.SchemaType.Json)).Result;
-            var s3 = sr.GetLatestSchemaAsync(subject3).Result;
+            var id3 = await sr.RegisterSchemaAsync(subject3, new(Schema3, Confluent.SchemaRegistry.SchemaType.Json));
+            var s3 = await sr.GetLatestSchemaAsync(subject3);
 
             var subject1 = "OrderDetails";
             var refs1 = new List<SchemaReference> { new("http://example.com/customer.schema.json", subject3, s3.Version) };
-            var id1 = sr.RegisterSchemaAsync(subject1, new(Schema1, refs1, Confluent.SchemaRegistry.SchemaType.Json)).Result;
-            var s1 = sr.GetLatestSchemaAsync(subject1).Result;
+            var id1 = await sr.RegisterSchemaAsync(subject1, new(Schema1, refs1, Confluent.SchemaRegistry.SchemaType.Json));
+            var s1 = await sr.GetLatestSchemaAsync(subject1);
 
             // Register the top level schema
             var subject2 = "Order";
             var refs2 = new List<SchemaReference> { new("http://example.com/order_details.schema.json", subject1, s1.Version) };
-            var id2 = sr.RegisterSchemaAsync(subject2, new(Schema2, refs2, Confluent.SchemaRegistry.SchemaType.Json)).Result;
-            var s2 = sr.GetLatestSchemaAsync(subject2).Result;
+            var id2 = await sr.RegisterSchemaAsync(subject2, new(Schema2, refs2, Confluent.SchemaRegistry.SchemaType.Json));
+            var s2 = await sr.GetLatestSchemaAsync(subject2);
 
             // Create serialiser and deserialiser along with the Order schema
             using (var topic = new TemporaryTopic(bootstrapServers, 1))
@@ -207,7 +208,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, Order> { Key = "test1", Value = order }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, Order> { Key = "test1", Value = order }, TestContext.Current.CancellationToken);
                 }
                 
                 using (var consumer =
@@ -217,7 +218,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     var classObj = cr.Message.Value;
                     Assert.Equal<int>(123, classObj.OrderDetails.Id);
                 }
@@ -234,7 +235,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                             jsonSchemaGeneratorSettings: jsonSchemaGeneratorSettings))
                         .Build())
                 {
-                    producer.ProduceAsync(topic.Name, new Message<string, JObject> { Key = "test1", Value = jsonObject }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, JObject> { Key = "test1", Value = jsonObject }, TestContext.Current.CancellationToken);
                 }
                 
                 using (var consumer =
@@ -244,7 +245,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                     .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     var classObj = cr.Message.Value;
                     Assert.Equal(123, classObj["order_details"]?["id"]?.Value<int>() ?? 0);
                 }
@@ -264,8 +265,8 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var c = new Confluent.SchemaRegistry.Serdes.IntegrationTests.TestClasses2.TestPoco { StringField = "Test" };
                     // Validation failure when passing TestClasses2.TestPoco
-                    Assert.Throws<AggregateException>(
-                        () => producer.ProduceAsync(topic.Name, new Message<string, TestClasses2.TestPoco> { Key = "test1", Value = c }).Wait());
+                    await Assert.ThrowsAnyAsync<Exception>(
+                        () => producer.ProduceAsync(topic.Name, new Message<string, TestClasses2.TestPoco> { Key = "test1", Value = c }, TestContext.Current.CancellationToken));
                 }
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeBasic.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeBasic.cs
@@ -16,6 +16,7 @@
 
 using Xunit;
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 
@@ -28,7 +29,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     Basic test of producing/consuming using the protobuf serdes.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceConsumeBasicProtobuf(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceConsumeBasicProtobuf(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -42,7 +43,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var u = new UInt32Value();
                 u.Value = 42;
-                producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
                 var consumerConfig = new ConsumerConfig
                 {
@@ -58,7 +59,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.Equal(u.Value, cr.Message.Value.Value);
                 }
 
@@ -66,7 +67,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 using (var consumer = new ConsumerBuilder<string, byte[]>(consumerConfig).Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     // magic byte + schema id + expected array index length + at least one data byte.
                     Assert.True(cr.Message.Value.Length >= 1 + 4 + 1 + 1);
                     // magic byte

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeExternalRef.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeExternalRef.cs
@@ -16,6 +16,7 @@
 
 using Xunit;
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 
@@ -29,7 +30,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     schema that references another schema.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceConsumeExternalRefProtobuf(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceConsumeExternalRefProtobuf(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -44,7 +45,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 var u = new WithExternalReference();
                 u.Value1 = new RefByAnother { Value = 111 };
                 u.Value2 = 123;
-                producer.ProduceAsync(topic.Name, new Message<string, WithExternalReference> { Key = "test1", Value = u }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, WithExternalReference> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
                 var consumerConfig = new ConsumerConfig
                 {
@@ -60,7 +61,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.Equal(u.Value2, cr.Message.Value.Value2);
                     Assert.Equal(u.Value1.Value, cr.Message.Value.Value1.Value);
                 }
@@ -69,7 +70,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 using (var consumer = new ConsumerBuilder<string, byte[]>(consumerConfig).Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     // magic byte + schema id + expected array index length + at least one data byte.
                     Assert.True(cr.Message.Value.Length >= 1 + 4 + 1 + 1);
                     // magic byte
@@ -79,7 +80,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 }
 
                 // Check the referenced schema is in schema registry.
-                var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                var subjects = await schemaRegistry.GetAllSubjectsAsync();
                 Assert.Contains("RefByAnother.proto", subjects);
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeGoogleRef.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeGoogleRef.cs
@@ -16,6 +16,7 @@
 
 using Xunit;
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 
@@ -29,7 +30,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     schema that references well known google schemas.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceConsumeGoogleRefProtobuf(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceConsumeGoogleRefProtobuf(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -47,7 +48,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 u.ReceivedTime = new Google.Protobuf.WellKnownTypes.Timestamp();
                 u.ReceivedTime.Seconds = 1591364591;
 
-                producer.ProduceAsync(topic.Name, new Message<string, WithGoogleRefs.TheRecord> { Key = "test1", Value = u }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, WithGoogleRefs.TheRecord> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
                 var consumerConfig = new ConsumerConfig
                 {
@@ -63,7 +64,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.Equal(u.ListType.Value, cr.Message.Value.ListType.Value);
                     Assert.Equal(u.ReceivedTime.Seconds, cr.Message.Value.ReceivedTime.Seconds);
                 }
@@ -72,7 +73,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 using (var consumer = new ConsumerBuilder<string, byte[]>(consumerConfig).Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     // magic byte + schema id + expected array index length + at least one data byte.
                     Assert.True(cr.Message.Value.Length >= 1 + 4 + 1 + 1);
                     // magic byte
@@ -82,7 +83,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 }
 
                 // Check the referenced schemas are in schema registry.
-                var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                var subjects = await schemaRegistry.GetAllSubjectsAsync();
                 Assert.Contains("google/protobuf/timestamp.proto", subjects);
                 Assert.Contains("google/protobuf/wrappers.proto", subjects);
             }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeNested.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeNested.cs
@@ -16,6 +16,7 @@
 
 using Xunit;
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Confluent.Kafka.Examples.Protobuf;
@@ -30,7 +31,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     a nested message type (test of index array generation)
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceConsumeNestedProtobuf(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceConsumeNestedProtobuf(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -44,7 +45,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var u = new NestedOuter.Types.NestedMid2.Types.NestedLower();
                 u.Field2 = "field_2_value";
-                producer.ProduceAsync(topic.Name, new Message<string, NestedOuter.Types.NestedMid2.Types.NestedLower> { Key = "test1", Value = u }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, NestedOuter.Types.NestedMid2.Types.NestedLower> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
                 var consumerConfig = new ConsumerConfig
                 {
@@ -61,7 +62,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.Equal(u.Field2, cr.Message.Value.Field2);
                 }
             }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeSchemaManyMessages.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/ProduceConsumeSchemaManyMessages.cs
@@ -16,6 +16,7 @@
 
 using Xunit;
 using System;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 
@@ -30,7 +31,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     i.e. multi-byte varint value.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void ProduceConsumeSchemaManyMessagesProtobuf(string bootstrapServers, string schemaRegistryServers)
+        public static async Task ProduceConsumeSchemaManyMessagesProtobuf(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -44,7 +45,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
             {
                 var u = new Msg230();
                 u.Value = 41;
-                producer.ProduceAsync(topic.Name, new Message<string, Msg230> { Key = "test1", Value = u }).Wait();
+                await producer.ProduceAsync(topic.Name, new Message<string, Msg230> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
                 var consumerConfig = new ConsumerConfig
                 {
@@ -60,7 +61,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                         .Build())
                 {
                     consumer.Subscribe(topic.Name);
-                    var cr = consumer.Consume();
+                    var cr = consumer.Consume(TestContext.Current.CancellationToken);
                     Assert.Equal(u.Value, cr.Message.Value.Value);
                 }
             }

--- a/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/SubjectNameStrategies.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.IntegrationTests/Tests_Protobuf/SubjectNameStrategies.cs
@@ -15,6 +15,7 @@
 // Refer to LICENSE for more information.
 
 using Xunit;
+using System.Threading.Tasks;
 using Confluent.Kafka;
 
 
@@ -27,7 +28,7 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
         ///     strategies works for Protobuf serializers.
         /// </summary>
         [Theory, MemberData(nameof(TestParameters))]
-        public static void SubjectNameStrategiesProtobuf(string bootstrapServers, string schemaRegistryServers)
+        public static async Task SubjectNameStrategiesProtobuf(string bootstrapServers, string schemaRegistryServers)
         {
             var producerConfig = new ProducerConfig { BootstrapServers = bootstrapServers };
             var schemaRegistryConfig = new SchemaRegistryConfig { Url = schemaRegistryServers };
@@ -42,9 +43,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new UInt32Value();
                     u.Value = 42;
-                    producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
-                    var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                    var subjects = await schemaRegistry.GetAllSubjectsAsync();
                     Assert.Contains(topic.Name + "-UInt32Value", subjects);
                     Assert.DoesNotContain(topic.Name + "-value", subjects);
                     // May contain the record name subject from a previous test.
@@ -57,9 +58,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new UInt32Value();
                     u.Value = 42;
-                    producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
-                    var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                    var subjects = await schemaRegistry.GetAllSubjectsAsync();
                     // Note: If this value is in SR by any means (even if not via this test),
                     // it implies what is being tested here is functional.
                     Assert.Contains("UInt32Value", subjects);
@@ -73,9 +74,9 @@ namespace Confluent.SchemaRegistry.Serdes.IntegrationTests
                 {
                     var u = new UInt32Value();
                     u.Value = 42;
-                    producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }).Wait();
+                    await producer.ProduceAsync(topic.Name, new Message<string, UInt32Value> { Key = "test1", Value = u }, TestContext.Current.CancellationToken);
 
-                    var subjects = schemaRegistry.GetAllSubjectsAsync().Result;
+                    var subjects = await schemaRegistry.GetAllSubjectsAsync();
                     Assert.Contains(topic.Name + "-value", subjects);
                 }
             }

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/Confluent.SchemaRegistry.Serdes.UnitTests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <!-- Needed for testing net462 on Linux -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="protobuf-net.Reflection" Version="3.2.12" />
     <PackageReference Include="Apache.Avro" Version="1.12.1" />

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/JsonSerializeDeserialize.cs
@@ -203,32 +203,32 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void Null()
+        public async Task Null()
         {
             var jsonSerializer = new JsonSerializer<UInt32Value>(schemaRegistryClient);
             var jsonDeserializer = new JsonDeserializer<UInt32Value>(schemaRegistryClient);
 
-            var bytes = jsonSerializer
-                .SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await jsonSerializer
+                .SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic));
             Assert.Null(bytes);
-            Assert.Null(jsonDeserializer
-                .DeserializeAsync(bytes, true, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            Assert.Null(await jsonDeserializer
+                .DeserializeAsync(bytes, true, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
 
         [Fact]
-        public void UInt32SerDe()
+        public async Task UInt32SerDe()
         {
             var jsonSerializer = new JsonSerializer<UInt32Value>(schemaRegistryClient);
             var jsonDeserializer = new JsonDeserializer<UInt32Value>();
 
             var v = new UInt32Value { Value = 1234 };
-            var bytes = jsonSerializer
-                .SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await jsonSerializer
+                .SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
             Assert.Equal(v.Value,
-                jsonDeserializer
-                    .DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic))
-                    .Result.Value);
+                (await jsonDeserializer
+                    .DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)))
+                    .Value);
         }
 
         [Fact]
@@ -442,7 +442,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             try
             {
                 await jsonSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
-                Assert.True(false, "Serialization did not throw an expected exception");
+                Assert.Fail("Serialization did not throw an expected exception");
             }
             catch (InvalidDataException ex)
             {
@@ -450,7 +450,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             }
             catch (Exception ex)
             {
-                Assert.True(false,
+                Assert.Fail(
                     $"Serialization threw exception of type {ex.GetType().FullName} instead of the expected {typeof(InvalidDataException).FullName}");
             }
         }
@@ -471,7 +471,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             try
             {
                 await jsonSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
-                Assert.True(false, "Serialization did not throw an expected exception");
+                Assert.Fail("Serialization did not throw an expected exception");
             }
             catch (InvalidDataException ex)
             {
@@ -479,7 +479,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             }
             catch (Exception ex)
             {
-                Assert.True(false,
+                Assert.Fail(
                     $"Serialization threw exception of type {ex.GetType().FullName} instead of the expected {typeof(InvalidDataException).FullName}");
             }
         }
@@ -503,7 +503,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             try
             {
                 await jsonSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
-                Assert.True(false, "Serialization did not throw an expected exception");
+                Assert.Fail("Serialization did not throw an expected exception");
             }
             catch (InvalidDataException ex)
             {
@@ -511,13 +511,13 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             }
             catch (Exception ex)
             {
-                Assert.True(false,
+                Assert.Fail(
                     $"Serialization threw exception of type {ex.GetType().FullName} instead of the expected {typeof(InvalidDataException).FullName}");
             }
         }
 
         [Fact]
-        public async void ValidationUseLatest()
+        public async Task ValidationUseLatest()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -556,7 +556,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             try
             {
                 await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
-                Assert.True(false, "Serialization did not throw an expected exception");
+                Assert.Fail("Serialization did not throw an expected exception");
             }
             catch (InvalidDataException ex)
             {
@@ -564,13 +564,13 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             }
             catch (Exception ex)
             {
-                Assert.True(false,
+                Assert.Fail(
                     $"Serialization threw exception of type {ex.GetType().FullName} instead of the expected {typeof(InvalidDataException).FullName}");
             }
         }
 
         [Fact]
-        public void WithGuidInHeader()
+        public async Task WithGuidInHeader()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -607,8 +607,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.Name);
             Assert.Equal(user.FavoriteColor, result.FavoriteColor);
@@ -616,7 +616,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELCondition()
+        public async Task CELCondition()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -658,8 +658,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.Name);
             Assert.Equal(user.FavoriteColor, result.FavoriteColor);
@@ -667,7 +667,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELConditionFail()
+        public async Task CELConditionFail()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -708,11 +708,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void CELFieldTransform()
+        public async Task CELFieldTransform()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -754,8 +754,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix", result.Name);
             Assert.Equal("blue-suffix", result.FavoriteColor);
@@ -763,7 +763,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELFieldTransformWithNullable()
+        public async Task CELFieldTransformWithNullable()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -805,8 +805,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix", result.Name);
             Assert.Equal("blue-suffix", result.FavoriteColor);
@@ -814,7 +814,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELFieldTransformEnum()
+        public async Task CELFieldTransformEnum()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -852,15 +852,15 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var jObject = JObject.FromObject(order, newtonsoftSerializer);
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(jObject, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(jObject, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             var resultOrder = result.ToObject<Order>(newtonsoftSerializer);
             Assert.Equal(OrderStatus.CLOSED, resultOrder.Status);
         }
 
         [Fact]
-        public void FieldEncryptionEnum()
+        public async Task FieldEncryptionEnum()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -914,15 +914,15 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var jObject = JObject.FromObject(order, newtonsoftSerializer);
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(jObject, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(jObject, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             var resultOrder = result.ToObject<Order>(newtonsoftSerializer);
             Assert.Equal(OrderStatus.OPEN, resultOrder.Status);
         }
 
         [Fact]
-        public void CELFieldTransformWithUnionOfRefs()
+        public async Task CELFieldTransformWithUnionOfRefs()
         {
             var schemaStr = @"{
                 ""type"": ""object"",
@@ -1020,14 +1020,14 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(msg, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(msg, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("12345-suffix", result.Payload.MessageId);
         }
 
         [Fact]
-        public void CELFieldTransformWithDef()
+        public async Task CELFieldTransformWithDef()
         {
             var schemaStr = @"{
                 ""$schema"" : ""http://json-schema.org/draft-07/schema#"",
@@ -1093,15 +1093,15 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("bob-suffix", result.Name);
             Assert.Equal("1234-suffix", result.Address.DoorPin);
         }
 
         [Fact]
-        public void CELFieldTransformWithList()
+        public async Task CELFieldTransformWithList()
         {
             var schemaStr = @"{
                 ""$schema"" : ""http://json-schema.org/draft-07/schema#"",
@@ -1175,8 +1175,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("bob-suffix", result.Name);
             Assert.Equal("1234-suffix", result.Addresses[0].DoorPin);
@@ -1184,7 +1184,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELFieldTransformNestedAnyOf()
+        public async Task CELFieldTransformNestedAnyOf()
         {
             var schemaStr = @"{
                 ""$schema"": ""http://json-schema.org/draft-07/schema#"",
@@ -1244,15 +1244,15 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(holder, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(holder, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("P123456789-suffix", result.Pins.Pin);
             Assert.Equal("NP00012345678-suffix", result.Pins.Npin);
         }
 
         [Fact]
-        public void CELFieldTransformSiblingAnyOf()
+        public async Task CELFieldTransformSiblingAnyOf()
         {
             var schemaStr = @"{
                 ""$schema"": ""http://json-schema.org/draft-07/schema#"",
@@ -1308,15 +1308,15 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(holder, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(holder, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("P123456789-suffix", result.Pins.Pin);
             Assert.Equal("NP00012345678-suffix", result.Pins.Npin);
         }
 
         [Fact]
-        public void CELFieldTransformAllOf()
+        public async Task CELFieldTransformAllOf()
         {
             var schemaStr = @"{
                 ""$schema"": ""http://json-schema.org/draft-07/schema#"",
@@ -1376,15 +1376,15 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(holder, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(holder, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("P123456789-suffix", result.Pins.Pin);
             Assert.Equal("NP00012345678-suffix", result.Pins.Npin);
         }
 
         [Fact]
-        public void CELFieldCondition()
+        public async Task CELFieldCondition()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -1426,8 +1426,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.Name);
             Assert.Equal(user.FavoriteColor, result.FavoriteColor);
@@ -1435,7 +1435,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELFieldConditionFail()
+        public async Task CELFieldConditionFail()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -1476,11 +1476,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void FieldEncryption()
+        public async Task FieldEncryption()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -1543,10 +1543,10 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer
-                .SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer
+                .SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.Name);
@@ -1555,7 +1555,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void PayloadEncryption()
+        public async Task PayloadEncryption()
         {
             var schemaStr = @"{
               ""type"": ""object"",
@@ -1618,10 +1618,10 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer
-                .SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer
+                .SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.Name);
@@ -1630,7 +1630,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void JSONataFullyCompatible()
+        public async Task JSONataFullyCompatible()
         {
             var rule1To2 = "$merge([$sift($, function($v, $k) {$k != 'name'}), {'full_name': $.'name'}])";
             var rule2To1 = "$merge([$sift($, function($v, $k) {$k != 'full_name'}), {'name': $.'full_name'}])";
@@ -1788,29 +1788,29 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             subjectStore["topic-value"] = new List<RegisteredSchema> { schema, newSchema, newerSchema };
 
             Headers headers = new Headers();
-            var bytes = serializer1
-                .SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            DeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            var bytes = await serializer1
+                .SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await DeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
 
-            bytes = serializer2.SerializeAsync(newUser,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            DeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            bytes = await serializer2.SerializeAsync(newUser,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await DeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
 
-            bytes = serializer3.SerializeAsync(newerUser,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            DeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            bytes = await serializer3.SerializeAsync(newerUser,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await DeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
         }
 
-        private void DeserializeAllVersions(JsonDeserializer<Customer> deserializer1,
+        private async Task DeserializeAllVersions(JsonDeserializer<Customer> deserializer1,
             JsonDeserializer<NewCustomer> deserializer2, JsonDeserializer<NewerCustomer> deserializer3,
             byte[] bytes, Headers headers, Customer user)
         {
-            var result1 = deserializer1.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result2 = deserializer2.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result3 = deserializer3.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result1 = await deserializer1.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result2 = await deserializer2.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result3 = await deserializer3.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result1.Name);
             Assert.Equal(user.FavoriteColor, result1.FavoriteColor);
@@ -1826,7 +1826,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void AssociatedNameStrategy()
+        public async Task AssociatedNameStrategy()
         {
             // Setup association for the topic
             var associatedSubject = "my-associated-json-subject-value";
@@ -1856,14 +1856,14 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var deserializer = new JsonDeserializer<UInt32Value>(schemaRegistryClient, deserializerConfig);
 
             var v = new UInt32Value { Value = 1234 };
-            var bytes = serializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(v.Value, result.Value);
         }
 
         [Fact]
-        public void AssociatedNameStrategyWithFallback()
+        public async Task AssociatedNameStrategyWithFallback()
         {
             // No association is set up, so it should fall back to TopicNameStrategy
             var serializerConfig = new JsonSerializerConfig
@@ -1879,14 +1879,14 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var deserializer = new JsonDeserializer<UInt32Value>(schemaRegistryClient, deserializerConfig);
 
             var v = new UInt32Value { Value = 42 };
-            var bytes = serializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(v.Value, result.Value);
         }
 
         [Fact]
-        public void AssociatedNameStrategyWithKafkaClusterId()
+        public async Task AssociatedNameStrategyWithKafkaClusterId()
         {
             // Setup association for the topic with a specific kafka cluster ID as namespace
             var kafkaClusterId = "lkc-12345";
@@ -1920,8 +1920,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var deserializer = new JsonDeserializer<UInt32Value>(schemaRegistryClient, deserializerConfig);
 
             var v = new UInt32Value { Value = 777 };
-            var bytes = serializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(v.Value, result.Value);
         }
@@ -2013,7 +2013,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             try
             {
                 await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
-                Assert.True(false, "Serialization did not throw an expected exception");
+                Assert.Fail("Serialization did not throw an expected exception");
             }
             catch (InvalidDataException ex)
             {
@@ -2021,7 +2021,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             }
             catch (Exception ex)
             {
-                Assert.True(false,
+                Assert.Fail(
                     $"Serialization threw exception of type {ex.GetType().FullName} instead of the expected {typeof(InvalidDataException).FullName}");
             }
         }

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/ProtoSerializeDeserialize.cs
@@ -18,6 +18,7 @@
 #pragma warning disable CS0618
 
 using System;
+using System.Threading.Tasks;
 using Xunit;
 using System.Collections.Generic;
 using System.Linq;
@@ -76,7 +77,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             Assert.Contains("google/protobuf/descriptor.proto", fileNames);
 
             var rootFile = fds.Files.First(s => s.Name == "__root.proto");
-            Assert.Equal(1, rootFile.MessageTypes.Count);
+            Assert.Single(rootFile.MessageTypes);
             Assert.Equal("ReferrerMessage", rootFile.MessageTypes.First().Name);
         }
 
@@ -116,29 +117,29 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void Null()
+        public async Task Null()
         {
             var protoSerializer = new ProtobufSerializer<UInt32Value>(schemaRegistryClient);
             var protoDeserializer = new ProtobufDeserializer<UInt32Value>(schemaRegistryClient);
 
-            var bytes = protoSerializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await protoSerializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic));
             Assert.Null(bytes);
-            Assert.Null(protoDeserializer.DeserializeAsync(bytes, true, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            Assert.Null(await protoDeserializer.DeserializeAsync(bytes, true, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void UInt32SerDe()
+        public async Task UInt32SerDe()
         {
             var protoSerializer = new ProtobufSerializer<UInt32Value>(schemaRegistryClient);
             var protoDeserializer = new ProtobufDeserializer<UInt32Value>();
 
             var v = new UInt32Value { Value = 1234 };
-            var bytes = protoSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(v.Value, protoDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result.Value);
+            var bytes = await protoSerializer.SerializeAsync(v, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Equal(v.Value, (await protoDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic))).Value);
         }
 
         [Fact]
-        public void WithGuidInHeader()
+        public async Task WithGuidInHeader()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -177,8 +178,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.Name);
             Assert.Equal(user.FavoriteColor, result.FavoriteColor);
@@ -186,7 +187,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELCondition()
+        public async Task CELCondition()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -229,8 +230,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.Name);
             Assert.Equal(user.FavoriteColor, result.FavoriteColor);
@@ -238,7 +239,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELConditionFail()
+        public async Task CELConditionFail()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -280,11 +281,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void CELFieldTransform()
+        public async Task CELFieldTransform()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -327,8 +328,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix", result.Name);
             Assert.Equal("blue-suffix", result.FavoriteColor);
@@ -337,7 +338,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELFieldCondition()
+        public async Task CELFieldCondition()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -380,8 +381,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.Name);
             Assert.Equal(user.FavoriteColor, result.FavoriteColor);
@@ -389,7 +390,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void CELFieldConditionFail()
+        public async Task CELFieldConditionFail()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -431,11 +432,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void FieldEncryption()
+        public async Task FieldEncryption()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -496,8 +497,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.Name);
@@ -507,7 +508,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void PayloadEncryption()
+        public async Task PayloadEncryption()
         {
             string schemaStr = @"syntax = ""proto3"";
             import ""confluent/meta.proto"";
@@ -568,8 +569,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.Name);
@@ -579,14 +580,14 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ProtobufSerializerEncodesMessageIndexes()
+        public async Task ProtobufSerializerEncodesMessageIndexes()
         {
             var protoSerializer = new ProtobufSerializer<NestedOuter.Types.NestedMid2.Types.NestedLower>(schemaRegistryClient);
 
             var value = new NestedOuter.Types.NestedMid2.Types.NestedLower();
             value.Field2 = "field_2_value";
 
-            var bytes = protoSerializer.SerializeAsync(value, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await protoSerializer.SerializeAsync(value, new SerializationContext(MessageComponentType.Value, testTopic));
 
             var schemaId = new SchemaId(SchemaType.Protobuf);
             schemaId.FromBytes(bytes);
@@ -602,7 +603,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void AssociatedNameStrategy()
+        public async Task AssociatedNameStrategy()
         {
             // Setup association for the topic
             var associatedSubject = "my-associated-proto-subject-value";
@@ -639,8 +640,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 OneofString = "oneof"
             };
 
-            var bytes = serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(person.Name, result.Name);
             Assert.Equal(person.FavoriteColor, result.FavoriteColor);
@@ -648,7 +649,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void AssociatedNameStrategyWithFallback()
+        public async Task AssociatedNameStrategyWithFallback()
         {
             // No association is set up, so it should fall back to TopicNameStrategy
             var serializerConfig = new ProtobufSerializerConfig
@@ -671,8 +672,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 OneofString = "oneof"
             };
 
-            var bytes = serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(person.Name, result.Name);
             Assert.Equal(person.FavoriteColor, result.FavoriteColor);
@@ -680,7 +681,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void AssociatedNameStrategyWithKafkaClusterId()
+        public async Task AssociatedNameStrategyWithKafkaClusterId()
         {
             // Setup association for the topic with a specific kafka cluster ID as namespace
             var kafkaClusterId = "lkc-12345";
@@ -721,8 +722,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 OneofString = "oneof"
             };
 
-            var bytes = serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(person, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(person.Name, result.Name);
             Assert.Equal(person.FavoriteColor, result.FavoriteColor);

--- a/test/Confluent.SchemaRegistry.Serdes.UnitTests/SerializeDeserialize.cs
+++ b/test/Confluent.SchemaRegistry.Serdes.UnitTests/SerializeDeserialize.cs
@@ -18,6 +18,7 @@
 #pragma warning disable CS0618
 
 using Xunit;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using Avro.Specific;
 using Confluent.Kafka;
@@ -63,88 +64,88 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void IntSerDe()
+        public async Task IntSerDe()
         {
             var avroSerializer = new AvroSerializer<int>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<int>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(1234, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(1234, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync(1234, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Equal(1234, await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void LongSerDe()
+        public async Task LongSerDe()
         {
             var avroSerializer = new AvroSerializer<long>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<long>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(123, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(123, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync(123, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Equal(123, await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void BoolSerDe()
+        public async Task BoolSerDe()
         {
             var avroSerializer = new AvroSerializer<bool>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<bool>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(true, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(true, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync(true, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.True(await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void StringSerDe()
+        public async Task StringSerDe()
         {
             var avroSerializer = new AvroSerializer<string>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<string>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync("abc", new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal("abc", avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync("abc", new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Equal("abc", await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void DoubleSerDe()
+        public async Task DoubleSerDe()
         {
             var avroSerializer = new AvroSerializer<double>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<double>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(123d, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(123d, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync(123d, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Equal(123d, await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void FloatSerDe()
+        public async Task FloatSerDe()
         {
             var avroSerializer = new AvroSerializer<float>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<float>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(123f, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(123f, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync(123f, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Equal(123f, await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void BytesSerDe()
+        public async Task BytesSerDe()
         {
             var avroSerializer = new AvroSerializer<byte[]>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<byte[]>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(new byte[] { 2, 3, 4 }, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = await avroSerializer.SerializeAsync(new byte[] { 2, 3, 4 }, new SerializationContext(MessageComponentType.Value, testTopic));
             Assert.Equal(new byte[] { 0, 0, 0, 0, 1, 2, 3, 4 }, bytes);
-            Assert.Equal(new byte[] { 2, 3, 4 }, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            Assert.Equal(new byte[] { 2, 3, 4 }, await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void NullSerDe()
+        public async Task NullSerDe()
         {
             var avroSerializer = new AvroSerializer<Null>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<Null>(schemaRegistryClient);
             byte[] bytes;
-            bytes = avroSerializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Equal(null, avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            bytes = await avroSerializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic));
+            Assert.Null(await avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         [Fact]
-        public void ISpecificRecord()
+        public async Task ISpecificRecord()
         {
             var serializer = new AvroSerializer<User>(schemaRegistryClient);
             var deserializer = new AvroDeserializer<User>(schemaRegistryClient);
@@ -156,8 +157,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -171,8 +172,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -180,7 +181,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordUseSchemaId()
+        public async Task ISpecificRecordUseSchemaId()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -202,8 +203,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -211,7 +212,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordStrings()
+        public async Task ISpecificRecordStrings()
         {
             var schemaStr = "{\"type\":\"string\"}";
             var schema = new RegisteredSchema("topic1-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -234,21 +235,21 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             var serializer = new AvroSerializer<String>(schemaRegistryClient, config);
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync("hi", new SerializationContext(MessageComponentType.Value, "topic1", headers)).Result;
+            var bytes = await serializer.SerializeAsync("hi", new SerializationContext(MessageComponentType.Value, "topic1", headers));
             Assert.Equal(1, bytes[4]);
 
-            bytes = serializer.SerializeAsync("world", new SerializationContext(MessageComponentType.Value, "topic2", headers)).Result;
+            bytes = await serializer.SerializeAsync("world", new SerializationContext(MessageComponentType.Value, "topic2", headers));
             Assert.Equal(2, bytes[4]);
 
-            bytes = serializer.SerializeAsync("hi", new SerializationContext(MessageComponentType.Value, "topic1", headers)).Result;
+            bytes = await serializer.SerializeAsync("hi", new SerializationContext(MessageComponentType.Value, "topic1", headers));
             Assert.Equal(1, bytes[4]);
 
-            bytes = serializer.SerializeAsync("world", new SerializationContext(MessageComponentType.Value, "topic2", headers)).Result;
+            bytes = await serializer.SerializeAsync("world", new SerializationContext(MessageComponentType.Value, "topic2", headers));
             Assert.Equal(2, bytes[4]);
         }
 
         [Fact]
-        public void ISpecificRecordRecordNameStrategy()
+        public async Task ISpecificRecordRecordNameStrategy()
         {
             var serializerConfig = new AvroSerializerConfig
             {
@@ -268,8 +269,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -283,8 +284,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -292,7 +293,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordAssociatedNameStrategy()
+        public async Task ISpecificRecordAssociatedNameStrategy()
         {
             // Setup association for the topic
             var associatedSubject = "my-associated-subject-value";
@@ -335,8 +336,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -344,7 +345,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordAssociatedNameStrategyWithFallback()
+        public async Task ISpecificRecordAssociatedNameStrategyWithFallback()
         {
             // No association is set up, so it should fall back to TopicNameStrategy
             var schemaStr = User._SCHEMA.ToString();
@@ -372,8 +373,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "fallback"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -381,7 +382,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordAssociatedNameStrategyWithKafkaClusterId()
+        public async Task ISpecificRecordAssociatedNameStrategyWithKafkaClusterId()
         {
             // Setup association for the topic with a specific kafka cluster ID as namespace
             var kafkaClusterId = "lkc-12345";
@@ -431,8 +432,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "cluster-user"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -440,7 +441,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELCondition()
+        public async Task ISpecificRecordCELCondition()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -469,8 +470,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
@@ -478,7 +479,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELConditionFail()
+        public async Task ISpecificRecordCELConditionFail()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -506,11 +507,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void ISpecificRecordCELFieldTransform()
+        public async Task ISpecificRecordCELFieldTransform()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -539,8 +540,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix", result.name);
             Assert.Equal("blue-suffix", result.favorite_color);
@@ -548,7 +549,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELFieldTransformMissingProp()
+        public async Task ISpecificRecordCELFieldTransformMissingProp()
         {
             var schemaStr =
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific\",\"fields\":[" +
@@ -585,8 +586,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix-suffix", result.name);
             Assert.Equal("blue-suffix-suffix", result.favorite_color);
@@ -594,7 +595,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELFieldTransformDisable()
+        public async Task ISpecificRecordCELFieldTransformDisable()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -626,8 +627,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.name);
             Assert.Equal("blue", result.favorite_color);
@@ -635,7 +636,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELFieldTransformComplex()
+        public async Task ISpecificRecordCELFieldTransformComplex()
         {
             var schemaStr = Complex._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -664,8 +665,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("hello-suffix", result.arrayField[0]);
             Assert.Equal("world-suffix", result.mapField["key"]);
@@ -673,7 +674,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELFieldCondition()
+        public async Task ISpecificRecordCELFieldCondition()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -702,8 +703,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result.name);
             Assert.Equal("blue", result.favorite_color);
@@ -711,7 +712,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordCELFieldConditionFail()
+        public async Task ISpecificRecordCELFieldConditionFail()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -739,11 +740,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void ISpecificRecordFieldEncryption()
+        public async Task ISpecificRecordFieldEncryption()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"UserWithPic\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                     "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\"," +
@@ -796,8 +797,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.name);
@@ -807,7 +808,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordPayloadEncryption()
+        public async Task ISpecificRecordPayloadEncryption()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"UserWithPic\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                     "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\"," +
@@ -858,8 +859,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.name);
@@ -869,7 +870,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordEncryptionAlternateKeks()
+        public async Task ISpecificRecordEncryptionAlternateKeks()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"UserWithPic\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                     "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\"," +
@@ -921,8 +922,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.name);
@@ -932,7 +933,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void ISpecificRecordFieldEncryptionDekRotation()
+        public async Task ISpecificRecordFieldEncryptionDekRotation()
         {
             var schemaStr =
                 "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
@@ -983,16 +984,16 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             };
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
             Assert.Equal(user.favorite_number, result.favorite_number);
 
-            RegisteredDek dek = dekRegistryClient.GetDekVersionAsync(
-                "kek1", "topic-value", -1, DekFormat.AES256_GCM, false).Result;
+            RegisteredDek dek = await dekRegistryClient.GetDekVersionAsync(
+                "kek1", "topic-value", -1, DekFormat.AES256_GCM, false);
             Assert.Equal(1, dek.Version);
 
             // Advance 2 days
@@ -1005,16 +1006,16 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
             Assert.Equal(user.favorite_number, result.favorite_number);
 
-            dek = dekRegistryClient.GetDekVersionAsync(
-                "kek1", "topic-value", -1, DekFormat.AES256_GCM, false).Result;
+            dek = await dekRegistryClient.GetDekVersionAsync(
+                "kek1", "topic-value", -1, DekFormat.AES256_GCM, false);
             Assert.Equal(2, dek.Version);
 
             // Advance 2 days
@@ -1027,21 +1028,21 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             // The user name has been modified
             Assert.Equal("awesome", result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);
             Assert.Equal(user.favorite_number, result.favorite_number);
 
-            dek = dekRegistryClient.GetDekVersionAsync(
-                "kek1", "topic-value", -1, DekFormat.AES256_GCM, false).Result;
+            dek = await dekRegistryClient.GetDekVersionAsync(
+                "kek1", "topic-value", -1, DekFormat.AES256_GCM, false);
             Assert.Equal(3, dek.Version);
         }
 
         [Fact]
-        public void ISpecificRecordJSONataFullyCompatible()
+        public async Task ISpecificRecordJSONataFullyCompatible()
         {
             var rule1To2 = "$merge([$sift($, function($v, $k) {$k != 'name'}), {'full_name': $.'name'}])";
             var rule2To1 = "$merge([$sift($, function($v, $k) {$k != 'full_name'}), {'name': $.'full_name'}])";
@@ -1160,23 +1161,23 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             subjectStore["topic-value"] = new List<RegisteredSchema> { schema, newSchema, newerSchema }; 
 
             Headers headers = new Headers();
-            var bytes = serializer1.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            ISpecificRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            var bytes = await serializer1.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await ISpecificRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
             
-            bytes = serializer2.SerializeAsync(newUser, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            ISpecificRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            bytes = await serializer2.SerializeAsync(newUser, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await ISpecificRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
             
-            bytes = serializer3.SerializeAsync(newerUser, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            ISpecificRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            bytes = await serializer3.SerializeAsync(newerUser, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await ISpecificRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
         }
 
-        private void ISpecificRecordDeserializeAllVersions(AvroDeserializer<User> deserializer1, 
+        private async Task ISpecificRecordDeserializeAllVersions(AvroDeserializer<User> deserializer1, 
             AvroDeserializer<NewUser> deserializer2, AvroDeserializer<NewerUser> deserializer3, 
             byte[] bytes, Headers headers, User user)
         {
-            var result1 = deserializer1.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result2 = deserializer2.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result3 = deserializer3.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result1 = await deserializer1.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result2 = await deserializer2.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result3 = await deserializer3.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result1.name);
             Assert.Equal(user.favorite_color, result1.favorite_color);
@@ -1192,7 +1193,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecord()
+        public async Task GenericRecord()
         {
             var serializer = new AvroSerializer<GenericRecord>(schemaRegistryClient, null);
             var deserializer = new AvroDeserializer<GenericRecord>(schemaRegistryClient, null);
@@ -1203,8 +1204,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal(user["name"], result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1216,8 +1217,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_number", 100);
             user.Add("favorite_color", "red");
 
-            bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal(user["name"], result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1225,7 +1226,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordWithGuidInHeader()
+        public async Task GenericRecordWithGuidInHeader()
         {
             var config = new AvroSerializerConfig
             {
@@ -1241,10 +1242,10 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal(user["name"], result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1256,11 +1257,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_number", 100);
             user.Add("favorite_color", "red");
 
-            bytes = serializer.SerializeAsync(user,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            bytes = await serializer.SerializeAsync(user,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
-            result = deserializer.DeserializeAsync(bytes, false,
-                new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            result = await deserializer.DeserializeAsync(bytes, false,
+                new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal(user["name"], result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1268,7 +1269,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordWithReferences()
+        public async Task GenericRecordWithReferences()
         {
             var subject1 = "topic-value";
             var subject2 = "ref";
@@ -1307,8 +1308,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             obj1.Add("refField", obj2);
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(obj1, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(obj1, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             var refField = (GenericRecord) result["refField"];
             Assert.Equal(obj2["intField"], refField["intField"]);
@@ -1319,7 +1320,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordSchemaEvolution()
+        public async Task GenericRecordSchemaEvolution()
         {
             var schemaStr1 = "{\n"
                              + "  \"name\": \"SchemaEvolution\",\n"
@@ -1363,17 +1364,17 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             obj.Add("fieldToDelete", "bye");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(obj, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(obj, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             store[schemaStr2] = 2;
             subjectStore["topic-value"] = new List<RegisteredSchema> { schema1, schema2 };
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal(result["newOptionalField"], "optional");
         }
 
         [Fact]
-        public void GenericRecordCELCondition()
+        public async Task GenericRecordCELCondition()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1400,8 +1401,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1409,7 +1410,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordCELConditionLogicalType()
+        public async Task GenericRecordCELConditionLogicalType()
         {
             var uuid = "550e8400-e29b-41d4-a716-446655440000";
             var schemaStr = "{\"type\":\"record\",\"name\":\"UserWithPic\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
@@ -1441,8 +1442,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal(new Guid(uuid), result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1450,7 +1451,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordCELConditionFail()
+        public async Task GenericRecordCELConditionFail()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1476,11 +1477,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void GenericRecordCELConditionEmail()
+        public async Task GenericRecordCELConditionEmail()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1507,8 +1508,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("bob@confluent.com", result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1516,7 +1517,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordCELConditionEmailFail()
+        public async Task GenericRecordCELConditionEmailFail()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1542,11 +1543,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void GenericRecordCELFieldTransform()
+        public async Task GenericRecordCELFieldTransform()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1573,8 +1574,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix", result["name"]);
             Assert.Equal("blue-suffix", result["favorite_color"]);
@@ -1582,7 +1583,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordCELFieldCondition()
+        public async Task GenericRecordCELFieldCondition()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1609,8 +1610,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1618,7 +1619,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordCELFieldConditionFail()
+        public async Task GenericRecordCELFieldConditionFail()
         {
             var schemaStr = User._SCHEMA.ToString();
             var schema = new RegisteredSchema("topic-value", 1, 1, schemaStr, SchemaType.Avro, null);
@@ -1644,11 +1645,11 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("favorite_color", "blue");
 
             Headers headers = new Headers();
-            Assert.Throws<AggregateException>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result);
+            await Assert.ThrowsAnyAsync<Exception>(() => serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)));
         }
 
         [Fact]
-        public void GenericRecordFieldEncryption()
+        public async Task GenericRecordFieldEncryption()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"UserWithPic\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                     "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\"," +
@@ -1699,8 +1700,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("picture", pic);
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1709,7 +1710,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordPayloadEncryption()
+        public async Task GenericRecordPayloadEncryption()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"UserWithPic\",\"namespace\":\"Confluent.Kafka.Examples.AvroSpecific" +
                     "\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"favorite_number\"," +
@@ -1760,8 +1761,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             user.Add("picture", pic);
 
             Headers headers = new Headers();
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result["name"]);
             Assert.Equal(user["favorite_color"], result["favorite_color"]);
@@ -1770,7 +1771,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordFieldEncryptionF1Preserialized()
+        public async Task GenericRecordFieldEncryptionF1Preserialized()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"myrecord\"," +
                             "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
@@ -1825,13 +1826,13 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 };
             Headers headers = new Headers();
             byte[] bytes = new byte[]{0, 0, 0, 0, 1, 104, 122, 103, 121, 47, 106, 70, 78, 77, 86, 47, 101, 70, 105, 108, 97, 72, 114, 77, 121, 101, 66, 103, 100, 97, 86, 122, 114, 82, 48, 117, 100, 71, 101, 111, 116, 87, 56, 99, 65, 47, 74, 97, 108, 55, 117, 107, 114, 43, 77, 47, 121, 122};
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("hello world", result["f1"]);
         }
 
         [Fact]
-        public void GenericRecordFieldEncryptionDeterministicF1Preserialized()
+        public async Task GenericRecordFieldEncryptionDeterministicF1Preserialized()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"myrecord\"," +
                             "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
@@ -1887,13 +1888,13 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 };
             Headers headers = new Headers();
             byte[] bytes = new byte[]{0, 0, 0, 0, 1, 72, 68, 54, 89, 116, 120, 114, 108, 66, 110, 107, 84, 87, 87, 57, 78, 54, 86, 98, 107, 51, 73, 73, 110, 106, 87, 72, 56, 49, 120, 109, 89, 104, 51, 107, 52, 100};
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("hello world", result["f1"]);
         }
 
         [Fact]
-        public void GenericRecordFieldEncryptionDekRotationF1Preserialized()
+        public async Task GenericRecordFieldEncryptionDekRotationF1Preserialized()
         {
             var schemaStr = "{\"type\":\"record\",\"name\":\"myrecord\"," +
                             "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
@@ -1949,13 +1950,13 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 };
             Headers headers = new Headers();
             byte[] bytes = new byte[]{0, 0, 0, 0, 1, 120, 65, 65, 65, 65, 65, 65, 71, 52, 72, 73, 54, 98, 49, 110, 88, 80, 88, 113, 76, 121, 71, 56, 99, 73, 73, 51, 53, 78, 72, 81, 115, 101, 113, 113, 85, 67, 100, 43, 73, 101, 76, 101, 70, 86, 65, 101, 78, 112, 83, 83, 51, 102, 120, 80, 110, 74, 51, 50, 65, 61};
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("hello world", result["f1"]);
         }
 
         [Fact]
-        public void GenericRecordJSONataWithCEL()
+        public async Task GenericRecordJSONataWithCEL()
         {
             var rule1To2 = "$merge([$sift($, function($v, $k) {$k != 'name'}), {'full_name': $.'name'}])";
 
@@ -2012,9 +2013,9 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             subjectStore["topic-value"] = new List<RegisteredSchema> { schema, newSchema };
 
             Headers headers = new Headers();
-            var bytes = serializer1.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var bytes = await serializer1.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
-            var result2 = deserializer2.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result2 = await deserializer2.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome-suffix", result2["full_name"]);
             Assert.Equal(user["favorite_color"], result2["favorite_color"]);
@@ -2022,7 +2023,7 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void GenericRecordJSONataFullyCompatible()
+        public async Task GenericRecordJSONataFullyCompatible()
         {
             var rule1To2 = "$merge([$sift($, function($v, $k) {$k != 'name'}), {'full_name': $.'name'}])";
             var rule2To1 = "$merge([$sift($, function($v, $k) {$k != 'full_name'}), {'name': $.'full_name'}])";
@@ -2135,23 +2136,23 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
             subjectStore["topic-value"] = new List<RegisteredSchema> { schema, newSchema, newerSchema }; 
 
             Headers headers = new Headers();
-            var bytes = serializer1.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            GenericRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            var bytes = await serializer1.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await GenericRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
             
-            bytes = serializer2.SerializeAsync(newUser, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            GenericRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            bytes = await serializer2.SerializeAsync(newUser, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await GenericRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
             
-            bytes = serializer3.SerializeAsync(newerUser, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            GenericRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
+            bytes = await serializer3.SerializeAsync(newerUser, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            await GenericRecordDeserializeAllVersions(deserializer1, deserializer2, deserializer3, bytes, headers, user);
         }
 
-        private void GenericRecordDeserializeAllVersions(AvroDeserializer<GenericRecord> deserializer1, 
+        private async Task GenericRecordDeserializeAllVersions(AvroDeserializer<GenericRecord> deserializer1, 
             AvroDeserializer<GenericRecord> deserializer2, AvroDeserializer<GenericRecord> deserializer3, 
             byte[] bytes, Headers headers, GenericRecord user)
         {
-            var result1 = deserializer1.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result2 = deserializer2.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
-            var result3 = deserializer3.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers)).Result;
+            var result1 = await deserializer1.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result2 = await deserializer2.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
+            var result3 = await deserializer3.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic, headers));
 
             Assert.Equal("awesome", result1["name"]);
             Assert.Equal(user["favorite_color"], result1["favorite_color"]);
@@ -2167,56 +2168,56 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void NullISpecificRecord()
+        public async Task NullISpecificRecord()
         {
             var serializer = new AvroSerializer<User>(schemaRegistryClient);
             var deserializer = new AvroDeserializer<User>(schemaRegistryClient);
 
-            var bytes = serializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Null(bytes);
             Assert.Null(result);
         }
 
         [Fact]
-        public void NullGenericRecord()
+        public async Task NullGenericRecord()
         {
             var serializer = new AvroSerializer<GenericRecord>(schemaRegistryClient);
             var deserializer = new AvroDeserializer<GenericRecord>(schemaRegistryClient);
 
-            var bytes = serializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Null(bytes);
             Assert.Null(result);
         }
 
         [Fact]
-        public void NullString()
+        public async Task NullString()
         {
             var serializer = new AvroSerializer<string>(schemaRegistryClient);
             var deserializer = new AvroDeserializer<string>(schemaRegistryClient);
 
-            var bytes = serializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(null, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Null(bytes);
             Assert.Null(result);
         }
 
         [Fact]
-        public void NullInt()
+        public async Task NullInt()
         {
             var deserializer = new AvroDeserializer<int>(schemaRegistryClient);
 
-            var exception = Assert.Throws<AggregateException>(() => deserializer.DeserializeAsync(ReadOnlyMemory<byte>.Empty, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => deserializer.DeserializeAsync(ReadOnlyMemory<byte>.Empty, isNull: true, new SerializationContext(MessageComponentType.Value, testTopic)));
 
-            Assert.Equal("Cannot deserialize null to a Value Type", exception.InnerException.Message);
+            Assert.Equal("Cannot deserialize null to a Value Type", exception.Message);
         }
 
         [Fact]
-        public void Multiple_ISpecificRecords()
+        public async Task Multiple_ISpecificRecords()
         {
             var serializer = new AvroSerializer<ISpecificRecord>(schemaRegistryClient);
             var deserializerUser = new AvroDeserializer<User>(schemaRegistryClient);
@@ -2235,16 +2236,16 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "great_brand"
             };
 
-            var bytesUser = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var resultUser = deserializerUser.DeserializeAsync(bytesUser, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result as User;
+            var bytesUser = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var resultUser = await deserializerUser.DeserializeAsync(bytesUser, false, new SerializationContext(MessageComponentType.Value, testTopic)) as User;
 
             Assert.NotNull(resultUser);
             Assert.Equal(user.name, resultUser.name);
             Assert.Equal(user.favorite_color, resultUser.favorite_color);
             Assert.Equal(user.favorite_number, resultUser.favorite_number);
 
-            var bytesCar = serializer.SerializeAsync(car, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var resultCar = deserializerCar.DeserializeAsync(bytesCar, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result as Car;
+            var bytesCar = await serializer.SerializeAsync(car, new SerializationContext(MessageComponentType.Value, testTopic));
+            var resultCar = await deserializerCar.DeserializeAsync(bytesCar, false, new SerializationContext(MessageComponentType.Value, testTopic)) as Car;
 
             Assert.NotNull(resultCar);
             Assert.Equal(car.name, resultCar.name);
@@ -2252,33 +2253,33 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
         }
 
         [Fact]
-        public void Poco_Serialize()
+        public async Task Poco_Serialize()
         {
             var serializer = new AvroSerializer<Dictionary<string, string>>(schemaRegistryClient);
-            Assert.Throws<System.InvalidOperationException>(() => serializer.SerializeAsync(new Dictionary<string, string> { { "cat", "dog" } }, new SerializationContext(MessageComponentType.Key, testTopic)).GetAwaiter().GetResult());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => serializer.SerializeAsync(new Dictionary<string, string> { { "cat", "dog" } }, new SerializationContext(MessageComponentType.Key, testTopic)));
         }
 
         [Fact]
-        public void Poco_Deserialize()
+        public async Task Poco_Deserialize()
         {
             var deserializer = new AvroDeserializer<Dictionary<string, string>>(schemaRegistryClient);
-            Assert.Throws<System.InvalidOperationException>(() => deserializer.DeserializeAsync(new System.ReadOnlyMemory<byte>(new byte[] { 1, 2, 3 }), false, new SerializationContext(MessageComponentType.Key, testTopic)).GetAwaiter().GetResult());
+            await Assert.ThrowsAsync<InvalidOperationException>(() => deserializer.DeserializeAsync(new System.ReadOnlyMemory<byte>(new byte[] { 1, 2, 3 }), false, new SerializationContext(MessageComponentType.Key, testTopic)));
         }
 
         [Fact]
-        public void Incompatible()
+        public async Task Incompatible()
         {
             var avroSerializer = new AvroSerializer<string>(schemaRegistryClient);
             var avroDeserializer = new AvroDeserializer<int>(schemaRegistryClient);
-            var bytes = avroSerializer.SerializeAsync("hello world", new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            Assert.Throws<System.AggregateException>(() => avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result);
+            var bytes = await avroSerializer.SerializeAsync("hello world", new SerializationContext(MessageComponentType.Value, testTopic));
+            await Assert.ThrowsAnyAsync<Exception>(() => avroDeserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)));
         }
 
         /// <summary>
         /// Test a case when .NET data class name and / or namespace do not match the schema name and / or namespace.
         /// </summary>
         [Fact]
-        public void ISpecificRecord_SchemaTypeMismatch()
+        public async Task ISpecificRecord_SchemaTypeMismatch()
         {
             var serializer = new AvroSerializer<User2>(schemaRegistryClient);
             var deserializer = new AvroDeserializer<User2>(schemaRegistryClient);
@@ -2290,8 +2291,8 @@ namespace Confluent.SchemaRegistry.Serdes.UnitTests
                 name = "awesome"
             };
 
-            var bytes = serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
-            var result = deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic)).Result;
+            var bytes = await serializer.SerializeAsync(user, new SerializationContext(MessageComponentType.Value, testTopic));
+            var result = await deserializer.DeserializeAsync(bytes, false, new SerializationContext(MessageComponentType.Value, testTopic));
 
             Assert.Equal(user.name, result.name);
             Assert.Equal(user.favorite_color, result.favorite_color);

--- a/test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
+++ b/test/Confluent.SchemaRegistry.UnitTests/Confluent.SchemaRegistry.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-      <PackageReference Include="xunit" Version="2.3.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+      <PackageReference Include="xunit.v3" Version="4.0.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Confluent.SchemaRegistry.UnitTests/RestServiceTests.cs
+++ b/test/Confluent.SchemaRegistry.UnitTests/RestServiceTests.cs
@@ -170,14 +170,14 @@ namespace Confluent.SchemaRegistry.UnitTests
                 {
                     while (true)
                     {
-                        accepted.Add(await listener.AcceptTcpClientAsync());
+                        accepted.Add(await listener.AcceptTcpClientAsync(TestContext.Current.CancellationToken));
                     }
                 }
                 catch
                 {
                     // listener stopped - expected on cleanup.
                 }
-            });
+            }, TestContext.Current.CancellationToken);
 
             try
             {
@@ -202,7 +202,7 @@ namespace Confluent.SchemaRegistry.UnitTests
                 // enumerating the accepted clients, to avoid mutating the list
                 // while it is being read.
                 listener.Stop();
-                await acceptLoop.ConfigureAwait(false);
+                await acceptLoop;
                 foreach (var client in accepted)
                 {
                     client.Dispose();


### PR DESCRIPTION
## Summary

- Bumps `NJsonSchema` -> `NJsonSchema.NewtonsoftJson` 11.0.2 in the OAuth examples (`OAuthConsumer`, `OAuthOIDC`, `OAuthProducer`) to resolve security advisories against the old `NJsonSchema` 10.8.0, and drops the now-redundant `System.Net.Http` reference from `ConfigGen`.
- That NJsonSchema bump surfaced a pre-existing bump of `Confluent.Kafka.UnitTests` to `Microsoft.NET.Test.Sdk` 18.9.0 / `xunit.v3` 4.0.0 / `Moq` 4.20.72, which no longer built. This PR completes that migration properly for both `Confluent.Kafka.UnitTests` and `Confluent.Kafka.IntegrationTests`, and cleans up every warning the new xunit.v3 analyzers surfaced along the way.

## Details

**Build fixes (xunit v2 -> v3):**
- Converted `async void` test methods to `async Task` — xunit.v3 removed support for `async void` tests (`xUnit1049`).
- Replaced `Xunit.SkippableFact`/`Skip.If` (incompatible with xunit.v3's execution engine) with xunit.v3's native dynamic-skip API, `Assert.SkipWhen`.

**Warning cleanup (xunit.v3 analyzer):**
- Converted test methods that blocked on `.Wait()`/`.Result` to `async`/`await`, passed `TestContext.Current.CancellationToken` to cancellable APIs, and unwrapped `catch (AggregateException) { ex.InnerException }` patterns to catch the concrete exception type directly now that `await` propagates it unwrapped (`xUnit1031`/`xUnit1051`).
- A handful of tests deliberately block on purpose (thread-pool-exhaustion/deadlock-avoidance tests, sync-over-async tests, and one test that intentionally verifies `.Wait()`'s `AggregateException`-wrapping behavior) — those were left blocking, with a scoped `#pragma warning disable/restore` and a comment explaining why.
- Converting a couple of methods to `async` surfaced two pre-existing fire-and-forget bugs (an admin-client call that was never awaited) — fixed alongside the warning cleanup.
- Fixed assertion-style warnings: `Assert.Equal` argument order, `Assert.True(false, msg)`/`Assert.False(true, msg)` -> `Assert.Fail(msg)`, and `Assert.Empty`/`Assert.Single` over a `.Where(...)` -> `Assert.DoesNotContain`/`Assert.Single` with a predicate (`xUnit2000`/`xUnit2020`/`xUnit2029`/`xUnit2031`).

## Test plan

- [x] `Confluent.Kafka.UnitTests` builds with 0 warnings / 0 errors on `net8.0` and `net10.0`; all 259 tests pass on both target frameworks.
- [x] `Confluent.Kafka.IntegrationTests` builds with 0 warnings / 0 errors on `net8.0` and `net10.0`.
- [x] Ran the full `Confluent.Kafka.IntegrationTests` suite against a live local cluster: 99 total, 0 errors, 0 failed, 1 skipped (pre-existing `[SKIP] FIXME: Review and fix this test`).